### PR TITLE
fix(suggest-compact): don't quote a percentage against an assumed window

### DIFF
--- a/scripts/hooks/suggest-compact.js
+++ b/scripts/hooks/suggest-compact.js
@@ -38,7 +38,8 @@ const {
   resolveContextThreshold,
   resolveContextInterval,
   computeContextBucket,
-  formatWindowLabel
+  formatWindowLabel,
+  isContextWindowInferred
 } = require('../lib/transcript-context');
 
 const COUNTER_FILE_PREFIX = 'claude-tool-count-';
@@ -185,8 +186,13 @@ function buildContextSuggestion(transcriptPath, bucketFile, env) {
     writeFile(bucketFile, String(bucket));
 
     const approxTokens = `${Math.round(usage.tokens / 1000)}k`;
-    const percent = Math.round((usage.tokens / windowTokens) * 100);
-    return `[StrategicCompact] Context ~${approxTokens} tokens (${percent}% of ${formatWindowLabel(windowTokens)} window) - consider /compact at the next logical boundary`;
+    // Only quote a percentage when the window size was actually detected.
+    // Against an assumed 200k default the denominator is a guess, and a
+    // "97% of 200k window" line on a 1M session triggers needless compaction.
+    const scale = isContextWindowInferred(usage.tokens, usage.model)
+      ? ''
+      : ` (${Math.round((usage.tokens / windowTokens) * 100)}% of ${formatWindowLabel(windowTokens)} window)`;
+    return `[StrategicCompact] Context ~${approxTokens} tokens${scale} - consider /compact at the next logical boundary`;
   } catch (err) {
     log(`[StrategicCompact] Context signal skipped: ${err.message}`);
     return null;

--- a/scripts/hooks/suggest-compact.js
+++ b/scripts/hooks/suggest-compact.js
@@ -34,12 +34,11 @@ const {
 } = require('../lib/utils');
 const {
   readLatestContextTokens,
-  resolveContextWindowTokens,
+  resolveContextWindow,
   resolveContextThreshold,
   resolveContextInterval,
   computeContextBucket,
-  formatWindowLabel,
-  isContextWindowInferred
+  formatWindowLabel
 } = require('../lib/transcript-context');
 
 const COUNTER_FILE_PREFIX = 'claude-tool-count-';
@@ -172,7 +171,7 @@ function buildContextSuggestion(transcriptPath, bucketFile, env) {
     const usage = readLatestContextTokens(transcriptPath);
     if (!usage) return null;
 
-    const windowTokens = resolveContextWindowTokens(usage.tokens, usage.model);
+    const { windowTokens, inferred } = resolveContextWindow(usage.tokens, usage.model);
     const threshold = resolveContextThreshold(env, windowTokens);
     if (threshold <= 0) return null; // COMPACT_CONTEXT_THRESHOLD=0 disables
 
@@ -189,7 +188,7 @@ function buildContextSuggestion(transcriptPath, bucketFile, env) {
     // Only quote a percentage when the window size was actually detected.
     // Against an assumed 200k default the denominator is a guess, and a
     // "97% of 200k window" line on a 1M session triggers needless compaction.
-    const scale = isContextWindowInferred(usage.tokens, usage.model)
+    const scale = inferred
       ? ''
       : ` (${Math.round((usage.tokens / windowTokens) * 100)}% of ${formatWindowLabel(windowTokens)} window)`;
     return `[StrategicCompact] Context ~${approxTokens} tokens${scale} - consider /compact at the next logical boundary`;

--- a/scripts/lib/transcript-context.js
+++ b/scripts/lib/transcript-context.js
@@ -157,24 +157,29 @@ function readLatestContextTokens(transcriptPath, options = {}) {
 }
 
 /**
- * Detect the context window size for a turn.
- * 1M when the model id carries the `[1m]` marker, matches a known large-window
- * model family, or when the observed token count already exceeds the standard
- * 200k window (covers logs that drop the suffix); otherwise the standard 200k
- * window.
+ * Detect the context window size for a turn, and report whether that size was
+ * positively detected or merely assumed.
+ *
+ * `inferred: false` means the size came from evidence — an explicit env
+ * override, the `[1m]` marker, a known large-window family, or an observed
+ * token count that already exceeds the standard window. `inferred: true` means
+ * every check fell through and the standard 200k default was assumed; the
+ * window may actually be larger and callers must not present it as fact.
+ *
+ * @returns {{ windowTokens: number, inferred: boolean }}
  */
-function resolveContextWindowTokens(tokens, model) {
+function resolveContextWindow(tokens, model) {
   // Explicit window override wins: 400k models (e.g. Opus 4.x) match neither the
   // 200k default nor the 1M marker and would otherwise report ~double usage (#2290).
   // Honor ECC's own knob and Claude Code's native CLAUDE_CODE_AUTO_COMPACT_WINDOW.
   const env = (typeof process !== 'undefined' && process.env) || {};
   const envWindow = Number.parseInt(env.ECC_CONTEXT_WINDOW_TOKENS || env.CLAUDE_CODE_AUTO_COMPACT_WINDOW || '', 10);
   if (Number.isInteger(envWindow) && envWindow > 0) {
-    return envWindow;
+    return { windowTokens: envWindow, inferred: false };
   }
 
   if (typeof model === 'string' && model.includes(LARGE_WINDOW_MODEL_MARKER)) {
-    return LARGE_CONTEXT_WINDOW_TOKENS;
+    return { windowTokens: LARGE_CONTEXT_WINDOW_TOKENS, inferred: false };
   }
 
   // Large-window model families without a [1m] marker fall through the checks
@@ -182,15 +187,37 @@ function resolveContextWindowTokens(tokens, model) {
   if (typeof model === 'string') {
     const known = KNOWN_MODEL_WINDOW_TOKENS.find(([familyId]) => isKnownModelFamilyMatch(model, familyId));
     if (known) {
-      return known[1];
+      return { windowTokens: known[1], inferred: false };
     }
   }
 
   if (Number.isFinite(tokens) && tokens > STANDARD_CONTEXT_WINDOW_TOKENS) {
-    return LARGE_CONTEXT_WINDOW_TOKENS;
+    return { windowTokens: LARGE_CONTEXT_WINDOW_TOKENS, inferred: false };
   }
 
-  return STANDARD_CONTEXT_WINDOW_TOKENS;
+  return { windowTokens: STANDARD_CONTEXT_WINDOW_TOKENS, inferred: true };
+}
+
+/**
+ * Detect the context window size for a turn.
+ * 1M when the model id carries the `[1m]` marker, matches a known large-window
+ * model family, or when the observed token count already exceeds the standard
+ * 200k window (covers logs that drop the suffix); otherwise the standard 200k
+ * window.
+ */
+function resolveContextWindowTokens(tokens, model) {
+  return resolveContextWindow(tokens, model).windowTokens;
+}
+
+/**
+ * True when the resolved window is the assumed 200k default rather than a
+ * detected size. Opt-in large-window models that ship no `[1m]` marker in the
+ * transcript (e.g. a 1M-context Opus tier, where the base tier is 200k and the
+ * two are indistinguishable by model id) land here, so a percentage computed
+ * against 200k can be wildly wrong while usage sits below that mark.
+ */
+function isContextWindowInferred(tokens, model) {
+  return resolveContextWindow(tokens, model).inferred;
 }
 
 /**
@@ -253,7 +280,9 @@ module.exports = {
   DEFAULT_CONTEXT_INTERVAL_TOKENS,
   DEFAULT_TRANSCRIPT_TAIL_BYTES,
   readLatestContextTokens,
+  resolveContextWindow,
   resolveContextWindowTokens,
+  isContextWindowInferred,
   resolveContextThreshold,
   resolveContextInterval,
   computeContextBucket,

--- a/tests/hooks/suggest-compact.test.js
+++ b/tests/hooks/suggest-compact.test.js
@@ -694,7 +694,7 @@ function runTests() {
     };
   }
 
-  if (test('suggests compact when context exceeds the 200k-window threshold', () => {
+  if (test('omits the percentage when the context window is assumed', () => {
     const ctx = createContextContext();
     const transcript = writeTranscriptFixture(170000);
     try {
@@ -704,7 +704,7 @@ function runTests() {
       const parsed = JSON.parse(result.stdout);
       const context = parsed.hookSpecificOutput.additionalContext;
       assert.ok(context.includes('Context ~170k tokens'), `Expected token estimate. Got: ${context}`);
-      assert.ok(context.includes('85% of 200k window'), `Expected window percentage. Got: ${context}`);
+      assert.ok(!context.includes('% of'), `Expected no percentage for an assumed window. Got: ${context}`);
     } finally {
       try { fs.unlinkSync(transcript); } catch (_err) { /* ignore */ }
       ctx.cleanup();

--- a/tests/lib/transcript-context.test.js
+++ b/tests/lib/transcript-context.test.js
@@ -23,7 +23,8 @@ const {
   resolveContextThreshold,
   resolveContextInterval,
   computeContextBucket,
-  formatWindowLabel
+  formatWindowLabel,
+  isContextWindowInferred
 } = require('../../scripts/lib/transcript-context');
 
 console.log('=== Testing transcript-context.js ===\n');
@@ -212,6 +213,37 @@ test('keeps the 200k default for unknown model ids at low token counts (no false
 
 test('treats an empty model id as standard window', () => {
   assert.strictEqual(resolveContextWindowTokens(100000, ''), STANDARD_CONTEXT_WINDOW_TOKENS);
+});
+
+// ── isContextWindowInferred ──
+console.log('\nisContextWindowInferred:');
+
+delete process.env.ECC_CONTEXT_WINDOW_TOKENS;
+delete process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
+
+test('flags the assumed 200k default as inferred', () => {
+  assert.strictEqual(isContextWindowInferred(187000, 'claude-opus-9'), true);
+});
+
+test('an env override is a detected window, not inferred', () => {
+  process.env.ECC_CONTEXT_WINDOW_TOKENS = '1000000';
+  try {
+    assert.strictEqual(isContextWindowInferred(187000, 'claude-opus-9'), false);
+  } finally {
+    delete process.env.ECC_CONTEXT_WINDOW_TOKENS;
+  }
+});
+
+test('a [1m] marker is a detected window, not inferred', () => {
+  assert.strictEqual(isContextWindowInferred(187000, 'claude-opus-4-5[1m]'), false);
+});
+
+test('a known large-window family is a detected window, not inferred', () => {
+  assert.strictEqual(isContextWindowInferred(187000, 'claude-fable-5'), false);
+});
+
+test('tokens above the standard window make the size detected, not inferred', () => {
+  assert.strictEqual(isContextWindowInferred(220000, 'claude-opus-9'), false);
 });
 
 // ── resolveContextThreshold ──


### PR DESCRIPTION
## Problem

The context signal always renders `N% of <window> window`, including when the window size is the **assumed 200k default** rather than a detected value.

On a 1M-context session whose transcript carries no `[1m]` marker, this produces:

```
[StrategicCompact] Context ~194k tokens (97% of 200k window) - consider /compact at the next logical boundary
```

while actual usage is ~19%. Observed in real use today: the model faithfully relayed "context is 97% full" to the user across several sessions, the user compacted on the false alarm, lost context, and the resulting quality drop was initially diagnosed as a model regression. The status line — which reads the harness's own `context_window.used_percentage` — showed ~20% at the same moment.

## Why it fires exactly where it can't know

The context threshold defaults to 80% of the window (160k on 200k), so the signal fires precisely in the **160k–200k band**, which is the one range where the size cannot be determined:

- below 160k — nothing fires
- 160k–200k — window unknown, but a confident percentage is printed
- above 200k — the observed-tokens fallback correctly infers 1M, and the message becomes accurate again

So the warning appears and then *disappears* as the context grows past 200k.

## Why the model id can't fix it

A model tier can ship both a 200k and a 1M variant under one id, with the `[1m]` suffix present in settings but **absent from the transcript's `message.model` field**. Verified locally: 143/143 assistant records in a `[1m]` session recorded the bare id. Adding such a family to `KNOWN_MODEL_WINDOW_TOKENS` would therefore be wrong in the opposite direction — it would claim 1M for the 200k variant too. The transcript carries no window field to consult.

## Change

Stop asserting what isn't known.

- `resolveContextWindow(tokens, model)` (new, exported) returns `{ windowTokens, inferred }`. `inferred: false` means the size came from evidence — env override, `[1m]` marker, known family, or observed tokens > 200k. `inferred: true` means every check fell through to the 200k default.
- `isContextWindowInferred(tokens, model)` (new, exported) for callers that only need the flag.
- `resolveContextWindowTokens()` keeps its exact signature and semantics — now a one-line delegate.
- The hook omits the percentage and window label when the size was assumed:

```
[StrategicCompact] Context ~194k tokens - consider /compact at the next logical boundary
```

Token count, threshold, bucketing, and firing behaviour are unchanged. Users who know their window can still set `ECC_CONTEXT_WINDOW_TOKENS` and get the percentage back.

## Tests

5 new cases in `tests/lib/transcript-context.test.js` covering inferred vs. detected for each detection path. `node tests/lib/transcript-context.test.js` → 41 passed, 0 failed.

Full suite, measured on both trees by checking out each commit:

| | tests | passed | failed |
|---|---|---|---|
| unmodified `main` (b6f461a3) | 3354 | 3347 | **7** |
| this branch | 3359 | 3352 | **7** |

The +5 are the new cases. **The failure count is unchanged** — all 7 are pre-existing, 3 of them in `tests/hooks/suggest-compact.test.js`, and they are untouched here.

ESLint clean on all three changed files.

