### PR TITLE
docs: map cross-harness control-plane roadmap

### DIFF
--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -65,13 +65,17 @@ The execution sequence is deliberately read-only first and promotion-gated:
    merge, approval, or filesystem mutation. Bind caller identity and a
    canonical realpath workspace ID at server startup; expose only records owned
    by that workspace/caller; deny undeclared read capabilities; and rate-limit
-   and audit every read without logging returned content.
+   and audit every read without logging returned content. Version every tool's
+   request and response schema, validate both at the boundary, and return the
+   common `{success, data, error, pagination}` envelope. Bounded list and diff
+   responses include cursor, `has_more`, and `truncated` metadata.
 3. **ECC2 MCP mutation plane.** Add `create_task`, `merge_task`, and
    `approve_tool` only after the read plane is stable. Require explicit
    capability gates, immutable audit receipts, dry-run previews, and the
    existing risk/profile policy at every mutation boundary. Caller identity,
    workspace ownership, and per-tool authorization fail closed before inputs
-   reach the store or filesystem.
+   reach the store or filesystem. Mutation tools use the same versioned,
+   boundary-validated request and response schemas and common envelope.
 4. **Worktree lifecycle contract.** Define and schema-validate
    `ecc.worktree.yml`; specify `new`, `split`, `fork`, and `close` state
    transitions; define bounded context seeding and lifecycle hooks without
@@ -82,7 +86,10 @@ The execution sequence is deliberately read-only first and promotion-gated:
    transactional acquire/renew/release, unique overlap enforcement, and
    compare-and-swap owner/epoch checks. Show overlap before blocking, then add
    queue serialization, bounded lease expiry/recovery after heartbeat loss,
-   and human escalation records.
+   and human escalation records. Incomplete or uninstrumented touched-path
+   coverage blocks mutation unless the caller atomically acquires a
+   workspace-wide lease. Revalidate the final touched-path set and lease
+   ownership immediately before every mutation and merge.
 6. **Consent-gated telemetry schema.** Standardize `ecc.*` span names and
    bounded attributes, define `TRACEPARENT` propagation, and require explicit
    consent, schema validation, and deterministic redaction before any sink.
