### PR TITLE
fix(hooks): bound plugin shell probe timeouts

### DIFF
--- a/scripts/hooks/plugin-hook-bootstrap.js
+++ b/scripts/hooks/plugin-hook-bootstrap.js
@@ -6,6 +6,8 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 const { ensureAgentDataHomeEnv } = require('../lib/agent-data-home');
 
+const SHELL_PROBE_TIMEOUT_MS = 2000;
+
 function readStdinRaw() {
   try {
     return fs.readFileSync(0, 'utf8');
@@ -95,7 +97,7 @@ function findShellBinary() {
     const probe = spawnSync(candidate, isPowerShellBin(candidate) ? psProbeArgs : shProbeArgs, {
       stdio: 'ignore',
       windowsHide: true,
-      timeout: 30000,
+      timeout: SHELL_PROBE_TIMEOUT_MS,
     });
     // A candidate is only usable if it both spawns AND exits cleanly. The
     // Windows System32 bash.exe WSL launcher spawns without error but exits
@@ -120,7 +122,11 @@ function findBashBinary() {
   candidates.push('bash.exe', 'bash');
 
   for (const candidate of candidates) {
-    const probe = spawnSync(candidate, ['-c', ':'], { stdio: 'ignore', windowsHide: true, timeout: 30000 });
+    const probe = spawnSync(candidate, ['-c', ':'], {
+      stdio: 'ignore',
+      windowsHide: true,
+      timeout: SHELL_PROBE_TIMEOUT_MS,
+    });
     // Require a clean exit, not just a successful spawn: the Windows System32
     // bash.exe WSL stub spawns fine but exits non-zero with no distro installed.
     if (!probe.error && probe.status === 0) {


### PR DESCRIPTION
## Summary
- Bound plugin shell discovery probes to 2s instead of 30s.
- Prevents Windows hook-bootstrap tests from timing out while checking unavailable bash candidates.
- Keeps hook behavior fail-open when shell runtimes are unavailable.

## Why
Main CI failed on run 29937336286 in Windows Node 22 npm: `hooks/plugin-hook-bootstrap.test.js` returned `status: null` for the no-bash Windows path. The outer test wrapper has a 10s timeout, but the bootstrap could spend up to 30s per shell probe, so the wrapper killed the process before it could return the expected fail-open status.

## Test plan
- `node tests/hooks/plugin-hook-bootstrap.test.js`
- `node tests/hooks/hooks.test.js`
- `node tests/hooks/pre-bash-commit-quality.test.js`