### PR TITLE
fix(skill-stocktake): Windows Git Bash/MSYS compatibility for stocktake scripts + two skill-doc fixes

### DIFF
--- a/skills/autonomous-agent-harness/SKILL.md
+++ b/skills/autonomous-agent-harness/SKILL.md
@@ -119,13 +119,13 @@ Trigger Claude Code agents remotely for event-driven workflows.
 **Dispatch patterns:**
 
 ```bash
-# Trigger from CI/CD
-curl -X POST "https://api.anthropic.com/dispatch" \
-  -H "Authorization: Bearer $ANTHROPIC_API_KEY" \
-  -d '{"prompt": "Build failed on main. Diagnose and fix.", "project": "/repo"}'
+# Trigger from CI/CD — run Claude Code headless inside the pipeline
+# (e.g., a GitHub Actions step; there is no hosted Anthropic "dispatch" endpoint)
+claude -p "Build failed on main. Read the CI logs in ci-failure.log, diagnose, and fix." \
+  --allowedTools "Read,Edit,Bash,Grep,Glob"
 
 # Trigger from webhook
-# GitHub webhook → dispatch → Claude agent → fix → PR
+# GitHub webhook → your listener → spawns `claude -p` in the repo → fix → PR
 
 # Trigger from another agent
 claude -p "Analyze the output of the security scan and create issues for findings"
@@ -186,24 +186,29 @@ description: Persistent task queue for autonomous operation
 
 ## Setup Guide
 
-### Step 1: Configure MCP Servers
+### Step 1: Wire Up Memory, Scheduling, and Browser Control
 
-Ensure these are in `~/.claude.json`:
+Use the capabilities that actually ship with Claude Code — Anthropic does not
+publish npm packages for these:
+
+- **Memory**: Claude Code's built-in persistent memory
+  (`~/.claude/projects/<project>/memory/` + `MEMORY.md` index). For a graph
+  layer, add a community memory MCP server of your choice to `mcpServers`
+  after reviewing its source.
+- **Scheduling**: Claude Code's native scheduled/background tasks (Cron tools
+  in supported clients) or plain OS schedulers (Windows Task Scheduler,
+  cron/launchd) invoking `claude -p "..."`.
+- **Browser / computer control**: the Claude in Chrome extension
+  (`mcp__claude-in-chrome__*` tools) or a Playwright MCP server.
+
+Example `mcpServers` entry (only add servers you have vetted):
 
 ```json
 {
   "mcpServers": {
-    "memory": {
+    "playwright": {
       "command": "npx",
-      "args": ["-y", "@anthropic/memory-mcp-server"]
-    },
-    "scheduled-tasks": {
-      "command": "npx",
-      "args": ["-y", "@anthropic/scheduled-tasks-mcp-server"]
-    },
-    "computer-use": {
-      "command": "npx",
-      "args": ["-y", "@anthropic/computer-use-mcp-server"]
+      "args": ["-y", "@playwright/mcp@latest"]
     }
   }
 }

--- a/skills/browser-qa/SKILL.md
+++ b/skills/browser-qa/SKILL.md
@@ -98,7 +98,7 @@ credentials/tokens/PII before saving any screenshot.
 ## Integration
 
 Works with any browser MCP:
-- `mChild__claude-in-chrome__*` tools (preferred — uses your actual Chrome)
+- `mcp__claude-in-chrome__*` tools (preferred — uses your actual Chrome)
 - Playwright via `mcp__browserbase__*`
 - Direct Puppeteer scripts
 

--- a/skills/skill-stocktake/scripts/quick-diff.sh
+++ b/skills/skill-stocktake/scripts/quick-diff.sh
@@ -28,6 +28,12 @@ if [[ -n "$CWD_SKILLS_DIR" && -d "$CWD_SKILLS_DIR" && "$CWD_SKILLS_DIR" != */.cl
   echo "Warning: CWD_SKILLS_DIR does not look like a .claude/skills path: $CWD_SKILLS_DIR" >&2
 fi
 
+# Skip the project scan when it resolves to the same directory as the global
+# dir (e.g., invoked from $HOME) — otherwise every file is scanned twice.
+if [[ -n "$CWD_SKILLS_DIR" && -d "$CWD_SKILLS_DIR" && "$(cd "$CWD_SKILLS_DIR" && pwd -P)" == "$(cd "$GLOBAL_DIR" && pwd -P)" ]]; then
+  CWD_SKILLS_DIR=""
+fi
+
 evaluated_at=$(jq -r '.evaluated_at' "$RESULTS_JSON")
 
 # Fail fast on a missing or malformed evaluated_at rather than producing
@@ -54,17 +60,46 @@ process_dir() {
   while IFS= read -r file; do
     local mtime dp is_new
     mtime=$(date -u -r "$file" +%Y-%m-%dT%H:%M:%SZ)
-    dp="${file/#$HOME/~}"
+    # Canonicalize the path. On Windows (MSYS/Git Bash) use cygpath -m to get
+    # the same C:/-style form that MSYS argument conversion produces when the
+    # path is passed to native jq.exe — a bare "~" replacement re-expands to
+    # $HOME and never matches the stored form. Elsewhere keep the ~ shorthand
+    # (escaped so it is not tilde-expanded back into $HOME).
+    if command -v cygpath >/dev/null 2>&1; then
+      dp=$(cygpath -m "$file")
+    else
+      dp="${file/#$HOME/\~}"
+    fi
 
-    # Check if this file is known to results.json (exact whole-line match to
-    # avoid substring false-positives, e.g. "python-patterns" matching "python-patterns-v2").
-    if echo "$known_paths" | grep -qxF "$dp"; then
+    # Known-ness is judged per SKILL, not per file: results.json records one
+    # entry per skill (its SKILL.md), while skills may carry auxiliary .md
+    # assets (references/, rules/, agents/). Map any file to its skill's
+    # SKILL.md anchor before the lookup, otherwise every auxiliary file is
+    # forever misreported as new.
+    local rel="${file#"$dir"/}"
+    local anchor_file
+    if [[ "$rel" == */* ]]; then
+      anchor_file="$dir/${rel%%/*}/SKILL.md"
+    else
+      anchor_file="$file"
+    fi
+    local anchor
+    if command -v cygpath >/dev/null 2>&1; then
+      anchor=$(cygpath -m "$anchor_file")
+    else
+      anchor="${anchor_file/#$HOME/\~}"
+    fi
+
+    # Exact whole-line match to avoid substring false-positives,
+    # e.g. "python-patterns" matching "python-patterns-v2".
+    if echo "$known_paths" | grep -qxF "$anchor"; then
       is_new="false"
-      # Known file: only emit if mtime changed (ISO 8601 string comparison is safe)
+      # Known skill: only emit if this file changed after the last evaluation
+      # (ISO 8601 string comparison is safe)
       [[ "$mtime" > "$evaluated_at" ]] || continue
     else
       is_new="true"
-      # New file: always emit regardless of mtime
+      # Unevaluated skill: always emit regardless of mtime
     fi
 
     jq -n \

--- a/skills/skill-stocktake/scripts/save-results.sh
+++ b/skills/skill-stocktake/scripts/save-results.sh
@@ -41,7 +41,11 @@ fi
 # Use mktemp for a collision-safe temp file (concurrent runs on the same RESULTS_JSON
 # would race on a predictable ".tmp" suffix; random suffix prevents silent overwrites).
 tmp=$(mktemp "${RESULTS_JSON}.XXXXXX")
-trap 'rm -f "$tmp"' EXIT
+# Write stdin JSON to a real temp file instead of process substitution —
+# native Windows jq.exe cannot open MSYS /proc/<pid>/fd paths from <(...).
+input_tmp=$(mktemp "${RESULTS_JSON}.in.XXXXXX")
+trap 'rm -f "$tmp" "$input_tmp"' EXIT
+printf '%s' "$input_json" > "$input_tmp"
 
 jq -s \
   --arg ea "$EVALUATED_AT" \
@@ -51,6 +55,6 @@ jq -s \
    .skills = ($existing.skills + ($new.skills // {})) |
    if ($new | has("mode")) then .mode = $new.mode else . end |
    if ($new | has("batch_progress")) then .batch_progress = $new.batch_progress else . end' \
-  "$RESULTS_JSON" <(echo "$input_json") > "$tmp"
+  "$RESULTS_JSON" "$input_tmp" > "$tmp"
 
 mv "$tmp" "$RESULTS_JSON"

--- a/skills/skill-stocktake/scripts/scan.sh
+++ b/skills/skill-stocktake/scripts/scan.sh
@@ -25,6 +25,12 @@ if [[ -n "$CWD_SKILLS_DIR" && -d "$CWD_SKILLS_DIR" && "$CWD_SKILLS_DIR" != */.cl
   echo "Warning: CWD_SKILLS_DIR does not look like a .claude/skills path: $CWD_SKILLS_DIR" >&2
 fi
 
+# Skip the project scan when it resolves to the same directory as the global
+# dir (e.g., invoked from $HOME) — otherwise every skill is double-counted.
+if [[ -n "$CWD_SKILLS_DIR" && -d "$CWD_SKILLS_DIR" && "$(cd "$CWD_SKILLS_DIR" && pwd -P)" == "$(cd "$GLOBAL_DIR" && pwd -P)" ]]; then
+  CWD_SKILLS_DIR=""
+fi
+
 # Extract a frontmatter field (handles both quoted and unquoted single-line values).
 # Does NOT support multi-line YAML blocks (| or >) or nested YAML keys.
 extract_field() {
@@ -106,7 +112,14 @@ scan_dir_to_json() {
     u7="${u7:-0}"
     u30=$(echo "$obs_30d_counts" | awk -v f="$file" '$2 == f {print $1}' | head -1)
     u30="${u30:-0}"
-    dp="${file/#$HOME/~}"
+    # Canonicalize the path (see quick-diff.sh): cygpath -m on Windows so the
+    # stored form matches what MSYS argument conversion hands to native jq.exe;
+    # escaped ~ elsewhere to avoid tilde re-expansion back into $HOME.
+    if command -v cygpath >/dev/null 2>&1; then
+      dp=$(cygpath -m "$file")
+    else
+      dp="${file/#$HOME/\~}"
+    fi
 
     jq -n \
       --arg path "$dp" \
@@ -151,20 +164,23 @@ if [[ -n "$CWD_SKILLS_DIR" && -d "$CWD_SKILLS_DIR" ]]; then
   project_count=$(echo "$project_skills" | jq 'length')
 fi
 
-# Merge global + project skills into one array
-all_skills=$(jq -s 'add' <(echo "$global_skills") <(echo "$project_skills"))
+# Merge global + project skills into one array.
+# Feed both arrays via stdin instead of process substitution — native Windows
+# jq.exe cannot open MSYS /proc/<pid>/fd paths produced by <(...).
+all_skills=$(printf '%s\n%s\n' "$global_skills" "$project_skills" | jq -s 'add')
 
-jq -n \
+# Pass the (potentially large) skills array via stdin rather than --argjson —
+# Windows enforces a ~32KB argv limit that a full inventory easily exceeds.
+printf '%s' "$all_skills" | jq \
   --arg global_found "$global_found" \
   --argjson global_count "$global_count" \
   --arg project_found "$project_found" \
   --arg project_path "$project_path" \
   --argjson project_count "$project_count" \
-  --argjson skills "$all_skills" \
   '{
     scan_summary: {
       global: { found: ($global_found == "true"), count: $global_count },
       project: { found: ($project_found == "true"), path: $project_path, count: $project_count }
     },
-    skills: $skills
+    skills: .
   }'


### PR DESCRIPTION
## Summary

Fixes six Windows (Git Bash / MSYS) compatibility bugs in the skill-stocktake scripts, plus two skill-doc defects found while running a full stocktake of 186 installed skills on Windows 11.

### skill-stocktake scripts

| Bug | Symptom on Windows | Fix |
|---|---|---|
| Process substitution `<(...)` fed to jq (`scan.sh`, `save-results.sh`) | Native jq.exe cannot open MSYS `/proc/<pid>/fd` paths → `Could not open file /proc/NNN/fd/63` | Feed via stdin (`scan.sh`) / real temp file (`save-results.sh`) |
| `--argjson skills "$all_skills"` with a full inventory (`scan.sh`) | `Argument list too long` (~32KB argv limit) | Pass the array via stdin |
| `dp="${file/#$HOME/~}"` canonicalization (`scan.sh`, `quick-diff.sh`) | The bare `~` in the replacement is tilde-expanded back to `$HOME` (no-op), while MSYS argument conversion turns POSIX paths into `C:/`-style before jq stores them → quick-diff never matches stored paths and reports **every** file as new | `cygpath -m` on Windows; escaped `\~` fallback elsewhere |
| Global dir == project dir (`scan.sh`, `quick-diff.sh`) | Invoking from `$HOME` makes `$PWD/.claude/skills` resolve to the global dir → every skill double-counted (242 files reported as 484) | Skip the project pass when both resolve to the same physical dir |
| Auxiliary `.md` assets (`quick-diff.sh`) | `results.json` records one entry per skill (its SKILL.md), but the scanner enumerates all `*.md` → `references/`, `rules/`, `agents/` files are forever misreported as `is_new` | Judge known-ness per skill via its SKILL.md anchor |

### Skill docs

- **browser-qa**: tool family was written as `mChild__claude-in-chrome__*`; the real prefix is `mcp__claude-in-chrome__*`, so an agent following the skill literally could never invoke the browser tools.
- **autonomous-agent-harness**: the Setup Guide instructed installing `@anthropic/memory-mcp-server`, `@anthropic/scheduled-tasks-mcp-server`, `@anthropic/computer-use-mcp-server` and POSTing to `https://api.anthropic.com/dispatch` — none of these npm packages or the hosted endpoint exist. Rewritten to point at what actually ships (Claude Code built-in memory, native scheduled tasks / OS schedulers with headless `claude -p`, Claude in Chrome or Playwright MCP, and `claude -p` inside CI for the dispatch pattern).

## Test plan

- [x] `bash -n` clean on all three scripts
- [x] End-to-end on Windows 11 Git Bash + jq 1.8.2 against a 186-skill install: `scan.sh` produces a correct single-count inventory; `quick-diff.sh` returns `[]` on a fresh baseline, and exactly the edited files (no false positives) after edits; `save-results.sh` merges and stamps `evaluated_at` correctly
- [x] `node tests/run-all.js`: 3037/3049 pass; the 12 failures (block-no-verify, config-protection, gateguard suites) reproduce identically on a clean checkout of `main` on this machine, i.e. pre-existing local-environment failures unrelated to this change (no test coverage exists for the stocktake bash scripts)
- [ ] Behavior on macOS/Linux is unchanged by design (`command -v cygpath` gates every Windows path; verifying on a POSIX runner would be a welcome double-check)

Side note: while committing, the local block-no-verify hook falsely rejected a commit message containing the text "bash -n clean" — a live reproduction of the failing `allows -n discussed in a quoted commit message` test case in the suite.