@@ -103,17 +110,21 @@ The execution sequence is deliberately read-only first and promotion-gated:
    locks, and optional dual-engine scanning from
    [issue #2415](https://github.com/affaan-m/ECC/issues/2415).
 10. **Distribution interop.** Add provenance-preserving npx-skills and ClawHub
-   import/export only after the policy and promotion contracts are stable.
-   Training or inference automation remains deferred until telemetry,
-   evaluation, consent, and rollback gates are operational.
+   import/export only after the policy and promotion contracts plus
+   AgentShield's signed-provenance and registry-lock verification are stable.
+   Import and export deny by default when provenance or lock verification is
+   missing, invalid, or unavailable. Training or inference automation remains
+   deferred until telemetry, evaluation, consent, and rollback gates are
+   operational.
 
 Each numbered item is a separate implementation lane. Do not combine the
 read-only MCP plane with mutations, the telemetry schema with live export, or
 candidate generation with promotion. Each lane requires unit and integration
-tests, end-to-end coverage for its critical operator flow, at least 80% line
-and function coverage, adversarial boundary tests, a migration/rollback note,
-and fresh Linux, macOS, and Windows evidence before the next dependent lane
-begins.
+tests plus end-to-end coverage for its critical operator flow to fail before
+implementation begins. After implementation, those tests must pass with at
+least 80% line and function coverage, adversarial boundary tests, a
+migration/rollback note, and fresh Linux, macOS, and Windows evidence before
+the next dependent lane begins.
 
 ## 2026-05-20 Delta
 

--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -68,14 +68,20 @@ The execution sequence is deliberately read-only first and promotion-gated:
    and audit every read without logging returned content. Version every tool's
    request and response schema, validate both at the boundary, and return the
    common `{success, data, error, pagination}` envelope. Bounded list and diff
-   responses include cursor, `has_more`, and `truncated` metadata.
+   responses include cursor, `has_more`, and `truncated` metadata. Bind every
+   cursor to an immutable session/worktree revision; reject stale cursors and
+   require pagination to restart when that revision is no longer available.
 3. **ECC2 MCP mutation plane.** Add `create_task`, `merge_task`, and
    `approve_tool` only after the read plane is stable. Require explicit
    capability gates, immutable audit receipts, dry-run previews, and the
    existing risk/profile policy at every mutation boundary. Caller identity,
    workspace ownership, and per-tool authorization fail closed before inputs
    reach the store or filesystem. Mutation tools use the same versioned,
-   boundary-validated request and response schemas and common envelope.
+   boundary-validated request and response schemas and common envelope. Apply
+   per-caller and per-workspace rate limits before mutation processing and fail
+   closed when the limiter is unavailable. Persist the immutable receipt before
+   any side effect, or use an atomic transaction/outbox whose reconciliation
+   guarantees every successful mutation has a durable receipt.
 4. **Worktree lifecycle contract.** Define and schema-validate
    `ecc.worktree.yml`; specify `new`, `split`, `fork`, and `close` state
    transitions; define bounded context seeding and lifecycle hooks without
@@ -113,9 +119,11 @@ The execution sequence is deliberately read-only first and promotion-gated:
    import/export only after the policy and promotion contracts plus
    AgentShield's signed-provenance and registry-lock verification are stable.
    Import and export deny by default when provenance or lock verification is
-   missing, invalid, or unavailable. Training or inference automation remains
-   deferred until telemetry, evaluation, consent, and rollback gates are
-   operational.
+   missing, invalid, or unavailable. Before any imported artifact reaches a
+   store or filesystem operation, validate its versioned schema, bounded size,
+   contained paths, and content policy, and reject malformed or untrusted
+   input with bounded errors. Training or inference automation remains deferred
+   until telemetry, evaluation, consent, and rollback gates are operational.
 
 Each numbered item is a separate implementation lane. Do not combine the
 read-only MCP plane with mutations, the telemetry schema with live export, or

--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -62,33 +62,47 @@ The execution sequence is deliberately read-only first and promotion-gated:
 2. **ECC2 MCP read plane.** Add an opt-in MCP server over existing ECC2
    stores with bounded, redacted `list_sessions`, `get_diff`,
    `worktree_status`, and `merge_queue` tools. This slice performs no task,
-   merge, approval, or filesystem mutation.
+   merge, approval, or filesystem mutation. Bind caller identity and a
+   canonical realpath workspace ID at server startup; expose only records owned
+   by that workspace/caller; deny undeclared read capabilities; and rate-limit
+   and audit every read without logging returned content.
 3. **ECC2 MCP mutation plane.** Add `create_task`, `merge_task`, and
    `approve_tool` only after the read plane is stable. Require explicit
    capability gates, immutable audit receipts, dry-run previews, and the
-   existing risk/profile policy at every mutation boundary.
+   existing risk/profile policy at every mutation boundary. Caller identity,
+   workspace ownership, and per-tool authorization fail closed before inputs
+   reach the store or filesystem.
 4. **Worktree lifecycle contract.** Define and schema-validate
    `ecc.worktree.yml`; specify `new`, `split`, `fork`, and `close` state
    transitions; define bounded context seeding and lifecycle hooks without
    copying secrets or raw harness transcripts.
 5. **TCAS leases and merge serialization.** Derive touched paths from tool
-   activity, persist `{session, branch, touched_paths, heartbeat}` leases, show
-   overlap before blocking, then add queue serialization, lease expiry, and
-   human escalation records.
-6. **Consent-gated OTLP v2.** Standardize `ecc.*` span names and redacted
-   attributes, propagate `TRACEPARENT`, and add an explicit opt-in live
-   exporter. Existing JSON export remains the offline fallback; no prompts,
-   secrets, or memory bodies enter telemetry.
-7. **Skill-quality and promotion gates.** Stabilize invocation telemetry
+   activity and normalize each path against the canonical workspace. Persist
+   `{session, branch, touched_paths, heartbeat, owner, epoch}` leases with
+   transactional acquire/renew/release, unique overlap enforcement, and
+   compare-and-swap owner/epoch checks. Show overlap before blocking, then add
+   queue serialization, bounded lease expiry/recovery after heartbeat loss,
+   and human escalation records.
+6. **Consent-gated telemetry schema.** Standardize `ecc.*` span names and
+   bounded attributes, define `TRACEPARENT` propagation, and require explicit
+   consent, schema validation, and deterministic redaction before any sink.
+   Missing or invalid consent fails closed. Prompts, secrets, memory bodies,
+   raw diffs, and unbounded error text are forbidden by schema and regression
+   tests for both offline and future live output.
+7. **Consent-gated OTLP exporter.** Add the opt-in live exporter only after
+   the telemetry schema and redaction suite are stable. Existing JSON export
+   remains the offline fallback, but it passes through the same consent,
+   validation, redaction, and bounded-output gate as the live sink.
+8. **Skill-quality and promotion gates.** Stabilize invocation telemetry
    before adding determinism and delta-value measures. Proposed skills live in
    a candidate area and may reach canonical surfaces only through a recorded
    eval result, human approval, append-only transition event, and reversible
    promotion.
-8. **AgentShield v2 enforcement.** Introduce a versioned allow/approve/block
+9. **AgentShield v2 enforcement.** Introduce a versioned allow/approve/block
    policy contract enforced by ECC2, followed by signed provenance, registry
    locks, and optional dual-engine scanning from
    [issue #2415](https://github.com/affaan-m/ECC/issues/2415).
-9. **Distribution interop.** Add provenance-preserving npx-skills and ClawHub
+10. **Distribution interop.** Add provenance-preserving npx-skills and ClawHub
    import/export only after the policy and promotion contracts are stable.
    Training or inference automation remains deferred until telemetry,
    evaluation, consent, and rollback gates are operational.
@@ -96,8 +110,10 @@ The execution sequence is deliberately read-only first and promotion-gated:
 Each numbered item is a separate implementation lane. Do not combine the
 read-only MCP plane with mutations, the telemetry schema with live export, or
 candidate generation with promotion. Each lane requires unit and integration
-coverage, adversarial boundary tests, a migration/rollback note, and fresh
-Linux, macOS, and Windows evidence before the next dependent lane begins.
+tests, end-to-end coverage for its critical operator flow, at least 80% line
+and function coverage, adversarial boundary tests, a migration/rollback note,
+and fresh Linux, macOS, and Windows evidence before the next dependent lane
+begins.
 
 ## 2026-05-20 Delta
 

--- a/docs/ECC-2.0-GA-ROADMAP.md
+++ b/docs/ECC-2.0-GA-ROADMAP.md
@@ -17,6 +17,88 @@ The May 19 release/growth execution map lives at
 It is the operator surface for the final ECC 2.0 repo identity, video suite,
 partner/sponsor funnel, consulting/talk funnel, and social launch plan.
 
+## 2026-07-26 Cross-Harness Control-Plane Delta
+
+The next product layer is composition, not a second harness. ECC already has
+session storage, worktree lifecycle helpers, merge-queue state, OTEL export,
+skill-run records, learning hooks, and provenance checks. The missing work is
+to expose those primitives through governed cross-harness contracts and make
+promotion, merge, and policy decisions auditable.
+
+The first cross-harness knowledge-transfer slice is tracked in
+[PR #2581](https://github.com/affaan-m/ECC/pull/2581). It adds a file-first
+memory vault for Codex, Claude Code, OpenCode, Cursor, and Hermes-style agents,
+with Markdown as the portable source of truth and an optional MCP projection.
+Every new memory remains unreviewed until a later, explicit promotion system is
+implemented. [PR #2582](https://github.com/affaan-m/ECC/pull/2582) addresses
+Claude's flat skill-discovery layout, and
+[PR #2583](https://github.com/affaan-m/ECC/pull/2583) aligns Claude agent tool
+frontmatter with the documented scalar format.
+
+Existing implementation anchors:
+
+- `ecc2/src/session/store.rs` persists sessions, tool logs, decisions, context
+  graph edges, queues, and conflict incidents.
+- `ecc2/src/main.rs` already exposes session, worktree, merge-queue, daemon,
+  and OTEL-export commands.
+- `scripts/lib/worktree-lifecycle/` and `scripts/worktree-lifecycle.js`
+  classify worktree state and produce conflict and cleanup plans.
+- `scripts/lib/skill-evolution/` records skill runs, health, and provenance;
+  `skills/continuous-learning-v2/` and `skills/eval-harness/` provide the
+  learning and evaluation substrate.
+- `skills/security-scan/`, `schemas/provenance.schema.json`, and
+  `docs/architecture/agentshield-enterprise-research-roadmap.md` provide the
+  current policy and supply-chain substrate.
+
+The execution sequence is deliberately read-only first and promotion-gated:
+
+1. **Distribution and knowledge-transfer correctness.** Land the memory,
+   Claude skill-layout, and Claude agent-frontmatter fixes with their complete
+   security and cross-platform matrices. Re-evaluate
+   [PR #2555](https://github.com/affaan-m/ECC/pull/2555),
+   [PR #2490](https://github.com/affaan-m/ECC/pull/2490), and
+   [PR #2578](https://github.com/affaan-m/ECC/pull/2578) after those bases are
+   stable.
+2. **ECC2 MCP read plane.** Add an opt-in MCP server over existing ECC2
+   stores with bounded, redacted `list_sessions`, `get_diff`,
+   `worktree_status`, and `merge_queue` tools. This slice performs no task,
+   merge, approval, or filesystem mutation.
+3. **ECC2 MCP mutation plane.** Add `create_task`, `merge_task`, and
+   `approve_tool` only after the read plane is stable. Require explicit
+   capability gates, immutable audit receipts, dry-run previews, and the
+   existing risk/profile policy at every mutation boundary.
+4. **Worktree lifecycle contract.** Define and schema-validate
+   `ecc.worktree.yml`; specify `new`, `split`, `fork`, and `close` state
+   transitions; define bounded context seeding and lifecycle hooks without
+   copying secrets or raw harness transcripts.
+5. **TCAS leases and merge serialization.** Derive touched paths from tool
+   activity, persist `{session, branch, touched_paths, heartbeat}` leases, show
+   overlap before blocking, then add queue serialization, lease expiry, and
+   human escalation records.
+6. **Consent-gated OTLP v2.** Standardize `ecc.*` span names and redacted
+   attributes, propagate `TRACEPARENT`, and add an explicit opt-in live
+   exporter. Existing JSON export remains the offline fallback; no prompts,
+   secrets, or memory bodies enter telemetry.
+7. **Skill-quality and promotion gates.** Stabilize invocation telemetry
+   before adding determinism and delta-value measures. Proposed skills live in
+   a candidate area and may reach canonical surfaces only through a recorded
+   eval result, human approval, append-only transition event, and reversible
+   promotion.
+8. **AgentShield v2 enforcement.** Introduce a versioned allow/approve/block
+   policy contract enforced by ECC2, followed by signed provenance, registry
+   locks, and optional dual-engine scanning from
+   [issue #2415](https://github.com/affaan-m/ECC/issues/2415).
+9. **Distribution interop.** Add provenance-preserving npx-skills and ClawHub
+   import/export only after the policy and promotion contracts are stable.
+   Training or inference automation remains deferred until telemetry,
+   evaluation, consent, and rollback gates are operational.
+
+Each numbered item is a separate implementation lane. Do not combine the
+read-only MCP plane with mutations, the telemetry schema with live export, or
+candidate generation with promotion. Each lane requires unit and integration
+coverage, adversarial boundary tests, a migration/rollback note, and fresh
+Linux, macOS, and Windows evidence before the next dependent lane begins.
+
 ## 2026-05-20 Delta
 
 - The tracked platform audit is still green on May 20 with 0 open PRs,


### PR DESCRIPTION
## Summary

Records the July 2026 cross-harness control-plane plan in the existing GA roadmap.

- maps the proposal onto ECC2 session/worktree/merge/OTEL primitives already in the repo
- sequences the memory and Claude compatibility blockers before control-plane expansion
- separates read-only MCP tools from gated mutations
- defines bounded slices for worktree lifecycle, TCAS leases, consent-gated OTLP, promotion gates, AgentShield v2, and distribution interop
- keeps training/inference automation deferred behind telemetry, evaluation, consent, and rollback gates

## Validation

- markdownlint: passing
- personal-path validator: passing
- git diff --check: passing

Related #2474, #2415.