### PR TITLE
docs: note container isolation limits, add Jailbox reference

### DIFF
--- a/the-security-guide.md
+++ b/the-security-guide.md
@@ -163,6 +163,10 @@ docker run -it --rm \
 
 No network. No access outside `/workspace`. Much better failure mode.
 
+Three limits worth naming. A container shares the host kernel, so it's a weaker boundary than hardware virtualization. The agent can sit inside the container, as it does above, while the editor you open the repo with does not: the 2025 Amazon Q Developer incident put a malicious payload into a VS Code extension update, landing on the developer's machine outside anything a container was wrapping. And `internal: true` is the right default, but the agent needs its model API, package registries, and git remotes, so you open a route out on day one.
+
+The path of least resistance is to open all of it. A narrower version is a VM that holds the editor and its extensions alongside the agent, reaches the internet, and has no route to the host, the LAN, or any private address. See [Jailbox](https://karamatli.com/posts/network-isolated-kvm-sandbox-ai-agents/).
+
 ### Restrict tools and paths
 
 This is the boring part people skip. It is also one of the highest leverage controls, literally maxxed out ROI on this because its so easy to do.
@@ -442,6 +446,7 @@ Scan your setup: [github.com/affaan-m/agentshield](https://github.com/affaan-m/a
 - Hunt.io, "CVE-2026-25253 OpenClaw AI Agent Exposure" (February 3, 2026): [hunt.io](https://hunt.io/blog/cve-2026-25253-openclaw-ai-agent-exposure)
 - OpenAI, "Designing AI agents to resist prompt injection" (March 11, 2026): [openai.com](https://openai.com/index/designing-agents-to-resist-prompt-injection/)
 - OpenAI Codex docs, "Agent network access": [platform.openai.com](https://platform.openai.com/docs/codex/agent-network)
+- Jailbox (hardened KVM sandbox VMs for agents and untrusted code: internet egress allowed, host/LAN/private addresses blocked): [karamatli.com](https://karamatli.com/posts/network-isolated-kvm-sandbox-ai-agents/)
 
 ---
 

--- a/the-security-guide.md
+++ b/the-security-guide.md
@@ -163,9 +163,9 @@ docker run -it --rm \
 
 No network. No access outside `/workspace`. Much better failure mode.
 
-Three limits worth naming. A container shares the host kernel, so it's a weaker boundary than hardware virtualization. The agent can sit inside the container, as it does above, while the editor you open the repo with does not: the 2025 Amazon Q Developer incident put a malicious payload into a VS Code extension update, landing on the developer's machine outside anything a container was wrapping. And `internal: true` is the right default, but the agent needs its model API, package registries, and git remotes, so you open a route out on day one.
+Three limits are worth naming. A container shares the host kernel, so it is a weaker boundary than hardware virtualization. The agent can sit inside the container, as it does above, while the editor you open the repo with does not. In 2025, malicious code reached version 1.84.0 of the Amazon Q Developer VS Code extension, although AWS reports that a syntax error prevented it from executing. A container around the agent would not have isolated an editor extension running on the host. And `internal: true` is the right default, but the agent needs its model API, package registries, and git remotes, so you open a route out on day one.
 
-The path of least resistance is to open all of it. A narrower version is a VM that holds the editor and its extensions alongside the agent, reaches the internet, and has no route to the host, the LAN, or any private address. See [Jailbox](https://karamatli.com/posts/network-isolated-kvm-sandbox-ai-agents/).
+The path of least resistance is to open all of it. A narrower version is a VM that holds the editor and its extensions alongside the agent, reaches the internet, and has no route to the host, the LAN, or any private address. [Jailbox](https://karamatli.com/posts/network-isolated-kvm-sandbox-ai-agents/) is one concrete KVM-based reference architecture for that pattern.
 
 ### Restrict tools and paths
 
@@ -446,6 +446,7 @@ Scan your setup: [github.com/affaan-m/agentshield](https://github.com/affaan-m/a
 - Hunt.io, "CVE-2026-25253 OpenClaw AI Agent Exposure" (February 3, 2026): [hunt.io](https://hunt.io/blog/cve-2026-25253-openclaw-ai-agent-exposure)
 - OpenAI, "Designing AI agents to resist prompt injection" (March 11, 2026): [openai.com](https://openai.com/index/designing-agents-to-resist-prompt-injection/)
 - OpenAI Codex docs, "Agent network access": [platform.openai.com](https://platform.openai.com/docs/codex/agent-network)
+- AWS, "Security Update for Amazon Q Developer Extension for Visual Studio Code (Version #1.84)": [aws.amazon.com](https://aws.amazon.com/security/security-bulletins/AWS-2025-015/)
 - Jailbox (hardened KVM sandbox VMs for agents and untrusted code: internet egress allowed, host/LAN/private addresses blocked): [karamatli.com](https://karamatli.com/posts/network-isolated-kvm-sandbox-ai-agents/)
 
 ---

--- a/the-security-guide.md
+++ b/the-security-guide.md
@@ -163,9 +163,11 @@ docker run -it --rm \
 
 No network. No access outside `/workspace`. Much better failure mode.
 
-Three limits are worth naming. A container shares the host kernel, so it is a weaker boundary than hardware virtualization. The agent can sit inside the container, as it does above, while the editor you open the repo with does not. In 2025, malicious code reached version 1.84.0 of the Amazon Q Developer VS Code extension, although AWS reports that a syntax error prevented it from executing. A container around the agent would not have isolated an editor extension running on the host. And `internal: true` is the right default, but the agent needs its model API, package registries, and git remotes, so you open a route out on day one.
+Three limits are worth naming. A container shares the host kernel, so it is a weaker boundary than hardware virtualization. It also protects only what actually runs inside it: with VS Code remote development, workspace extensions may run in the remote environment while UI extensions remain local. In 2025, malicious code reached version 1.84.0 of the Amazon Q Developer VS Code extension, although AWS reports that a syntax error prevented it from executing. A container around the agent would not have isolated an editor extension running on the host.
 
-The path of least resistance is to open all of it. A narrower version is a VM that holds the editor and its extensions alongside the agent, reaches the internet, and has no route to the host, the LAN, or any private address. [Jailbox](https://karamatli.com/posts/network-isolated-kvm-sandbox-ai-agents/) is one concrete KVM-based reference architecture for that pattern.
+Keep `internal: true` when the work can stay offline. When model APIs, package registries, or git remotes require network access, add only a deliberately constrained egress path. Allowlist the required destinations or proxy them, block host, LAN, private, link-local, and metadata ranges, and verify the boundary from inside the sandbox. Attaching a general-purpose network restores broader reachability and should be an explicit exception.
+
+A stronger version is a VM that holds the editor and its extensions alongside the agent, reaches the internet through a verified policy, and has no route to the host, the LAN, or other private addresses. [Jailbox](https://karamatli.com/posts/network-isolated-kvm-sandbox-ai-agents/) is one concrete KVM-based reference architecture for that pattern; its default rules block private destinations and support narrowly scoped exceptions, so the effective configuration still needs verification.
 
 ### Restrict tools and paths
 
@@ -436,7 +438,6 @@ Scan your setup: [github.com/affaan-m/agentshield](https://github.com/affaan-m/a
 - GitHub Docs, "Responsible use of Copilot coding agent on GitHub.com": [docs.github.com](https://docs.github.com/en/copilot/responsible-use-of-github-copilot-features/responsible-use-of-copilot-coding-agent-on-githubcom)
 - GitHub Docs, "Customize the agent firewall": [docs.github.com](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-firewall)
 - Simon Willison prompt injection series / lethal trifecta framing: [simonwillison.net](https://simonwillison.net/series/prompt-injection/)
-- AWS Security Bulletin, AWS-2025-015: [aws.amazon.com](https://aws.amazon.com/security/security-bulletins/rss/aws-2025-015/)
 - AWS Security Bulletin, AWS-2025-016: [aws.amazon.com](https://aws.amazon.com/security/security-bulletins/aws-2025-016/)
 - Unit 42, "Fooling AI Agents: Web-Based Indirect Prompt Injection Observed in the Wild" (March 3, 2026): [unit42.paloaltonetworks.com](https://unit42.paloaltonetworks.com/ai-agent-prompt-injection/)
 - Microsoft Security, "AI Recommendation Poisoning" (February 10, 2026): [microsoft.com](https://www.microsoft.com/en-us/security/blog/2026/02/10/ai-recommendation-poisoning/)


### PR DESCRIPTION
## What Changed
Two additions to `the-security-guide.md`, both in existing sections. No new dependency and no
change to what the guide already recommends.

**1. "Run untrusted work in isolation"** (after the `--network=none` block): two short paragraphs
naming three limits of the container setup already in that section, and what a narrower boundary
looks like.

**2. References**: one line for Jailbox.

## Why This Change
The section's two examples bracket the range well: a Compose service on an `internal: true`
network, and `docker run --network=none`. Both are good advice and the paragraph does not touch
them. What the addition covers is the part that decides where the boundary actually lands:

- A container shares the host kernel, so it is a weaker boundary than hardware virtualization.
- The agent can be inside the container, as it is in the Compose example, but the editor is not.
  The Amazon Q Developer incident the guide already cites arrived in a VS Code extension update,
  landing on the developer's machine outside anything a container was wrapping.
- `internal: true` is the right default, but the agent needs its model API, package registries, and git remotes,
  so a route out gets opened on day one, and the path of least resistance is to open all of it.
  The guide already notes this ("unless you deliberately give it a route out"); the paragraph
  picks up from there.

The linked post covers one answer: a KVM VM that holds the editor and its extensions alongside
the agent, allows internet egress, and blocks the host, LAN, and RFC1918/link-local/CGNAT with
nftables, plus a script that creates these hardened sandbox VMs and checks the boundary holds.

The linked post is mine. Happy to drop the prose and keep the References line alone if the section
addition is not wanted.

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [X] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [X] Edge cases considered and tested

## Type of Change
- [ ] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [X] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [X] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [X] JSON files validate cleanly
- [X] Shell scripts pass shellcheck (if applicable)
- [X] Pre-commit hooks pass locally (if configured)
- [X] No sensitive data exposed in logs or output
- [X] Follows conventional commits format

## If you changed dependencies or `package.json` (`bin` / `files` / deps)
Not applicable (documentation only).
