### PR TITLE
Trim provider names in prompt builder

### DIFF
--- a/src/llm/prompt/builder.py
+++ b/src/llm/prompt/builder.py
@@ -111,7 +111,7 @@ _PROVIDER_TEMPLATE_MAP: dict[str, dict[str, Any]] = {
 
 
 def get_provider_builder(provider_name: str) -> PromptBuilder:
-    config_dict = _PROVIDER_TEMPLATE_MAP.get(provider_name.lower(), {})
+    config_dict = _PROVIDER_TEMPLATE_MAP.get(provider_name.strip().lower(), {})
     config = PromptConfig(**config_dict)
     return PromptBuilder(config)
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -82,3 +82,13 @@ class TestAdaptMessagesForProvider:
         messages = [Message(role=Role.USER, content="Hello")]
         result = adapt_messages_for_provider(messages, "ollama")
         assert len(result) == 1
+
+    def test_provider_names_allow_outer_whitespace(self):
+        messages = [Message(role=Role.USER, content="Hello")]
+        tools = [ToolDefinition(name="search", description="Search the web", parameters={})]
+
+        result = adapt_messages_for_provider(messages, " ollama ", tools)
+
+        assert len(result) == 2
+        assert result[0].role == Role.SYSTEM
+        assert "Available Tools" in result[0].content

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,7 +1,7 @@
 import pytest
 from llm.core.types import LLMInput, Message, Role, ToolDefinition
 from llm.prompt import PromptBuilder, adapt_messages_for_provider
-from llm.prompt.builder import PromptConfig
+from llm.prompt.builder import PromptConfig, get_provider_builder
 
 
 class TestPromptBuilder:
@@ -89,6 +89,7 @@ class TestAdaptMessagesForProvider:
 
         result = adapt_messages_for_provider(messages, " ollama ", tools)
 
+        assert get_provider_builder(" ollama ").config.tool_format == "text"
         assert len(result) == 2
         assert result[0].role == Role.SYSTEM
         assert "Available Tools" in result[0].content


### PR DESCRIPTION
## Summary
- trim outer whitespace before resolving provider-specific prompt builder settings
- add a regression test for provider names with surrounding spaces

## Validation
- python -m pytest tests/test_builder.py