### PR TITLE
feat(control-pane): expose skill runs in the snapshot feed

### DIFF
--- a/scripts/lib/control-pane/state.js
+++ b/scripts/lib/control-pane/state.js
@@ -563,14 +563,84 @@ function summarizeWorkItems(items) {
   return summary;
 }
 
-async function readWorkItemsSnapshot(stateDbPath) {
+const SKILL_RUN_LIMIT = 50;
+
+function normalizeSkillRunOutcome(outcome) {
+  const normalized = String(outcome || '')
+    .trim()
+    .toLowerCase();
+  if (['success', 'succeeded', 'pass', 'passed', 'ok'].includes(normalized)) return 'success';
+  if (['failure', 'failed', 'fail', 'error'].includes(normalized)) return 'failure';
+  return 'unknown';
+}
+
+function normalizeSkillRun(row) {
+  const optionalNumber = (value) => (value === null || value === undefined || value === '' ? null : toNumber(value, 0));
+  return {
+    id: String(row.id || ''),
+    skillId: String(row.skill_id || ''),
+    skillVersion: row.skill_version ? String(row.skill_version) : null,
+    sessionId: row.session_id ? String(row.session_id) : null,
+    taskDescription: String(row.task_description || ''),
+    outcome: normalizeSkillRunOutcome(row.outcome),
+    rawOutcome: String(row.outcome || ''),
+    failureReason: row.failure_reason ? String(row.failure_reason) : null,
+    tokensUsed: optionalNumber(row.tokens_used),
+    durationMs: optionalNumber(row.duration_ms),
+    userFeedback: row.user_feedback ? String(row.user_feedback) : null,
+    createdAt: String(row.created_at || '')
+  };
+}
+
+function readSkillRuns(db) {
+  if (!tableExists(db, 'skill_runs')) return [];
+  return execRows(
+    db,
+    `SELECT *
+     FROM skill_runs
+     ORDER BY created_at DESC, id DESC
+     LIMIT ?`,
+    [SKILL_RUN_LIMIT]
+  ).map(normalizeSkillRun);
+}
+
+function summarizeSkillRuns(runs) {
+  const summary = {
+    totalCount: runs.length,
+    successCount: 0,
+    failureCount: 0,
+    unknownCount: 0,
+    successRate: null,
+    windowSize: SKILL_RUN_LIMIT,
+    items: runs
+  };
+
+  for (const run of runs) {
+    if (run.outcome === 'success') summary.successCount += 1;
+    else if (run.outcome === 'failure') summary.failureCount += 1;
+    else summary.unknownCount += 1;
+  }
+
+  // Unknown outcomes are excluded from the rate so a partially instrumented
+  // harness does not read as a drop in skill reliability.
+  const decided = summary.successCount + summary.failureCount;
+  if (decided > 0) summary.successRate = summary.successCount / decided;
+
+  return summary;
+}
+
+async function readStateStoreSnapshot(stateDbPath) {
+  const empty = { workItems: summarizeWorkItems([]), skillRuns: summarizeSkillRuns([]) };
   let db = null;
   try {
     db = await openSqlDatabase(stateDbPath);
-    if (!db) return summarizeWorkItems([]);
-    return summarizeWorkItems(readWorkItems(db));
+    if (!db) return empty;
+    return {
+      workItems: summarizeWorkItems(readWorkItems(db)),
+      skillRuns: summarizeSkillRuns(readSkillRuns(db))
+    };
   } catch {
-    return summarizeWorkItems([]);
+    return empty;
   } finally {
     if (db) db.close();
   }
@@ -590,7 +660,7 @@ async function buildControlPaneSnapshot(options = {}) {
   const query = String(options.query || '').trim();
   const limit = Math.max(1, Math.min(Number.parseInt(String(options.limit || 12), 10) || 12, 50));
   const generatedAt = new Date().toISOString();
-  const workItems = await readWorkItemsSnapshot(stateDbPath);
+  const { workItems, skillRuns } = await readStateStoreSnapshot(stateDbPath);
   const base = {
     schemaVersion: SNAPSHOT_SCHEMA_VERSION,
     generatedAt,
@@ -620,6 +690,7 @@ async function buildControlPaneSnapshot(options = {}) {
     },
     connectors: connectorStatus(config, null),
     workItems,
+    skillRuns,
     actions: buildControlPaneActions({ repoRoot, query, limit })
   };
 

--- a/tests/scripts/control-pane.test.js
+++ b/tests/scripts/control-pane.test.js
@@ -191,6 +191,10 @@ async function runTests() {
           host: '127.0.0.1',
           port: 0,
           dbPath,
+          // Isolate the state store too, otherwise the assertions below read the
+          // operator's real ~/.claude/ecc/state.db and fail on any machine that
+          // has recorded work items.
+          stateDbPath: path.join(tempDir, 'state.db'),
           repoRoot: REPO_ROOT,
           query: 'control pane',
           allowActions: false
@@ -656,6 +660,82 @@ async function runTests() {
         }
       } finally {
         fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    await test('snapshot exposes skill runs from the state store', async () => {
+      const { createStateStore } = require('../../scripts/lib/state-store');
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-control-pane-skill-runs-'));
+      const stateDbPath = path.join(tempDir, 'state.db');
+
+      try {
+        const store = await createStateStore({ dbPath: stateDbPath });
+        store.upsertSession({ id: 'sid-1', adapterId: 'claude', harness: 'claude-code', state: 'active' });
+        store.insertSkillRun({
+          id: 'run-1',
+          skillId: 'security-review',
+          skillVersion: '1.0.0',
+          sessionId: 'sid-1',
+          taskDescription: 'Audit the auth module',
+          outcome: 'success',
+          durationMs: 1200,
+          createdAt: '2026-01-01T00:00:00.000Z'
+        });
+        store.insertSkillRun({
+          id: 'run-2',
+          skillId: 'security-review',
+          skillVersion: '1.0.0',
+          sessionId: 'sid-1',
+          taskDescription: 'Audit the billing module',
+          outcome: 'failure',
+          failureReason: 'missing test fixtures',
+          createdAt: '2026-01-02T00:00:00.000Z'
+        });
+        store.close();
+
+        const app = await createControlPaneServer({ host: '127.0.0.1', port: 0, stateDbPath, repoRoot: REPO_ROOT, allowActions: false });
+        await app.listen();
+        try {
+          const snapshot = await fetchLocal(`${app.url}/api/snapshot`).then(r => r.json());
+          assert.strictEqual(snapshot.skillRuns.totalCount, 2);
+          assert.strictEqual(snapshot.skillRuns.successCount, 1);
+          assert.strictEqual(snapshot.skillRuns.failureCount, 1);
+          assert.strictEqual(snapshot.skillRuns.successRate, 0.5);
+          // Newest first.
+          assert.strictEqual(snapshot.skillRuns.items[0].id, 'run-2');
+          assert.strictEqual(snapshot.skillRuns.items[0].outcome, 'failure');
+          assert.strictEqual(snapshot.skillRuns.items[0].failureReason, 'missing test fixtures');
+          assert.strictEqual(snapshot.skillRuns.items[1].skillId, 'security-review');
+          assert.strictEqual(snapshot.skillRuns.items[1].durationMs, 1200);
+        } finally {
+          await app.close();
+        }
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    await test('snapshot returns an empty skill-run summary without a state store', async () => {
+      // Point at a path that does not exist so the test never reads the
+      // operator's real state store.
+      const stateDbPath = path.join(os.tmpdir(), 'ecc-control-pane-missing-state', 'state.db');
+      const app = await createControlPaneServer({ host: '127.0.0.1', port: 0, stateDbPath, repoRoot: REPO_ROOT, allowActions: false });
+      await app.listen();
+      try {
+        const snapshot = await fetchLocal(`${app.url}/api/snapshot`).then(r => r.json());
+        assert.strictEqual(snapshot.skillRuns.totalCount, 0);
+        assert.strictEqual(snapshot.skillRuns.successRate, null);
+        assert.deepStrictEqual(snapshot.skillRuns.items, []);
+      } finally {
+        await app.close();
       }
     })
   )


### PR DESCRIPTION
@
## Problem

The control pane snapshot publishes work items, sessions, knowledge and connectors, but not skill runs — even though they are already recorded in the state store and `ecc status` prints them.

That leaves any external reader of `/api/snapshot` with no way to surface skill reliability. The only alternative is reading `state.db` off disk, which defeats the point of having the control pane as the read boundary.

## Change

- `GET /api/snapshot` now includes a `skillRuns` block:

```json
{
  "skillRuns": {
    "totalCount": 2,
    "successCount": 1,
    "failureCount": 1,
    "unknownCount": 0,
    "successRate": 0.5,
    "windowSize": 50,
    "items": [ { "id": "...", "skillId": "...", "outcome": "failure", "failureReason": "...", "durationMs": 1200, "createdAt": "..." } ]
  }
}
```

- 50 most recent runs, newest first, mirroring how work items are read.
- Outcomes normalized to `success` / `failure` / `unknown`; the raw value is kept as `rawOutcome`.
- Unknown outcomes are excluded from `successRate`, so a partially instrumented harness does not read as a reliability drop.
- Work items and skill runs now share one state-store open per snapshot instead of opening the database twice.

## Test isolation fix

`serves HTML and snapshot JSON from a temp ECC2 database` isolated `dbPath` but not `stateDbPath`, so it fell through to the real `~/.claude/ecc/state.db`. On any machine with a recorded work item the test failed with `1 !== 0`. It now uses a temp state store. The new empty-state test points at a nonexistent path for the same reason.

## Tests

Two new cases in `tests/scripts/control-pane.test.js`: populated state store (counts, rate, ordering, failure reason) and missing state store (empty summary, `successRate: null`).

```
node tests/scripts/control-pane.test.js
Results: Passed: 18, Failed: 0

node tests/run-all.js
Total Tests: 3117, Passed: 3116, Failed: 1
```

The single failure is `detects newest Claude plugin install from cache marketplace layout`, unrelated to this change — it reads the real `~/.claude/plugins` directory and fails on a machine with plugins installed. It fails the same way on a clean checkout.

`npx eslint` clean on both changed files.

## Not included

No UI rendering in `ui.js` — this only exposes the data. Happy to add the panel in a follow-up if you want it on the page itself.

## Context

Found while wiring an external operator console to the control pane as a read-only client. Work items, sessions and knowledge mapped cleanly; skills were the one screen with no available source.
@