### PR TITLE
fix: resolve pnpm in Git Bash pre-push hook

### DIFF
--- a/scripts/codex-git-hooks/pre-push
+++ b/scripts/codex-git-hooks/pre-push
@@ -62,6 +62,8 @@ has_node_script() {
 
 run_pnpm() {
   if command -v corepack >/dev/null 2>&1; then
+    # Corepack may download the pinned pnpm version on a cache miss. Set
+    # COREPACK_ENABLE_NETWORK=0 to make an offline cache miss fail immediately.
     corepack pnpm "$@"
   elif command -v pnpm >/dev/null 2>&1; then
     pnpm "$@"

--- a/scripts/codex-git-hooks/pre-push
+++ b/scripts/codex-git-hooks/pre-push
@@ -60,11 +60,21 @@ has_node_script() {
   node -e 'const fs=require("fs"); const p=JSON.parse(fs.readFileSync("package.json","utf8")); process.exit(p.scripts && p.scripts[process.argv[1]] ? 0 : 1)' "$script_name" >/dev/null 2>&1
 }
 
+run_pnpm() {
+  if command -v corepack >/dev/null 2>&1; then
+    corepack pnpm "$@"
+  elif command -v pnpm >/dev/null 2>&1; then
+    pnpm "$@"
+  else
+    fail "pnpm could not be resolved from PATH or Corepack"
+  fi
+}
+
 run_node_script() {
   local pm="$1"
   local script_name="$2"
   case "$pm" in
-    pnpm) pnpm run "$script_name" ;;
+    pnpm) run_pnpm run "$script_name" ;;
     bun) bun run "$script_name" ;;
     yarn) yarn "$script_name" ;;
     npm) npm run "$script_name" ;;
@@ -90,7 +100,7 @@ if [[ -f "package.json" ]]; then
     ran_any_check=1
     log "Running dependency audit (ECC_PREPUSH_AUDIT=1)"
     case "$pm" in
-      pnpm) pnpm audit --prod || fail "pnpm audit failed" ;;
+      pnpm) run_pnpm audit --prod || fail "pnpm audit failed" ;;
       bun) bun audit || fail "bun audit failed" ;;
       yarn) yarn npm audit --recursive || fail "yarn audit failed" ;;
       npm) npm audit --omit=dev || fail "npm audit failed" ;;

--- a/tests/scripts/codex-hooks.test.js
+++ b/tests/scripts/codex-hooks.test.js
@@ -132,7 +132,12 @@ const cacheManifestWithLocalRefs = {
 let passed = 0;
 let failed = 0;
 
-function runHermeticPrePush({ failScript = null, includeCorepack = true, includePnpm = false } = {}) {
+function runHermeticPrePush({
+  failScript = null,
+  includeCorepack = true,
+  includePnpm = false,
+  audit = false,
+} = {}) {
   const tempDir = createTempDir('codex-pre-push-');
   const binDir = path.join(tempDir, 'bin');
   const projectDir = path.join(tempDir, 'project');
@@ -141,6 +146,7 @@ function runHermeticPrePush({ failScript = null, includeCorepack = true, include
   fs.mkdirSync(binDir);
   fs.mkdirSync(projectDir);
   const functionStub = (name, corepack) => `${name}() {
+${corepack ? 'node -e \'const p=require("./package.json"); process.exit(p.packageManager === "pnpm@11.9.0" ? 0 : 1)\' || return 97' : ':'}
 printf '%s\\n' "${corepack ? '' : 'pnpm '}$*" >> "${toBashPath(callsPath)}"
 ${corepack ? 'shift' : ':'}
 shift
@@ -165,7 +171,7 @@ ${includePnpm ? functionStub('pnpm', false) : ''}
     env: {
       PATH: toBashPath(binDir),
       BASH_ENV: toBashPath(bashEnv),
-      ECC_PREPUSH_AUDIT: '0',
+      ECC_PREPUSH_AUDIT: audit ? '1' : '0',
       ECC_SKIP_GIT_HOOKS: '0',
       ECC_SKIP_PREPUSH: '0',
       MSYS_NO_PATHCONV: '1',
@@ -230,6 +236,39 @@ if (
     assert.notStrictEqual(result.status, 0, `${result.stdout}\n${result.stderr}`);
     assert.deepStrictEqual(calls, ['pnpm run lint', 'pnpm run typecheck']);
     assert.match(result.stderr, /typecheck failed/);
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('pre-push runs the production audit through Corepack pnpm', () => {
+    const { result, calls } = runHermeticPrePush({ audit: true });
+    assert.strictEqual(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.deepStrictEqual(calls, [
+      'pnpm run lint',
+      'pnpm run typecheck',
+      'pnpm run test',
+      'pnpm run build',
+      'pnpm audit --prod',
+    ]);
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('pre-push fails closed when the production audit fails', () => {
+    const { result, calls } = runHermeticPrePush({ audit: true, failScript: '--prod' });
+    assert.notStrictEqual(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.deepStrictEqual(calls, [
+      'pnpm run lint',
+      'pnpm run typecheck',
+      'pnpm run test',
+      'pnpm run build',
+      'pnpm audit --prod',
+    ]);
+    assert.match(result.stderr, /pnpm audit failed/);
   })
 )
   passed++;

--- a/tests/scripts/codex-hooks.test.js
+++ b/tests/scripts/codex-hooks.test.js
@@ -43,7 +43,10 @@ function cleanup(dirPath) {
   fs.rmSync(dirPath, { recursive: true, force: true });
 }
 
-function runBash(scriptPath, args = [], env = {}, cwd = repoRoot, input = undefined, preservePath = true) {
+function runBash(
+  scriptPath,
+  { args = [], env = {}, cwd = repoRoot, input = undefined, preservePath = true } = {},
+) {
   const bash = process.platform === 'win32' && fs.existsSync('C:\\Program Files\\Git\\bin\\bash.exe')
     ? 'C:\\Program Files\\Git\\bin\\bash.exe'
     : fs.existsSync('/bin/bash')
@@ -129,11 +132,6 @@ const cacheManifestWithLocalRefs = {
 let passed = 0;
 let failed = 0;
 
-function makeExecutable(filePath, content) {
-  fs.writeFileSync(filePath, content, { mode: 0o755 });
-  fs.chmodSync(filePath, 0o755);
-}
-
 function runHermeticPrePush({ failScript = null, includeCorepack = true, includePnpm = false } = {}) {
   const tempDir = createTempDir('codex-pre-push-');
   const binDir = path.join(tempDir, 'bin');
@@ -163,10 +161,8 @@ ${includePnpm ? functionStub('pnpm', false) : ''}
     packageManager: 'pnpm@11.9.0',
     scripts: { lint: 'x', typecheck: 'x', test: 'x', build: 'x' },
   });
-  const result = runBash(
-    prePushHook,
-    [],
-    {
+  const result = runBash(prePushHook, {
+    env: {
       PATH: toBashPath(binDir),
       BASH_ENV: toBashPath(bashEnv),
       ECC_PREPUSH_AUDIT: '0',
@@ -174,10 +170,10 @@ ${includePnpm ? functionStub('pnpm', false) : ''}
       ECC_SKIP_PREPUSH: '0',
       MSYS_NO_PATHCONV: '1',
     },
-    projectDir,
-    Buffer.from('refs/heads/main 1111111111111111111111111111111111111111 refs/heads/main 0000000000000000000000000000000000000000\n'),
-    false,
-  );
+    cwd: projectDir,
+    input: Buffer.from('refs/heads/main 1111111111111111111111111111111111111111 refs/heads/main 0000000000000000000000000000000000000000\n'),
+    preservePath: false,
+  });
   const calls = fs.existsSync(callsPath)
     ? fs.readFileSync(callsPath, 'utf8').trim().split(/\r?\n/)
     : [];
@@ -389,9 +385,11 @@ if (os.platform() === 'win32') {
     const weirdHooksDir = path.join(homeDir, 'git-hooks "quoted"');
 
     try {
-      const result = runBash(installScript, [], {
-        HOME: homeDir,
-        ECC_GLOBAL_HOOKS_DIR: weirdHooksDir,
+      const result = runBash(installScript, {
+        env: {
+          HOME: homeDir,
+          ECC_GLOBAL_HOOKS_DIR: weirdHooksDir,
+        },
       });
 
       assert.strictEqual(result.status, 0, result.stderr || result.stdout);
@@ -786,7 +784,10 @@ if (
       fs.mkdirSync(codexDir, { recursive: true });
       fs.writeFileSync(configPath, config);
 
-      const syncResult = runBash(syncScript, ['--update-mcp'], makeHermeticCodexEnv(homeDir, codexDir));
+      const syncResult = runBash(syncScript, {
+        args: ['--update-mcp'],
+        env: makeHermeticCodexEnv(homeDir, codexDir),
+      });
       assert.strictEqual(syncResult.status, 0, `${syncResult.stdout}\n${syncResult.stderr}`);
 
       const syncedAgents = fs.readFileSync(agentsPath, 'utf8');
@@ -847,7 +848,9 @@ if (
       fs.mkdirSync(codexDir, { recursive: true });
       fs.writeFileSync(configPath, config);
 
-      const syncResult = runBash(syncScript, [], makeHermeticCodexEnv(homeDir, codexDir));
+      const syncResult = runBash(syncScript, {
+        env: makeHermeticCodexEnv(homeDir, codexDir),
+      });
       assert.strictEqual(syncResult.status, 0, `${syncResult.stdout}\n${syncResult.stderr}`);
 
       const parsedConfig = TOML.parse(fs.readFileSync(configPath, 'utf8'));

--- a/tests/scripts/codex-hooks.test.js
+++ b/tests/scripts/codex-hooks.test.js
@@ -11,6 +11,7 @@ const TOML = require('@iarna/toml');
 
 const repoRoot = path.join(__dirname, '..', '..');
 const installScript = path.join(repoRoot, 'scripts', 'codex', 'install-global-git-hooks.sh');
+const prePushHook = path.join(repoRoot, 'scripts', 'codex-git-hooks', 'pre-push');
 const pluginCacheCheckScript = path.join(repoRoot, 'scripts', 'codex', 'check-plugin-cache.js');
 const mergeCodexConfigScript = path.join(repoRoot, 'scripts', 'codex', 'merge-codex-config.js');
 const mergeMcpConfigScript = path.join(repoRoot, 'scripts', 'codex', 'merge-mcp-config.js');
@@ -42,16 +43,28 @@ function cleanup(dirPath) {
   fs.rmSync(dirPath, { recursive: true, force: true });
 }
 
-function runBash(scriptPath, args = [], env = {}, cwd = repoRoot) {
-  return spawnSync('bash', [scriptPath, ...args], {
+function runBash(scriptPath, args = [], env = {}, cwd = repoRoot, input = undefined, preservePath = true) {
+  const bash = process.platform === 'win32' && fs.existsSync('C:\\Program Files\\Git\\bin\\bash.exe')
+    ? 'C:\\Program Files\\Git\\bin\\bash.exe'
+    : fs.existsSync('/bin/bash')
+      ? '/bin/bash'
+      : 'bash';
+  return spawnSync(bash, [scriptPath, ...args], {
     cwd,
     env: {
-      ...process.env,
+      ...(preservePath ? process.env : {}),
       ...env,
     },
     encoding: 'utf8',
+    input,
     stdio: ['pipe', 'pipe', 'pipe'],
   });
+}
+
+function toBashPath(filePath) {
+  return process.platform === 'win32'
+    ? `/${filePath[0].toLowerCase()}${filePath.slice(2).replaceAll('\\', '/')}`
+    : filePath;
 }
 
 function runNode(scriptPath, args = [], env = {}, cwd = repoRoot) {
@@ -115,6 +128,116 @@ const cacheManifestWithLocalRefs = {
 
 let passed = 0;
 let failed = 0;
+
+function makeExecutable(filePath, content) {
+  fs.writeFileSync(filePath, content, { mode: 0o755 });
+  fs.chmodSync(filePath, 0o755);
+}
+
+function runHermeticPrePush({ failScript = null, includeCorepack = true, includePnpm = false } = {}) {
+  const tempDir = createTempDir('codex-pre-push-');
+  const binDir = path.join(tempDir, 'bin');
+  const projectDir = path.join(tempDir, 'project');
+  const callsPath = path.join(tempDir, 'calls.txt');
+  const bashEnv = path.join(tempDir, 'bash-env');
+  fs.mkdirSync(binDir);
+  fs.mkdirSync(projectDir);
+  const functionStub = (name, corepack) => `${name}() {
+printf '%s\\n' "${corepack ? '' : 'pnpm '}$*" >> "${toBashPath(callsPath)}"
+${corepack ? 'shift' : ':'}
+shift
+test "$1" != "${failScript || '__never__'}"
+}`;
+  fs.writeFileSync(
+    bashEnv,
+    `git() { return 0; }
+node() { "${toBashPath(process.execPath)}" "$@"; }
+${includeCorepack ? functionStub('corepack', true) : ''}
+${includePnpm ? functionStub('pnpm', false) : ''}
+`,
+  );
+  fs.writeFileSync(path.join(projectDir, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n');
+  const initialized = spawnSync('git', ['init', '--quiet'], { cwd: projectDir });
+  assert.strictEqual(initialized.status, 0, initialized.stderr?.toString());
+  writeJson(path.join(projectDir, 'package.json'), {
+    packageManager: 'pnpm@11.9.0',
+    scripts: { lint: 'x', typecheck: 'x', test: 'x', build: 'x' },
+  });
+  const result = runBash(
+    prePushHook,
+    [],
+    {
+      PATH: toBashPath(binDir),
+      BASH_ENV: toBashPath(bashEnv),
+      ECC_PREPUSH_AUDIT: '0',
+      ECC_SKIP_GIT_HOOKS: '0',
+      ECC_SKIP_PREPUSH: '0',
+      MSYS_NO_PATHCONV: '1',
+    },
+    projectDir,
+    Buffer.from('refs/heads/main 1111111111111111111111111111111111111111 refs/heads/main 0000000000000000000000000000000000000000\n'),
+    false,
+  );
+  const calls = fs.existsSync(callsPath)
+    ? fs.readFileSync(callsPath, 'utf8').trim().split(/\r?\n/)
+    : [];
+  cleanup(tempDir);
+  return { result, calls };
+}
+
+if (
+  test('pre-push uses Corepack pinned pnpm and runs every required verification script', () => {
+    const { result, calls } = runHermeticPrePush();
+    assert.strictEqual(result.status, 0, JSON.stringify(result, null, 2));
+    assert.deepStrictEqual(calls, [
+      'pnpm run lint',
+      'pnpm run typecheck',
+      'pnpm run test',
+      'pnpm run build',
+    ], JSON.stringify(result, null, 2));
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('pre-push falls back to direct pnpm when Corepack is absent', () => {
+    const { result, calls } = runHermeticPrePush({
+      includeCorepack: false,
+      includePnpm: true,
+    });
+    assert.strictEqual(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.deepStrictEqual(calls, [
+      'pnpm run lint',
+      'pnpm run typecheck',
+      'pnpm run test',
+      'pnpm run build',
+    ]);
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('pre-push fails closed when pnpm and Corepack cannot resolve', () => {
+    const { result } = runHermeticPrePush({ includeCorepack: false });
+    assert.notStrictEqual(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.match(result.stderr, /pnpm.*(?:resolve|found)/i);
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('pre-push stops immediately when a required verification script fails', () => {
+    const { result, calls } = runHermeticPrePush({ failScript: 'typecheck' });
+    assert.notStrictEqual(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.deepStrictEqual(calls, ['pnpm run lint', 'pnpm run typecheck']);
+    assert.match(result.stderr, /typecheck failed/);
+  })
+)
+  passed++;
+else failed++;
 
 if (
   test('check-plugin-cache fails when the installed cache is missing manifest-referenced files', () => {


### PR DESCRIPTION
## Summary
- resolve pnpm through Corepack first so consuming repositories use their pinned packageManager version
- preserve direct pnpm as a fallback and fail closed when neither runtime exists
- add hermetic cross-platform pre-push tests for required scripts, fallback, missing runtime, and failure short-circuiting

## Test plan
- node tests/scripts/codex-hooks.test.js (24 passed, 0 failed)
- bash -n scripts/codex-git-hooks/pre-push
- git diff --check
- npm audit --audit-level=high --omit=dev (0 vulnerabilities)
- normal local push probe: lint/typecheck/test/build executed in order and push succeeded
- controlled failing local push probe: typecheck exited nonzero, test/build did not run, push was rejected

## Context
Git Bash may have only pnpm.cmd on PATH, which PowerShell resolves through PATHEXT but Bash does not. Corepack is present and honors the consuming repository's packageManager pin.