### PR TITLE
feat(ecc2): add Feature Fleet planning foundation

### DIFF
--- a/ecc2/README.md
+++ b/ecc2/README.md
@@ -80,13 +80,13 @@ typed blockers kept separate from lifecycle state, durable events, and
 
 ```bash
 # Preview the DAG without creating a fleet record
-cargo run -- fleet plan examples/feature-fleet.toml
+cargo run -- fleet --state-db /tmp/ecc-feature-fleet.db plan examples/feature-fleet.toml
 
 # Create an idempotent fleet record and pin main's current commit OID
-cargo run -- fleet create examples/feature-fleet.toml
+cargo run -- fleet --state-db /tmp/ecc-feature-fleet.db create examples/feature-fleet.toml
 
 # Inspect the durable record and event history
-cargo run -- fleet status feature-fleet-runtime
+cargo run -- fleet --state-db /tmp/ecc-feature-fleet.db status feature-fleet-runtime
 ```
 
 The surface is explicitly experimental. This slice does **not** launch agents,

--- a/ecc2/README.md
+++ b/ecc2/README.md
@@ -70,6 +70,38 @@ cargo run -- resume <session-id>
 cargo run -- daemon
 ```
 
+## Experimental Feature Fleet
+
+Feature Fleet is the ECC 2.2 multi-feature workflow. Its first review slice
+provides a strict TOML/JSON manifest, normalized SHA-256 identity, deterministic
+DAG planning, declared path/contract collision detection, a pinned base commit,
+typed blockers kept separate from lifecycle state, durable events, and
+`plan` / `create` / `status` commands:
+
+```bash
+# Preview the DAG without creating a fleet record
+cargo run -- fleet plan examples/feature-fleet.toml
+
+# Create an idempotent fleet record and pin main's current commit OID
+cargo run -- fleet create examples/feature-fleet.toml
+
+# Inspect the durable record and event history
+cargo run -- fleet status feature-fleet-runtime
+```
+
+The surface is explicitly experimental. This slice does **not** launch agents,
+create fleet worktrees, run verification commands, integrate branches, or clean
+up fleet resources. Those operations require the admission, ownership, recovery,
+evidence, and safe-cleanup guarantees planned for later review slices. Existing
+session, worktree, and tmux workflows remain available as legacy surfaces.
+Local Feature Fleet capabilities stay MIT-licensed; hosted operation and
+advanced orchestration are separate private/paid surfaces.
+
+Verification checks are data, not shell strings: each check names one executable,
+an argument array, repository-relative working directory, timeout, environment
+allowlist, output limit, and whether repository-trust approval is required. See
+[`examples/feature-fleet.toml`](examples/feature-fleet.toml).
+
 ## Validate
 
 ```bash

--- a/ecc2/examples/feature-fleet.toml
+++ b/ecc2/examples/feature-fleet.toml
@@ -1,0 +1,67 @@
+schema = "ecc.feature-fleet.v1"
+id = "feature-fleet-runtime"
+title = "Feature Fleet runtime foundations"
+base_branch = "main"
+default_agent = "codex"
+
+[[features]]
+id = "fleet-ownership"
+title = "Fleet-owned sessions"
+task = """
+Add explicit fleet ownership to sessions and exclude fleet-managed sessions from
+legacy merge, prune, merge-queue, and daemon lifecycle automation.
+"""
+owns = ["ecc2/src/session/**"]
+contracts = ["session:fleet-controller-v1"]
+
+[[features.checks]]
+id = "session-tests"
+program = "cargo"
+args = ["test", "--no-default-features", "session"]
+working_directory = "ecc2"
+timeout_seconds = 1200
+environment_allowlist = ["CARGO_HOME", "RUSTUP_HOME"]
+max_output_bytes = 10485760
+requires_repository_trust = true
+
+[[features]]
+id = "pinned-worktrees"
+title = "Pinned-OID worktrees"
+task = """
+Create fleet worktrees from an explicit commit OID under a repository-scoped
+Git mutation lease, with identity-checked cleanup.
+"""
+owns = ["ecc2/src/worktree/**"]
+contracts = ["git:pinned-worktree-v1", "git:mutation-lease-v1"]
+
+[[features.checks]]
+id = "worktree-tests"
+program = "cargo"
+args = ["test", "--no-default-features", "worktree"]
+working_directory = "ecc2"
+timeout_seconds = 1200
+environment_allowlist = ["CARGO_HOME", "RUSTUP_HOME"]
+max_output_bytes = 10485760
+requires_repository_trust = true
+
+[[features]]
+id = "attempt-admission"
+title = "Revisioned attempt admission"
+task = """
+Reserve attempts atomically by fleet revision and idempotency key, compose
+verified dependency heads into the dispatch base, and recover interrupted
+provisioning without duplicate launches.
+"""
+depends_on = ["fleet-ownership", "pinned-worktrees"]
+owns = ["ecc2/src/feature_fleet/**"]
+contracts = ["fleet:attempt-admission-v1"]
+
+[[features.checks]]
+id = "fleet-tests"
+program = "cargo"
+args = ["test", "--no-default-features", "feature_fleet"]
+working_directory = "ecc2"
+timeout_seconds = 1200
+environment_allowlist = ["CARGO_HOME", "RUSTUP_HOME"]
+max_output_bytes = 10485760
+requires_repository_trust = true

--- a/ecc2/src/feature_fleet/cli.rs
+++ b/ecc2/src/feature_fleet/cli.rs
@@ -1,10 +1,19 @@
 use anyhow::Result;
-use clap::Subcommand;
+use clap::{Args, Subcommand};
 use std::path::PathBuf;
 
 use crate::session::store::StateStore;
 
 use super::report::{create_human, plan_human, status_human};
+
+#[derive(Args, Debug)]
+pub struct FleetArgs {
+    /// Fleet state database; overrides the normal ECC database for this command
+    #[arg(long, global = true)]
+    pub state_db: Option<PathBuf>,
+    #[command(subcommand)]
+    pub command: FleetCommand,
+}
 
 #[derive(Subcommand, Debug)]
 pub enum FleetCommand {
@@ -66,13 +75,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::FleetCommand;
+    use super::FleetArgs;
     use clap::Parser;
 
     #[derive(Parser)]
     struct TestCli {
-        #[command(subcommand)]
-        command: FleetCommand,
+        #[command(flatten)]
+        fleet: FleetArgs,
     }
 
     #[test]
@@ -80,19 +89,29 @@ mod tests {
         let plan = TestCli::try_parse_from(["fleet", "plan", "fleet.toml", "--json"])
             .expect("fleet plan parses");
         assert!(matches!(
-            plan.command,
-            FleetCommand::Plan {
+            plan.fleet.command,
+            super::FleetCommand::Plan {
                 manifest,
                 json: true
             } if manifest.as_os_str() == "fleet.toml"
         ));
 
-        let status = TestCli::try_parse_from(["fleet", "status", "onboarding-v2"])
-            .expect("fleet status parses");
+        let status = TestCli::try_parse_from([
+            "fleet",
+            "--state-db",
+            "/tmp/fleet.db",
+            "status",
+            "onboarding-v2",
+        ])
+        .expect("fleet status parses");
         assert!(matches!(
-            status.command,
-            FleetCommand::Status { fleet_id, json: false }
+            status.fleet.command,
+            super::FleetCommand::Status { fleet_id, json: false }
                 if fleet_id == "onboarding-v2"
         ));
+        assert_eq!(
+            status.fleet.state_db.as_deref(),
+            Some(std::path::Path::new("/tmp/fleet.db"))
+        );
     }
 }

--- a/ecc2/src/feature_fleet/cli.rs
+++ b/ecc2/src/feature_fleet/cli.rs
@@ -1,0 +1,98 @@
+use anyhow::Result;
+use clap::Subcommand;
+use std::path::PathBuf;
+
+use crate::session::store::StateStore;
+
+use super::report::{create_human, plan_human, status_human};
+
+#[derive(Subcommand, Debug)]
+pub enum FleetCommand {
+    /// Validate a manifest and preview its DAG and declared collisions
+    Plan {
+        /// Feature Fleet TOML or JSON manifest
+        manifest: PathBuf,
+        /// Emit machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Persist an approved fleet and pin its base commit
+    Create {
+        /// Feature Fleet TOML or JSON manifest
+        manifest: PathBuf,
+        /// Emit machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show durable fleet and feature state
+    Status {
+        /// Fleet identifier
+        fleet_id: String,
+        /// Emit machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+pub fn execute(command: FleetCommand, db: &StateStore) -> Result<()> {
+    match command {
+        FleetCommand::Plan { manifest, json } => {
+            let plan = super::plan(&manifest)?;
+            print_output(&plan, plan_human(&plan), json)?;
+        }
+        FleetCommand::Create { manifest, json } => {
+            let record = super::create(db, &manifest)?;
+            print_output(&record, create_human(&record), json)?;
+        }
+        FleetCommand::Status { fleet_id, json } => {
+            let status = super::status(db, &fleet_id)?;
+            print_output(&status, status_human(&status), json)?;
+        }
+    }
+    Ok(())
+}
+
+fn print_output<T>(value: &T, human: String, json: bool) -> Result<()>
+where
+    T: serde::Serialize,
+{
+    if json {
+        println!("{}", serde_json::to_string_pretty(value)?);
+    } else {
+        println!("{human}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FleetCommand;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(subcommand)]
+        command: FleetCommand,
+    }
+
+    #[test]
+    fn parses_experimental_fleet_commands() {
+        let plan = TestCli::try_parse_from(["fleet", "plan", "fleet.toml", "--json"])
+            .expect("fleet plan parses");
+        assert!(matches!(
+            plan.command,
+            FleetCommand::Plan {
+                manifest,
+                json: true
+            } if manifest.as_os_str() == "fleet.toml"
+        ));
+
+        let status = TestCli::try_parse_from(["fleet", "status", "onboarding-v2"])
+            .expect("fleet status parses");
+        assert!(matches!(
+            status.command,
+            FleetCommand::Status { fleet_id, json: false }
+                if fleet_id == "onboarding-v2"
+        ));
+    }
+}

--- a/ecc2/src/feature_fleet/collision.rs
+++ b/ecc2/src/feature_fleet/collision.rs
@@ -1,0 +1,168 @@
+use anyhow::Result;
+use std::collections::BTreeSet;
+
+use super::model::{DeclaredCollision, FeatureManifest, NormalizedManifest};
+use super::scheduler::{build_schedule, transitively_depends_on};
+
+pub fn declared_collisions(manifest: &NormalizedManifest) -> Result<Vec<DeclaredCollision>> {
+    build_schedule(manifest)?;
+    let mut collisions = Vec::new();
+
+    for (left_index, left) in manifest.features.iter().enumerate() {
+        for right in manifest.features.iter().skip(left_index + 1) {
+            if are_serialized(manifest, left, right) {
+                continue;
+            }
+            collisions.extend(path_collisions(left, right));
+            collisions.extend(contract_collisions(left, right));
+        }
+    }
+    Ok(collisions)
+}
+
+fn are_serialized(
+    manifest: &NormalizedManifest,
+    left: &FeatureManifest,
+    right: &FeatureManifest,
+) -> bool {
+    transitively_depends_on(manifest, &left.id, &right.id)
+        || transitively_depends_on(manifest, &right.id, &left.id)
+}
+
+fn path_collisions(left: &FeatureManifest, right: &FeatureManifest) -> Vec<DeclaredCollision> {
+    let mut collisions = Vec::new();
+    for left_path in &left.owns {
+        for right_path in &right.owns {
+            if ownership_patterns_overlap(left_path, right_path) {
+                collisions.push(collision(
+                    "path_overlap",
+                    left,
+                    right,
+                    format!("{left_path} overlaps {right_path}"),
+                ));
+            }
+        }
+    }
+    collisions
+}
+
+fn contract_collisions(left: &FeatureManifest, right: &FeatureManifest) -> Vec<DeclaredCollision> {
+    let left_contracts = left.contracts.iter().collect::<BTreeSet<_>>();
+    let right_contracts = right.contracts.iter().collect::<BTreeSet<_>>();
+    left_contracts
+        .intersection(&right_contracts)
+        .map(|contract| {
+            collision(
+                "contract_overlap",
+                left,
+                right,
+                format!("both features declare contract {contract}"),
+            )
+        })
+        .collect()
+}
+
+fn collision(
+    kind: &str,
+    left: &FeatureManifest,
+    right: &FeatureManifest,
+    detail: String,
+) -> DeclaredCollision {
+    DeclaredCollision {
+        kind: kind.to_string(),
+        left_feature: left.id.clone(),
+        right_feature: right.id.clone(),
+        detail,
+        required_action: "serialize_or_revise_ownership".to_string(),
+    }
+}
+
+fn ownership_patterns_overlap(left: &str, right: &str) -> bool {
+    let left_prefix = ownership_prefix(left);
+    let right_prefix = ownership_prefix(right);
+    if left_prefix.has_wildcard && right_prefix.raw.starts_with(left_prefix.raw) {
+        return true;
+    }
+    if right_prefix.has_wildcard && left_prefix.raw.starts_with(right_prefix.raw) {
+        return true;
+    }
+
+    left_prefix.path == right_prefix.path
+        || left_prefix
+            .path
+            .strip_prefix(right_prefix.path)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+        || right_prefix
+            .path
+            .strip_prefix(left_prefix.path)
+            .is_some_and(|suffix| suffix.starts_with('/'))
+}
+
+struct OwnershipPrefix<'pattern> {
+    raw: &'pattern str,
+    path: &'pattern str,
+    has_wildcard: bool,
+}
+
+fn ownership_prefix(pattern: &str) -> OwnershipPrefix<'_> {
+    let wildcard = pattern.find(['*', '?', '[']).unwrap_or(pattern.len());
+    let raw = &pattern[..wildcard];
+    OwnershipPrefix {
+        raw,
+        path: raw.trim_end_matches('/'),
+        has_wildcard: wildcard < pattern.len(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::declared_collisions;
+    use crate::feature_fleet::manifest::parse_manifest_text;
+    use crate::feature_fleet::manifest::tests::valid_manifest;
+
+    #[test]
+    fn reports_concurrent_path_and_contract_overlap_but_not_serial_dependencies() {
+        let concurrent = valid_manifest()
+            .replace("depends_on = [\"auth-api\"]\n", "")
+            .replace(
+                "owns = [\"apps/web/onboarding/**\"]",
+                "owns = [\"services/auth/handlers/**\"]\ncontracts = [\"api:auth-v2\"]",
+            );
+        let parsed = parse_manifest_text(&concurrent, "toml").expect("manifest");
+        let collisions = declared_collisions(&parsed.manifest).expect("collisions");
+
+        assert!(collisions.iter().any(|item| item.kind == "path_overlap"));
+        assert!(collisions
+            .iter()
+            .any(|item| item.kind == "contract_overlap"));
+
+        let serialized = valid_manifest().replace(
+            "owns = [\"apps/web/onboarding/**\"]",
+            "owns = [\"services/auth/handlers/**\"]\ncontracts = [\"api:auth-v2\"]",
+        );
+        let parsed = parse_manifest_text(&serialized, "toml").expect("manifest");
+        assert!(declared_collisions(&parsed.manifest)
+            .expect("collisions")
+            .is_empty());
+    }
+
+    #[test]
+    fn conservatively_reports_overlapping_glob_prefixes() {
+        let concurrent = valid_manifest()
+            .replace("depends_on = [\"auth-api\"]\n", "")
+            .replace(
+                "owns = [\"services/auth/**\"]",
+                "owns = [\"services/auth/handler*\"]",
+            )
+            .replace(
+                "owns = [\"apps/web/onboarding/**\"]",
+                "owns = [\"services/auth/handlers/**\"]",
+            );
+        let parsed = parse_manifest_text(&concurrent, "toml").expect("manifest");
+
+        assert!(declared_collisions(&parsed.manifest)
+            .expect("collisions")
+            .iter()
+            .any(|item| item.kind == "path_overlap"));
+    }
+}

--- a/ecc2/src/feature_fleet/manifest.rs
+++ b/ecc2/src/feature_fleet/manifest.rs
@@ -1,0 +1,499 @@
+use anyhow::{Context, Result};
+use regex::Regex;
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::Path;
+
+pub use super::model::{FeatureManifest, NormalizedManifest, ParsedManifest, VerificationCheck};
+
+const SCHEMA_VERSION: &str = "ecc.feature-fleet.v1";
+const MAX_MANIFEST_BYTES: usize = 1024 * 1024;
+const MAX_FEATURES: usize = 128;
+const MAX_FEATURE_RELATIONS: usize = 128;
+const MAX_FEATURE_DECLARATIONS: usize = 64;
+const MAX_CHECK_TIMEOUT_SECONDS: u64 = 24 * 60 * 60;
+const MAX_CHECK_OUTPUT_BYTES: u64 = 100 * 1024 * 1024;
+
+pub fn parse_manifest_path(path: &Path) -> Result<ParsedManifest> {
+    let file_size = fs::metadata(path)
+        .with_context(|| format!("Failed to inspect fleet manifest {}", path.display()))?
+        .len();
+    if file_size > MAX_MANIFEST_BYTES as u64 {
+        anyhow::bail!(
+            "Feature Fleet manifest exceeds the {} byte size limit",
+            MAX_MANIFEST_BYTES
+        );
+    }
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read fleet manifest {}", path.display()))?;
+    let format = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("toml");
+    parse_manifest_text(&content, format)
+        .with_context(|| format!("Invalid fleet manifest {}", path.display()))
+}
+
+pub fn parse_manifest_text(content: &str, format: &str) -> Result<ParsedManifest> {
+    if content.len() > MAX_MANIFEST_BYTES {
+        anyhow::bail!(
+            "Feature Fleet manifest exceeds the {} byte size limit",
+            MAX_MANIFEST_BYTES
+        );
+    }
+    let manifest = match format.trim().to_ascii_lowercase().as_str() {
+        "toml" => toml::from_str::<NormalizedManifest>(content)
+            .context("Failed to parse Feature Fleet TOML")?,
+        "json" => serde_json::from_str::<NormalizedManifest>(content)
+            .context("Failed to parse Feature Fleet JSON")?,
+        other => anyhow::bail!("Unsupported Feature Fleet manifest format: {other}"),
+    };
+    manifest.normalized()
+}
+
+impl NormalizedManifest {
+    pub fn normalized(self) -> Result<ParsedManifest> {
+        let normalized = normalize_manifest(self)?;
+        validate_manifest(&normalized)?;
+        let canonical =
+            serde_json::to_vec(&normalized).context("serialize normalized fleet manifest")?;
+        let digest = hex_digest(&canonical);
+        Ok(ParsedManifest {
+            manifest: normalized,
+            digest,
+        })
+    }
+}
+
+fn hex_digest(content: &[u8]) -> String {
+    Sha256::digest(content)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn normalize_manifest(manifest: NormalizedManifest) -> Result<NormalizedManifest> {
+    let mut features_by_id = BTreeMap::new();
+    for feature in manifest.features {
+        let normalized = normalize_feature(feature);
+        let id = normalized.id.clone();
+        if features_by_id.insert(id.clone(), normalized).is_some() {
+            anyhow::bail!("Duplicate feature id: {id}");
+        }
+    }
+
+    Ok(NormalizedManifest {
+        schema: manifest.schema.trim().to_string(),
+        id: manifest.id.trim().to_string(),
+        title: manifest.title.trim().to_string(),
+        base_branch: manifest.base_branch.trim().to_string(),
+        default_agent: manifest.default_agent.trim().to_string(),
+        default_profile: normalize_optional(manifest.default_profile),
+        features: features_by_id.into_values().collect(),
+    })
+}
+
+fn normalize_feature(feature: FeatureManifest) -> FeatureManifest {
+    FeatureManifest {
+        id: feature.id.trim().to_string(),
+        title: feature.title.trim().to_string(),
+        task: feature.task.trim().to_string(),
+        depends_on: sorted_strings(feature.depends_on),
+        owns: sorted_strings(feature.owns),
+        contracts: sorted_strings(feature.contracts),
+        checks: feature.checks.into_iter().map(normalize_check).collect(),
+        agent: normalize_optional(feature.agent),
+        profile: normalize_optional(feature.profile),
+    }
+}
+
+fn normalize_check(check: VerificationCheck) -> VerificationCheck {
+    VerificationCheck {
+        id: check.id.trim().to_string(),
+        program: check.program.trim().to_string(),
+        args: check.args,
+        working_directory: check.working_directory.trim().to_string(),
+        timeout_seconds: check.timeout_seconds,
+        environment_allowlist: sorted_strings(check.environment_allowlist),
+        max_output_bytes: check.max_output_bytes,
+        requires_repository_trust: check.requires_repository_trust,
+    }
+}
+
+fn normalize_optional(value: Option<String>) -> Option<String> {
+    value
+        .map(|entry| entry.trim().to_string())
+        .filter(|entry| !entry.is_empty())
+}
+
+fn sorted_strings(values: Vec<String>) -> Vec<String> {
+    values
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn validate_manifest(manifest: &NormalizedManifest) -> Result<()> {
+    if manifest.schema != SCHEMA_VERSION {
+        anyhow::bail!(
+            "Unsupported Feature Fleet schema '{}'; expected {SCHEMA_VERSION}",
+            manifest.schema
+        );
+    }
+    validate_slug("fleet id", &manifest.id)?;
+    validate_required("title", &manifest.title)?;
+    validate_base_branch(&manifest.base_branch)?;
+    validate_required("default_agent", &manifest.default_agent)?;
+    if let Some(profile) = &manifest.default_profile {
+        validate_required("default_profile", profile)?;
+    }
+    if manifest.features.is_empty() {
+        anyhow::bail!("Feature Fleet manifest requires at least one feature");
+    }
+    if manifest.features.len() > MAX_FEATURES {
+        anyhow::bail!("Feature Fleet manifest supports at most {MAX_FEATURES} features");
+    }
+    for feature in &manifest.features {
+        validate_feature(feature)?;
+    }
+    Ok(())
+}
+
+fn validate_feature(feature: &FeatureManifest) -> Result<()> {
+    validate_slug("feature id", &feature.id)?;
+    validate_required("feature title", &feature.title)?;
+    validate_required("feature task", &feature.task)?;
+    validate_item_limit(
+        &feature.id,
+        "dependencies",
+        feature.depends_on.len(),
+        MAX_FEATURE_RELATIONS,
+    )?;
+    validate_item_limit(
+        &feature.id,
+        "ownership declarations",
+        feature.owns.len(),
+        MAX_FEATURE_DECLARATIONS,
+    )?;
+    validate_item_limit(
+        &feature.id,
+        "contract declarations",
+        feature.contracts.len(),
+        MAX_FEATURE_DECLARATIONS,
+    )?;
+    validate_item_limit(
+        &feature.id,
+        "verification checks",
+        feature.checks.len(),
+        MAX_FEATURE_DECLARATIONS,
+    )?;
+    for dependency in &feature.depends_on {
+        validate_slug("dependency feature id", dependency)?;
+    }
+    for owned_path in &feature.owns {
+        validate_repo_relative("owns", owned_path, false)?;
+    }
+    for contract in &feature.contracts {
+        validate_required("contract", contract)?;
+    }
+    if let Some(agent) = &feature.agent {
+        validate_required("feature agent", agent)?;
+    }
+    if let Some(profile) = &feature.profile {
+        validate_required("feature profile", profile)?;
+    }
+
+    let mut check_ids = BTreeSet::new();
+    for check in &feature.checks {
+        validate_slug("check id", &check.id)?;
+        if !check_ids.insert(check.id.as_str()) {
+            anyhow::bail!(
+                "Feature {} contains duplicate check id {}",
+                feature.id,
+                check.id
+            );
+        }
+        validate_program(&check.program)?;
+        validate_repo_relative("working_directory", &check.working_directory, true)?;
+        if check.args.iter().any(|argument| argument.contains('\0')) {
+            anyhow::bail!("Feature {} check {} args contain NUL", feature.id, check.id);
+        }
+        if check.timeout_seconds == 0 || check.timeout_seconds > MAX_CHECK_TIMEOUT_SECONDS {
+            anyhow::bail!(
+                "Feature {} check {} timeout_seconds must be between 1 and {}",
+                feature.id,
+                check.id,
+                MAX_CHECK_TIMEOUT_SECONDS
+            );
+        }
+        if check.max_output_bytes == 0 || check.max_output_bytes > MAX_CHECK_OUTPUT_BYTES {
+            anyhow::bail!(
+                "Feature {} check {} max_output_bytes must be between 1 and {}",
+                feature.id,
+                check.id,
+                MAX_CHECK_OUTPUT_BYTES
+            );
+        }
+        for variable in &check.environment_allowlist {
+            validate_environment_name(variable)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_item_limit(feature_id: &str, label: &str, actual: usize, maximum: usize) -> Result<()> {
+    if actual > maximum {
+        anyhow::bail!("Feature {feature_id} supports at most {maximum} {label}");
+    }
+    Ok(())
+}
+
+fn validate_slug(label: &str, value: &str) -> Result<()> {
+    let pattern = Regex::new(r"^[a-z0-9][a-z0-9-]{0,62}$").expect("valid slug regex");
+    if !pattern.is_match(value) {
+        anyhow::bail!("{label} must match [a-z0-9][a-z0-9-]{{0,62}}: {value}");
+    }
+    Ok(())
+}
+
+fn validate_required(label: &str, value: &str) -> Result<()> {
+    if value.is_empty() || value.contains('\0') {
+        anyhow::bail!("{label} must be a non-empty string without NUL");
+    }
+    Ok(())
+}
+
+fn validate_base_branch(value: &str) -> Result<()> {
+    validate_required("base_branch", value)?;
+    let invalid_component = value.split('/').any(|component| {
+        component.is_empty()
+            || component.starts_with('.')
+            || component.ends_with('.')
+            || component.ends_with(".lock")
+    });
+    let invalid_character = value.chars().any(|character| {
+        character.is_control() || character.is_whitespace() || "~^:?*[\\".contains(character)
+    });
+    if value == "@"
+        || value.starts_with('-')
+        || value.ends_with('/')
+        || value.contains("..")
+        || value.contains("@{")
+        || invalid_component
+        || invalid_character
+    {
+        anyhow::bail!("base_branch is not a safe Git branch name: {value}");
+    }
+    Ok(())
+}
+
+fn validate_program(program: &str) -> Result<()> {
+    if program.is_empty()
+        || program.contains('\0')
+        || program.chars().any(char::is_whitespace)
+        || program
+            .chars()
+            .any(|character| ";&|`$<>(){}".contains(character))
+    {
+        anyhow::bail!(
+            "verification program must be one executable token; put arguments in args: {program}"
+        );
+    }
+    Ok(())
+}
+
+fn validate_repo_relative(label: &str, value: &str, allow_dot: bool) -> Result<()> {
+    if value.is_empty()
+        || value.contains('\0')
+        || value.starts_with('/')
+        || value.starts_with('\\')
+        || value.contains('\\')
+    {
+        anyhow::bail!("{label} path must be repository-relative: {value}");
+    }
+    if value == "." {
+        if allow_dot {
+            return Ok(());
+        }
+        anyhow::bail!("{label} path must identify a repository path or pattern");
+    }
+    if value
+        .split('/')
+        .any(|segment| segment.is_empty() || segment == "." || segment == "..")
+    {
+        anyhow::bail!("{label} path must not contain empty or parent segments: {value}");
+    }
+    Ok(())
+}
+
+fn validate_environment_name(value: &str) -> Result<()> {
+    let pattern = Regex::new(r"^[A-Z_][A-Z0-9_]*$").expect("valid environment regex");
+    if !pattern.is_match(value) {
+        anyhow::bail!("environment_allowlist contains invalid variable name: {value}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::{parse_manifest_path, parse_manifest_text};
+
+    const VALID_MANIFEST: &str = r#"
+schema = "ecc.feature-fleet.v1"
+id = "onboarding-v2"
+title = "Onboarding v2"
+base_branch = "main"
+default_agent = "codex"
+
+[[features]]
+id = "auth-api"
+title = "Authentication API"
+task = "Implement auth."
+owns = ["services/auth/**"]
+contracts = ["api:auth-v2"]
+
+[[features.checks]]
+id = "auth-tests"
+program = "cargo"
+args = ["test", "-p", "auth"]
+working_directory = "."
+timeout_seconds = 900
+environment_allowlist = ["RUSTUP_HOME", "CARGO_HOME"]
+max_output_bytes = 10485760
+requires_repository_trust = true
+
+[[features]]
+id = "onboarding-ui"
+title = "Onboarding UI"
+task = "Implement UI."
+depends_on = ["auth-api"]
+owns = ["apps/web/onboarding/**"]
+"#;
+
+    #[test]
+    fn parses_and_normalizes_structured_manifest() {
+        let parsed = parse_manifest_text(VALID_MANIFEST, "toml").expect("valid manifest");
+
+        assert_eq!(parsed.manifest.id, "onboarding-v2");
+        assert_eq!(parsed.manifest.features.len(), 2);
+        assert_eq!(parsed.manifest.features[0].id, "auth-api");
+        assert_eq!(
+            parsed.manifest.features[0].checks[0].args,
+            vec!["test", "-p", "auth"]
+        );
+        assert_eq!(
+            parsed.manifest.features[0].checks[0].environment_allowlist,
+            vec!["CARGO_HOME", "RUSTUP_HOME"]
+        );
+        assert_eq!(parsed.digest.len(), 64);
+    }
+
+    #[test]
+    fn repository_example_is_a_valid_manifest() {
+        let path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/feature-fleet.toml");
+        let parsed = parse_manifest_path(&path).expect("repository example");
+
+        assert_eq!(parsed.manifest.id, "feature-fleet-runtime");
+        assert_eq!(
+            parsed.manifest.features.len(),
+            3,
+            "example should demonstrate parallel roots and a dependent feature"
+        );
+    }
+
+    #[test]
+    fn normalized_digest_ignores_toml_formatting_and_feature_order() {
+        let first = parse_manifest_text(VALID_MANIFEST, "toml").expect("first manifest");
+        let mut reversed = first.manifest.clone();
+        reversed.features.reverse();
+        let reordered = reversed.normalized().expect("reordered manifest");
+
+        assert_eq!(first.digest, reordered.digest);
+
+        let canonical = serde_json::to_string_pretty(&first.manifest).expect("canonical json");
+        let reparsed = parse_manifest_text(&canonical, "json").expect("json manifest");
+        assert_eq!(first.digest, reparsed.digest);
+    }
+
+    #[test]
+    fn normalized_digest_changes_with_manifest_semantics() {
+        let first = parse_manifest_text(VALID_MANIFEST, "toml").expect("first manifest");
+        let reordered = VALID_MANIFEST
+            .replace(
+                "[[features]]\nid = \"auth-api\"",
+                "[[features]]\nid = \"z-auth-api\"",
+            )
+            .replace(
+                "depends_on = [\"auth-api\"]",
+                "depends_on = [\"z-auth-api\"]",
+            );
+        let second = parse_manifest_text(&reordered, "toml").expect("second manifest");
+
+        assert_ne!(
+            first.digest, second.digest,
+            "semantic changes must change digest"
+        );
+    }
+
+    #[test]
+    fn rejects_shell_strings_and_unsafe_paths() {
+        let shell_check = VALID_MANIFEST.replace(
+            "program = \"cargo\"\nargs = [\"test\", \"-p\", \"auth\"]",
+            "program = \"cargo test -p auth\"\nargs = []",
+        );
+        let error = parse_manifest_text(&shell_check, "toml").expect_err("shell string rejected");
+        assert!(error.to_string().contains("program"));
+
+        let unsafe_path = VALID_MANIFEST.replace(
+            "owns = [\"services/auth/**\"]",
+            "owns = [\"../outside/**\"]",
+        );
+        let error = parse_manifest_text(&unsafe_path, "toml").expect_err("unsafe path rejected");
+        assert!(error.to_string().contains("owns"));
+
+        let ambiguous_path = VALID_MANIFEST.replace(
+            "owns = [\"services/auth/**\"]",
+            "owns = [\"services/./auth/**\"]",
+        );
+        let error = parse_manifest_text(&ambiguous_path, "toml").expect_err("dot segment rejected");
+        assert!(error.to_string().contains("owns"));
+    }
+
+    #[test]
+    fn rejects_invalid_base_branch_and_unknown_fields() {
+        let unsafe_branch = VALID_MANIFEST.replace(
+            "base_branch = \"main\"",
+            "base_branch = \"--upload-pack=malicious\"",
+        );
+        let error =
+            parse_manifest_text(&unsafe_branch, "toml").expect_err("unsafe branch rejected");
+        assert!(error.to_string().contains("base_branch"));
+
+        let unknown = VALID_MANIFEST.replace(
+            "default_agent = \"codex\"",
+            "default_agent = \"codex\"\nunrecognized = true",
+        );
+        let error = parse_manifest_text(&unknown, "toml").expect_err("unknown field rejected");
+        assert!(format!("{error:#}").contains("unrecognized"));
+
+        let implicit_trust = VALID_MANIFEST.replace("requires_repository_trust = true\n", "");
+        let error =
+            parse_manifest_text(&implicit_trust, "toml").expect_err("trust must be explicit");
+        assert!(format!("{error:#}").contains("requires_repository_trust"));
+    }
+
+    #[test]
+    fn rejects_oversized_manifests() {
+        let oversized = format!("{}\n# {}", VALID_MANIFEST, "x".repeat(1024 * 1024));
+        let error = parse_manifest_text(&oversized, "toml").expect_err("oversized manifest");
+        assert!(error.to_string().contains("size limit"));
+    }
+
+    pub(crate) fn valid_manifest() -> &'static str {
+        VALID_MANIFEST
+    }
+}

--- a/ecc2/src/feature_fleet/mod.rs
+++ b/ecc2/src/feature_fleet/mod.rs
@@ -1,0 +1,215 @@
+pub mod cli;
+mod collision;
+mod manifest;
+mod model;
+mod report;
+mod scheduler;
+mod store;
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::session::store::StateStore;
+
+use self::collision::declared_collisions;
+use self::manifest::parse_manifest_path;
+use self::model::{FleetBlocker, FleetBlockerKind, FleetPlan, FleetRecord, FleetStatusReport};
+use self::scheduler::build_schedule;
+use self::store::FleetStore;
+
+pub fn plan(manifest_path: &Path) -> Result<FleetPlan> {
+    let parsed = parse_manifest_path(manifest_path)?;
+    let schedule = build_schedule(&parsed.manifest)?;
+    let collisions = declared_collisions(&parsed.manifest)?;
+    Ok(FleetPlan {
+        experimental: true,
+        manifest: parsed.manifest,
+        manifest_digest: parsed.digest,
+        schedule,
+        collisions,
+    })
+}
+
+pub fn create(db: &StateStore, manifest_path: &Path) -> Result<FleetRecord> {
+    let parsed = parse_manifest_path(manifest_path)?;
+    build_schedule(&parsed.manifest)?;
+    let blockers = declared_collisions(&parsed.manifest)?
+        .into_iter()
+        .map(|collision| FleetBlocker {
+            kind: FleetBlockerKind::Collision,
+            code: collision.kind,
+            entity_ids: vec![collision.left_feature, collision.right_feature],
+            summary: collision.detail,
+            required_resolution_action: collision.required_action,
+        })
+        .collect::<Vec<_>>();
+    let (repo_root, base_oid) = resolve_repository_base(&parsed.manifest.base_branch)?;
+    let repo_root = repo_root
+        .to_str()
+        .context("Feature Fleet repository root must be valid UTF-8")?;
+    FleetStore::new(db.connection()).create(&parsed, repo_root, &base_oid, &blockers)
+}
+
+pub fn status(db: &StateStore, fleet_id: &str) -> Result<FleetStatusReport> {
+    let store = FleetStore::new(db.connection());
+    let fleet = store
+        .get(fleet_id)?
+        .with_context(|| format!("Feature Fleet not found: {fleet_id}"))?;
+    let events = store.events(fleet_id)?;
+    Ok(FleetStatusReport {
+        experimental: true,
+        fleet,
+        events,
+    })
+}
+
+fn resolve_repository_base(base_branch: &str) -> Result<(PathBuf, String)> {
+    let working_directory =
+        std::env::current_dir().context("Failed to resolve current working directory")?;
+    let repo_root = git_stdout(&working_directory, &["rev-parse", "--show-toplevel"])
+        .context("Feature Fleet create must run inside a Git repository")?;
+    let repo_root = PathBuf::from(repo_root)
+        .canonicalize()
+        .context("Failed to canonicalize repository root")?;
+    let commit_ref = format!("{base_branch}^{{commit}}");
+    let base_oid = git_stdout(
+        &repo_root,
+        &["rev-parse", "--verify", "--end-of-options", &commit_ref],
+    )
+    .with_context(|| format!("Failed to resolve fleet base branch {base_branch}"))?;
+    if !matches!(base_oid.len(), 40 | 64)
+        || !base_oid
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+    {
+        anyhow::bail!("Git returned an invalid full object ID for {base_branch}");
+    }
+    Ok((repo_root, base_oid))
+}
+
+fn git_stdout(working_directory: &Path, args: &[&str]) -> Result<String> {
+    let mut command = Command::new("git");
+    command.current_dir(working_directory).args(args);
+    for variable in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_COMMON_DIR",
+        "GIT_PREFIX",
+    ] {
+        command.env_remove(variable);
+    }
+    let output = command.output().context("Failed to execute git")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        anyhow::bail!(
+            "git {} failed{}",
+            args.join(" "),
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(": {stderr}")
+            }
+        );
+    }
+    String::from_utf8(output.stdout)
+        .context("git output was not UTF-8")
+        .map(|value| value.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{create, git_stdout, status};
+    use crate::feature_fleet::manifest::tests::valid_manifest;
+    use crate::session::store::StateStore;
+    use crate::test_support::CurrentDirGuard;
+    use anyhow::Result;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new() -> Result<Self> {
+            let path =
+                std::env::temp_dir().join(format!("ecc2-feature-fleet-{}", uuid::Uuid::new_v4()));
+            fs::create_dir_all(&path)?;
+            Ok(Self(path))
+        }
+
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn create_pins_the_resolved_base_oid() -> Result<()> {
+        let test_dir = TestDir::new()?;
+        git(test_dir.path(), &["init", "-b", "main"])?;
+        fs::write(test_dir.path().join("README.md"), "first\n")?;
+        git(test_dir.path(), &["add", "README.md"])?;
+        git(
+            test_dir.path(),
+            &[
+                "-c",
+                "user.name=ECC Test",
+                "-c",
+                "user.email=ecc@example.invalid",
+                "commit",
+                "-m",
+                "first",
+            ],
+        )?;
+        let expected_oid = git_stdout(test_dir.path(), &["rev-parse", "main"])?;
+        let manifest_path = test_dir.path().join("fleet.toml");
+        fs::write(&manifest_path, valid_manifest())?;
+        let db = StateStore::open(&test_dir.path().join("state.db"))?;
+        let _current_dir = CurrentDirGuard::enter(test_dir.path())?;
+
+        let created = create(&db, &manifest_path)?;
+        assert_eq!(created.base_oid, expected_oid);
+
+        fs::write(test_dir.path().join("README.md"), "second\n")?;
+        git(test_dir.path(), &["add", "README.md"])?;
+        git(
+            test_dir.path(),
+            &[
+                "-c",
+                "user.name=ECC Test",
+                "-c",
+                "user.email=ecc@example.invalid",
+                "commit",
+                "-m",
+                "second",
+            ],
+        )?;
+
+        let current_oid = git_stdout(test_dir.path(), &["rev-parse", "main"])?;
+        assert_ne!(created.base_oid, current_oid);
+        assert_eq!(status(&db, "onboarding-v2")?.fleet.base_oid, expected_oid);
+        Ok(())
+    }
+
+    fn git(working_directory: &Path, args: &[&str]) -> Result<()> {
+        let output = Command::new("git")
+            .current_dir(working_directory)
+            .args(args)
+            .output()?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        Ok(())
+    }
+}

--- a/ecc2/src/feature_fleet/mod.rs
+++ b/ecc2/src/feature_fleet/mod.rs
@@ -34,7 +34,7 @@ pub fn plan(manifest_path: &Path) -> Result<FleetPlan> {
 pub fn create(db: &StateStore, manifest_path: &Path) -> Result<FleetRecord> {
     let parsed = parse_manifest_path(manifest_path)?;
     build_schedule(&parsed.manifest)?;
-    let blockers = declared_collisions(&parsed.manifest)?
+    let mut blockers = declared_collisions(&parsed.manifest)?
         .into_iter()
         .map(|collision| FleetBlocker {
             kind: FleetBlockerKind::Collision,
@@ -45,10 +45,34 @@ pub fn create(db: &StateStore, manifest_path: &Path) -> Result<FleetRecord> {
         })
         .collect::<Vec<_>>();
     let (repo_root, base_oid) = resolve_repository_base(&parsed.manifest.base_branch)?;
+    if repository_has_uncommitted_changes(&repo_root)? {
+        blockers.push(FleetBlocker {
+            kind: FleetBlockerKind::Git,
+            code: "repository_dirty".to_string(),
+            entity_ids: Vec::new(),
+            summary: "Repository has uncommitted, untracked, or dirty-submodule changes that are not included in the pinned base OID".to_string(),
+            required_resolution_action:
+                "commit_or_stash_changes_then_create_a_new_fleet_revision_before_launch"
+                    .to_string(),
+        });
+    }
     let repo_root = repo_root
         .to_str()
         .context("Feature Fleet repository root must be valid UTF-8")?;
     FleetStore::new(db.connection()).create(&parsed, repo_root, &base_oid, &blockers)
+}
+
+fn repository_has_uncommitted_changes(repo_root: &Path) -> Result<bool> {
+    Ok(!git_stdout(
+        repo_root,
+        &[
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            "--ignore-submodules=none",
+        ],
+    )?
+    .is_empty())
 }
 
 pub fn status(db: &StateStore, fleet_id: &str) -> Result<FleetStatusReport> {
@@ -176,6 +200,12 @@ mod tests {
 
         let created = create(&db, &manifest_path)?;
         assert_eq!(created.base_oid, expected_oid);
+        assert!(created.blockers.iter().any(|blocker| {
+            blocker.kind == crate::feature_fleet::model::FleetBlockerKind::Git
+                && blocker.code == "repository_dirty"
+                && blocker.required_resolution_action
+                    == "commit_or_stash_changes_then_create_a_new_fleet_revision_before_launch"
+        }));
 
         fs::write(test_dir.path().join("README.md"), "second\n")?;
         git(test_dir.path(), &["add", "README.md"])?;
@@ -195,6 +225,40 @@ mod tests {
         let current_oid = git_stdout(test_dir.path(), &["rev-parse", "main"])?;
         assert_ne!(created.base_oid, current_oid);
         assert_eq!(status(&db, "onboarding-v2")?.fleet.base_oid, expected_oid);
+        Ok(())
+    }
+
+    #[test]
+    fn create_has_no_git_blocker_for_a_clean_repository() -> Result<()> {
+        let test_dir = TestDir::new()?;
+        let repo = test_dir.path().join("repo");
+        fs::create_dir(&repo)?;
+        git(&repo, &["init", "-b", "main"])?;
+        fs::write(repo.join("README.md"), "first\n")?;
+        git(&repo, &["add", "README.md"])?;
+        git(
+            &repo,
+            &[
+                "-c",
+                "user.name=ECC Test",
+                "-c",
+                "user.email=ecc@example.invalid",
+                "commit",
+                "-m",
+                "first",
+            ],
+        )?;
+        let manifest_path = test_dir.path().join("fleet.toml");
+        fs::write(&manifest_path, valid_manifest())?;
+        let db = StateStore::open(&test_dir.path().join("state.db"))?;
+        let _current_dir = CurrentDirGuard::enter(&repo)?;
+
+        let created = create(&db, &manifest_path)?;
+
+        assert!(!created
+            .blockers
+            .iter()
+            .any(|blocker| blocker.code == "repository_dirty"));
         Ok(())
     }
 

--- a/ecc2/src/feature_fleet/model.rs
+++ b/ecc2/src/feature_fleet/model.rs
@@ -1,0 +1,246 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct NormalizedManifest {
+    pub schema: String,
+    pub id: String,
+    pub title: String,
+    pub base_branch: String,
+    pub default_agent: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_profile: Option<String>,
+    pub features: Vec<FeatureManifest>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct FeatureManifest {
+    pub id: String,
+    pub title: String,
+    pub task: String,
+    #[serde(default)]
+    pub depends_on: Vec<String>,
+    #[serde(default)]
+    pub owns: Vec<String>,
+    #[serde(default)]
+    pub contracts: Vec<String>,
+    #[serde(default)]
+    pub checks: Vec<VerificationCheck>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct VerificationCheck {
+    pub id: String,
+    pub program: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default = "default_working_directory")]
+    pub working_directory: String,
+    #[serde(default = "default_timeout_seconds")]
+    pub timeout_seconds: u64,
+    #[serde(default)]
+    pub environment_allowlist: Vec<String>,
+    #[serde(default = "default_max_output_bytes")]
+    pub max_output_bytes: u64,
+    pub requires_repository_trust: bool,
+}
+
+fn default_working_directory() -> String {
+    ".".to_string()
+}
+
+const fn default_timeout_seconds() -> u64 {
+    900
+}
+
+const fn default_max_output_bytes() -> u64 {
+    10 * 1024 * 1024
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ParsedManifest {
+    pub manifest: NormalizedManifest,
+    pub digest: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FleetSchedule {
+    pub topological_order: Vec<String>,
+    pub initial_ready: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DeclaredCollision {
+    pub kind: String,
+    pub left_feature: String,
+    pub right_feature: String,
+    pub detail: String,
+    pub required_action: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FleetLifecycleState {
+    Planned,
+    Running,
+    Reviewing,
+    Integrating,
+    Completed,
+    Failed,
+}
+
+impl FleetLifecycleState {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Planned => "planned",
+            Self::Running => "running",
+            Self::Reviewing => "reviewing",
+            Self::Integrating => "integrating",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl fmt::Display for FleetLifecycleState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+impl FromStr for FleetLifecycleState {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "planned" => Ok(Self::Planned),
+            "running" => Ok(Self::Running),
+            "reviewing" => Ok(Self::Reviewing),
+            "integrating" => Ok(Self::Integrating),
+            "completed" => Ok(Self::Completed),
+            "failed" => Ok(Self::Failed),
+            _ => anyhow::bail!("Unknown Feature Fleet lifecycle state: {value}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FleetBlockerKind {
+    Collision,
+    Dependency,
+    Verification,
+    Scope,
+    Git,
+    OperatorApproval,
+    Recovery,
+}
+
+impl FleetBlockerKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Collision => "collision",
+            Self::Dependency => "dependency",
+            Self::Verification => "verification",
+            Self::Scope => "scope",
+            Self::Git => "git",
+            Self::OperatorApproval => "operator_approval",
+            Self::Recovery => "recovery",
+        }
+    }
+}
+
+impl fmt::Display for FleetBlockerKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FleetBlocker {
+    pub kind: FleetBlockerKind,
+    pub code: String,
+    pub entity_ids: Vec<String>,
+    pub summary: String,
+    pub required_resolution_action: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FleetPlan {
+    pub experimental: bool,
+    pub manifest: NormalizedManifest,
+    pub manifest_digest: String,
+    pub schedule: FleetSchedule,
+    pub collisions: Vec<DeclaredCollision>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FleetRecord {
+    pub id: String,
+    pub title: String,
+    pub repo_root: String,
+    pub base_branch: String,
+    pub base_oid: String,
+    pub manifest_digest: String,
+    pub revision: i64,
+    pub lifecycle_state: FleetLifecycleState,
+    pub blockers: Vec<FleetBlocker>,
+    pub features: Vec<FleetFeatureRecord>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FleetFeatureRecord {
+    pub id: String,
+    pub title: String,
+    pub task: String,
+    pub depends_on: Vec<String>,
+    pub owns: Vec<String>,
+    pub contracts: Vec<String>,
+    pub checks: Vec<VerificationCheck>,
+    pub lifecycle_state: FleetLifecycleState,
+    pub blockers: Vec<FleetBlocker>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FleetEvent {
+    pub id: i64,
+    pub fleet_id: String,
+    pub fleet_revision: i64,
+    pub event_kind: String,
+    pub entity_kind: String,
+    pub entity_id: String,
+    pub payload: serde_json::Value,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FleetStatusReport {
+    pub experimental: bool,
+    pub fleet: FleetRecord,
+    pub events: Vec<FleetEvent>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FleetLifecycleState;
+    use std::str::FromStr;
+
+    #[test]
+    fn blockers_are_not_lifecycle_states() {
+        assert_eq!(
+            FleetLifecycleState::from_str("reviewing").expect("reviewing state"),
+            FleetLifecycleState::Reviewing
+        );
+        assert!(FleetLifecycleState::from_str("blocked").is_err());
+    }
+}

--- a/ecc2/src/feature_fleet/report.rs
+++ b/ecc2/src/feature_fleet/report.rs
@@ -1,0 +1,85 @@
+use super::model::{FleetPlan, FleetRecord, FleetStatusReport};
+
+pub fn plan_human(plan: &FleetPlan) -> String {
+    let mut lines = vec![
+        format!("Feature Fleet plan: {} [EXPERIMENTAL]", plan.manifest.id),
+        format!("Title: {}", plan.manifest.title),
+        format!("Base: {}", plan.manifest.base_branch),
+        format!("Manifest digest: {}", plan.manifest_digest),
+        format!("Features: {}", plan.manifest.features.len()),
+        format!(
+            "Initial ready: {}",
+            display_list(&plan.schedule.initial_ready)
+        ),
+        format!(
+            "Topological order: {}",
+            display_list(&plan.schedule.topological_order)
+        ),
+    ];
+
+    if plan.collisions.is_empty() {
+        lines.push("Declared collisions: none".to_string());
+    } else {
+        lines.push(format!(
+            "Declared collisions: {} (must serialize or revise ownership)",
+            plan.collisions.len()
+        ));
+        for collision in &plan.collisions {
+            lines.push(format!(
+                "- {}: {} <-> {} | {}",
+                collision.kind, collision.left_feature, collision.right_feature, collision.detail
+            ));
+        }
+    }
+    lines.join("\n")
+}
+
+pub fn create_human(record: &FleetRecord) -> String {
+    [
+        format!("Feature Fleet created: {} [EXPERIMENTAL]", record.id),
+        format!("Base: {} @ {}", record.base_branch, record.base_oid),
+        format!("Manifest digest: {}", record.manifest_digest),
+        format!("Revision: {}", record.revision),
+        format!("Features: {}", record.features.len()),
+        format!("Blockers: {}", record.blockers.len()),
+    ]
+    .join("\n")
+}
+
+pub fn status_human(status: &FleetStatusReport) -> String {
+    let fleet = &status.fleet;
+    let mut lines = vec![
+        format!("Feature Fleet status: {} [EXPERIMENTAL]", fleet.id),
+        format!("State: {}", fleet.lifecycle_state),
+        format!("Revision: {}", fleet.revision),
+        format!("Repository: {}", fleet.repo_root),
+        format!("Base: {} @ {}", fleet.base_branch, fleet.base_oid),
+        format!("Events: {}", status.events.len()),
+        format!("Blockers: {}", fleet.blockers.len()),
+    ];
+    for blocker in &fleet.blockers {
+        lines.push(format!(
+            "- {}:{} | {} | action: {}",
+            blocker.kind, blocker.code, blocker.summary, blocker.required_resolution_action
+        ));
+    }
+    lines.push("Features:".to_string());
+    for feature in &fleet.features {
+        lines.push(format!(
+            "- {} | {} | blockers {} | depends on {}",
+            feature.id,
+            feature.lifecycle_state,
+            feature.blockers.len(),
+            display_list(&feature.depends_on)
+        ));
+    }
+    lines.join("\n")
+}
+
+fn display_list(values: &[String]) -> String {
+    if values.is_empty() {
+        "none".to_string()
+    } else {
+        values.join(", ")
+    }
+}

--- a/ecc2/src/feature_fleet/scheduler.rs
+++ b/ecc2/src/feature_fleet/scheduler.rs
@@ -1,0 +1,131 @@
+use anyhow::Result;
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::model::{FleetSchedule, NormalizedManifest};
+
+pub fn build_schedule(manifest: &NormalizedManifest) -> Result<FleetSchedule> {
+    let dependencies = manifest
+        .features
+        .iter()
+        .map(|feature| (feature.id.clone(), feature.depends_on.clone()))
+        .collect::<BTreeMap<_, _>>();
+
+    validate_dependencies(&dependencies)?;
+
+    let mut remaining = dependencies.clone();
+    let mut completed = BTreeSet::new();
+    let mut order = Vec::with_capacity(remaining.len());
+    let initial_ready = ready_set(&remaining, &completed);
+
+    while !remaining.is_empty() {
+        let ready = ready_set(&remaining, &completed);
+        if ready.is_empty() {
+            let unresolved = remaining.keys().cloned().collect::<Vec<_>>().join(", ");
+            anyhow::bail!("Feature dependency cycle detected among: {unresolved}");
+        }
+        for feature_id in ready {
+            remaining.remove(&feature_id);
+            completed.insert(feature_id.clone());
+            order.push(feature_id);
+        }
+    }
+
+    Ok(FleetSchedule {
+        topological_order: order,
+        initial_ready,
+    })
+}
+
+pub fn transitively_depends_on(
+    manifest: &NormalizedManifest,
+    feature_id: &str,
+    dependency_id: &str,
+) -> bool {
+    let dependencies = manifest
+        .features
+        .iter()
+        .map(|feature| (feature.id.as_str(), feature.depends_on.as_slice()))
+        .collect::<BTreeMap<_, _>>();
+    let mut pending = vec![feature_id];
+    let mut visited = BTreeSet::new();
+
+    while let Some(current) = pending.pop() {
+        if !visited.insert(current) {
+            continue;
+        }
+        for dependency in dependencies.get(current).copied().unwrap_or_default() {
+            if dependency == dependency_id {
+                return true;
+            }
+            pending.push(dependency);
+        }
+    }
+    false
+}
+
+fn validate_dependencies(dependencies: &BTreeMap<String, Vec<String>>) -> Result<()> {
+    for (feature_id, required) in dependencies {
+        for dependency in required {
+            if dependency == feature_id {
+                anyhow::bail!("Feature {feature_id} cannot depend on itself");
+            }
+            if !dependencies.contains_key(dependency) {
+                anyhow::bail!("Feature {feature_id} depends on unknown feature {dependency}");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn ready_set(
+    remaining: &BTreeMap<String, Vec<String>>,
+    completed: &BTreeSet<String>,
+) -> Vec<String> {
+    remaining
+        .iter()
+        .filter(|(_, dependencies)| {
+            dependencies
+                .iter()
+                .all(|dependency| completed.contains(dependency))
+        })
+        .map(|(feature_id, _)| feature_id.clone())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_schedule;
+    use crate::feature_fleet::manifest::parse_manifest_text;
+    use crate::feature_fleet::manifest::tests::valid_manifest;
+
+    #[test]
+    fn builds_deterministic_topological_order_and_ready_set() {
+        let parsed = parse_manifest_text(valid_manifest(), "toml").expect("manifest");
+        let schedule = build_schedule(&parsed.manifest).expect("schedule");
+
+        assert_eq!(
+            schedule.topological_order,
+            vec!["auth-api", "onboarding-ui"]
+        );
+        assert_eq!(schedule.initial_ready, vec!["auth-api"]);
+    }
+
+    #[test]
+    fn rejects_unknown_dependencies_and_cycles() {
+        let unknown = valid_manifest().replace(
+            "depends_on = [\"auth-api\"]",
+            "depends_on = [\"missing-api\"]",
+        );
+        let parsed = parse_manifest_text(&unknown, "toml").expect("parse unknown dependency");
+        let error = build_schedule(&parsed.manifest).expect_err("unknown dependency rejected");
+        assert!(error.to_string().contains("missing-api"));
+
+        let cycle = valid_manifest().replace(
+            "contracts = [\"api:auth-v2\"]",
+            "contracts = [\"api:auth-v2\"]\ndepends_on = [\"onboarding-ui\"]",
+        );
+        let parsed = parse_manifest_text(&cycle, "toml").expect("parse cycle");
+        let error = build_schedule(&parsed.manifest).expect_err("cycle rejected");
+        assert!(error.to_string().contains("cycle"));
+    }
+}

--- a/ecc2/src/feature_fleet/store.rs
+++ b/ecc2/src/feature_fleet/store.rs
@@ -1,0 +1,358 @@
+use anyhow::{Context, Result};
+use rusqlite::{Connection, OptionalExtension};
+use std::path::Path;
+
+use super::model::{
+    FleetBlocker, FleetEvent, FleetFeatureRecord, FleetLifecycleState, FleetRecord, ParsedManifest,
+    VerificationCheck,
+};
+
+pub struct FleetStore<'connection> {
+    connection: &'connection Connection,
+}
+
+impl<'connection> FleetStore<'connection> {
+    pub fn new(connection: &'connection Connection) -> Self {
+        Self { connection }
+    }
+
+    pub fn create(
+        &self,
+        parsed: &ParsedManifest,
+        repo_root: &str,
+        base_oid: &str,
+        blockers: &[FleetBlocker],
+    ) -> Result<FleetRecord> {
+        validate_create_identity(repo_root, base_oid)?;
+        self.connection
+            .execute_batch("BEGIN IMMEDIATE")
+            .context("begin Feature Fleet create transaction")?;
+        let result = self.create_in_transaction(parsed, repo_root, base_oid, blockers);
+        match result {
+            Ok(record) => {
+                if let Err(error) = self.connection.execute_batch("COMMIT") {
+                    let _ = self.connection.execute_batch("ROLLBACK");
+                    Err(error).context("commit Feature Fleet create transaction")
+                } else {
+                    Ok(record)
+                }
+            }
+            Err(error) => {
+                let _ = self.connection.execute_batch("ROLLBACK");
+                Err(error)
+            }
+        }
+    }
+
+    pub fn get(&self, fleet_id: &str) -> Result<Option<FleetRecord>> {
+        let fleet = self
+            .connection
+            .query_row(
+                "SELECT id, title, repo_root, base_branch, base_oid, manifest_digest,
+                        revision, lifecycle_state, blockers_json, created_at, updated_at
+                 FROM feature_fleets
+                 WHERE id = ?1",
+                [fleet_id],
+                |row| {
+                    Ok(FleetRecord {
+                        id: row.get(0)?,
+                        title: row.get(1)?,
+                        repo_root: row.get(2)?,
+                        base_branch: row.get(3)?,
+                        base_oid: row.get(4)?,
+                        manifest_digest: row.get(5)?,
+                        revision: row.get(6)?,
+                        lifecycle_state: lifecycle_column(row.get(7)?)?,
+                        blockers: json_column(&row.get::<_, String>(8)?)?,
+                        features: Vec::new(),
+                        created_at: row.get(9)?,
+                        updated_at: row.get(10)?,
+                    })
+                },
+            )
+            .optional()?;
+
+        fleet
+            .map(|record| {
+                let features = self.features(&record.id)?;
+                Ok(FleetRecord { features, ..record })
+            })
+            .transpose()
+    }
+
+    pub fn events(&self, fleet_id: &str) -> Result<Vec<FleetEvent>> {
+        let mut statement = self.connection.prepare(
+            "SELECT id, fleet_id, fleet_revision, event_kind, entity_kind,
+                    entity_id, payload_json, created_at
+             FROM fleet_events
+             WHERE fleet_id = ?1
+             ORDER BY id",
+        )?;
+        let events = statement
+            .query_map([fleet_id], |row| {
+                let payload_json: String = row.get(6)?;
+                let payload = serde_json::from_str(&payload_json).map_err(|error| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        payload_json.len(),
+                        rusqlite::types::Type::Text,
+                        Box::new(error),
+                    )
+                })?;
+                Ok(FleetEvent {
+                    id: row.get(0)?,
+                    fleet_id: row.get(1)?,
+                    fleet_revision: row.get(2)?,
+                    event_kind: row.get(3)?,
+                    entity_kind: row.get(4)?,
+                    entity_id: row.get(5)?,
+                    payload,
+                    created_at: row.get(7)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(events)
+    }
+
+    fn create_in_transaction(
+        &self,
+        parsed: &ParsedManifest,
+        repo_root: &str,
+        base_oid: &str,
+        blockers: &[FleetBlocker],
+    ) -> Result<FleetRecord> {
+        if let Some(existing) = self.get(&parsed.manifest.id)? {
+            if existing.manifest_digest == parsed.digest
+                && existing.repo_root == repo_root
+                && existing.base_oid == base_oid
+                && existing.base_branch == parsed.manifest.base_branch
+            {
+                return Ok(existing);
+            }
+            anyhow::bail!(
+                "Fleet {} already exists with a different manifest, repository, or base",
+                parsed.manifest.id
+            );
+        }
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let manifest_json =
+            serde_json::to_string(&parsed.manifest).context("serialize fleet manifest")?;
+        let blockers_json = serde_json::to_string(blockers).context("serialize fleet blockers")?;
+        self.connection.execute(
+            "INSERT INTO feature_fleets(
+                id, schema_version, title, repo_root, base_branch, base_oid,
+                manifest_digest, manifest_json, revision, lifecycle_state, blockers_json,
+                created_at, updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 1, 'planned', ?9, ?10, ?10)",
+            rusqlite::params![
+                parsed.manifest.id,
+                parsed.manifest.schema,
+                parsed.manifest.title,
+                repo_root,
+                parsed.manifest.base_branch,
+                base_oid,
+                parsed.digest,
+                manifest_json,
+                blockers_json,
+                now
+            ],
+        )?;
+
+        for feature in &parsed.manifest.features {
+            self.connection.execute(
+                "INSERT INTO fleet_features(
+                    fleet_id, feature_id, title, task, dependencies_json, owns_json,
+                    contracts_json, checks_json, lifecycle_state, blockers_json,
+                    created_at, updated_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'planned', '[]', ?9, ?9)",
+                rusqlite::params![
+                    parsed.manifest.id,
+                    feature.id,
+                    feature.title,
+                    feature.task,
+                    serde_json::to_string(&feature.depends_on)?,
+                    serde_json::to_string(&feature.owns)?,
+                    serde_json::to_string(&feature.contracts)?,
+                    serde_json::to_string(&feature.checks)?,
+                    now
+                ],
+            )?;
+        }
+
+        let event_payload = serde_json::json!({
+            "base_branch": parsed.manifest.base_branch,
+            "base_oid": base_oid,
+            "manifest_digest": parsed.digest,
+            "feature_count": parsed.manifest.features.len(),
+            "blocker_count": blockers.len(),
+        });
+        self.connection.execute(
+            "INSERT INTO fleet_events(
+                fleet_id, fleet_revision, event_kind, entity_kind, entity_id,
+                payload_json, created_at
+             ) VALUES (?1, 1, 'fleet.created', 'fleet', ?1, ?2, ?3)",
+            rusqlite::params![
+                parsed.manifest.id,
+                serde_json::to_string(&event_payload)?,
+                now
+            ],
+        )?;
+
+        self.get(&parsed.manifest.id)?
+            .context("created fleet was not readable")
+    }
+
+    fn features(&self, fleet_id: &str) -> Result<Vec<FleetFeatureRecord>> {
+        let mut statement = self.connection.prepare(
+            "SELECT feature_id, title, task, dependencies_json, owns_json,
+                    contracts_json, checks_json, lifecycle_state, blockers_json
+             FROM fleet_features
+             WHERE fleet_id = ?1
+             ORDER BY feature_id",
+        )?;
+        let features = statement
+            .query_map([fleet_id], |row| {
+                let dependencies_json: String = row.get(3)?;
+                let owns_json: String = row.get(4)?;
+                let contracts_json: String = row.get(5)?;
+                let checks_json: String = row.get(6)?;
+                Ok(FleetFeatureRecord {
+                    id: row.get(0)?,
+                    title: row.get(1)?,
+                    task: row.get(2)?,
+                    depends_on: json_column(&dependencies_json)?,
+                    owns: json_column(&owns_json)?,
+                    contracts: json_column(&contracts_json)?,
+                    checks: json_column::<Vec<VerificationCheck>>(&checks_json)?,
+                    lifecycle_state: lifecycle_column(row.get(7)?)?,
+                    blockers: json_column(&row.get::<_, String>(8)?)?,
+                })
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(features)
+    }
+}
+
+fn lifecycle_column(value: String) -> rusqlite::Result<FleetLifecycleState> {
+    value.parse().map_err(|error: anyhow::Error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            value.len(),
+            rusqlite::types::Type::Text,
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                error.to_string(),
+            )),
+        )
+    })
+}
+
+fn json_column<T>(value: &str) -> rusqlite::Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    serde_json::from_str(value).map_err(|error| {
+        rusqlite::Error::FromSqlConversionFailure(
+            value.len(),
+            rusqlite::types::Type::Text,
+            Box::new(error),
+        )
+    })
+}
+
+fn validate_create_identity(repo_root: &str, base_oid: &str) -> Result<()> {
+    if !Path::new(repo_root).is_absolute() {
+        anyhow::bail!("Fleet repository root must be absolute: {repo_root}");
+    }
+    if !matches!(base_oid.len(), 40 | 64)
+        || !base_oid
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+    {
+        anyhow::bail!("Fleet base OID must be a full 40- or 64-character object ID");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FleetStore;
+    use crate::feature_fleet::manifest::parse_manifest_text;
+    use crate::feature_fleet::manifest::tests::valid_manifest;
+    use crate::feature_fleet::model::{FleetBlocker, FleetBlockerKind};
+    use crate::session::migrations::run_all;
+    use rusqlite::Connection;
+
+    #[test]
+    fn creates_and_loads_fleet_with_event_atomically() {
+        let connection = Connection::open_in_memory().expect("database");
+        run_all(&connection, || Ok(())).expect("migrations");
+        let store = FleetStore::new(&connection);
+        let manifest = parse_manifest_text(valid_manifest(), "toml").expect("manifest");
+        let blockers = vec![FleetBlocker {
+            kind: FleetBlockerKind::Collision,
+            code: "path_overlap".to_string(),
+            entity_ids: vec!["auth-api".to_string(), "onboarding-ui".to_string()],
+            summary: "declared paths overlap".to_string(),
+            required_resolution_action: "serialize_or_revise_ownership".to_string(),
+        }];
+
+        let created = store
+            .create(
+                &manifest,
+                "/repo",
+                "1111111111111111111111111111111111111111",
+                &blockers,
+            )
+            .expect("create fleet");
+        let loaded = store
+            .get("onboarding-v2")
+            .expect("load fleet")
+            .expect("fleet exists");
+
+        assert_eq!(created.id, "onboarding-v2");
+        assert_eq!(loaded.manifest_digest, manifest.digest);
+        assert_eq!(loaded.features.len(), 2);
+        assert_eq!(loaded.blockers, blockers);
+        assert_eq!(
+            loaded.lifecycle_state,
+            crate::feature_fleet::model::FleetLifecycleState::Planned
+        );
+        assert_eq!(store.events("onboarding-v2").expect("events").len(), 1);
+    }
+
+    #[test]
+    fn duplicate_create_is_idempotent_only_for_same_identity() {
+        let connection = Connection::open_in_memory().expect("database");
+        run_all(&connection, || Ok(())).expect("migrations");
+        let store = FleetStore::new(&connection);
+        let manifest = parse_manifest_text(valid_manifest(), "toml").expect("manifest");
+
+        let first = store
+            .create(
+                &manifest,
+                "/repo",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                &[],
+            )
+            .expect("first create");
+        let repeated = store
+            .create(
+                &manifest,
+                "/repo",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                &[],
+            )
+            .expect("idempotent create");
+        assert_eq!(first, repeated);
+
+        let error = store
+            .create(
+                &manifest,
+                "/repo",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                &[],
+            )
+            .expect_err("different base rejected");
+        assert!(error.to_string().contains("already exists"));
+    }
+}

--- a/ecc2/src/main.rs
+++ b/ecc2/src/main.rs
@@ -112,10 +112,7 @@ enum Commands {
     /// Launch the TUI dashboard
     Dashboard,
     /// Experimental multi-feature planning and durable fleet state
-    Fleet {
-        #[command(subcommand)]
-        command: feature_fleet::cli::FleetCommand,
-    },
+    Fleet(feature_fleet::cli::FleetArgs),
     /// Start a new agent session
     Start {
         /// Task description for the agent
@@ -1360,14 +1357,18 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     let cfg = config::Config::load()?;
-    let db = session::store::StateStore::open(&cfg.db_path)?;
+    let db_path = match &cli.command {
+        Some(Commands::Fleet(args)) => args.state_db.as_ref().unwrap_or(&cfg.db_path),
+        _ => &cfg.db_path,
+    };
+    let db = session::store::StateStore::open(db_path)?;
 
     match cli.command {
         Some(Commands::Dashboard) | None => {
             tui::app::run(db, cfg).await?;
         }
-        Some(Commands::Fleet { command }) => {
-            feature_fleet::cli::execute(command, &db)?;
+        Some(Commands::Fleet(args)) => {
+            feature_fleet::cli::execute(args.command, &db)?;
         }
         Some(Commands::Start {
             task,

--- a/ecc2/src/main.rs
+++ b/ecc2/src/main.rs
@@ -1,5 +1,6 @@
 mod comms;
 mod config;
+mod feature_fleet;
 mod notifications;
 mod observability;
 mod session;
@@ -110,6 +111,11 @@ impl OptionalWorktreePolicyArgs {
 enum Commands {
     /// Launch the TUI dashboard
     Dashboard,
+    /// Experimental multi-feature planning and durable fleet state
+    Fleet {
+        #[command(subcommand)]
+        command: feature_fleet::cli::FleetCommand,
+    },
     /// Start a new agent session
     Start {
         /// Task description for the agent
@@ -1359,6 +1365,9 @@ async fn main() -> Result<()> {
     match cli.command {
         Some(Commands::Dashboard) | None => {
             tui::app::run(db, cfg).await?;
+        }
+        Some(Commands::Fleet { command }) => {
+            feature_fleet::cli::execute(command, &db)?;
         }
         Some(Commands::Start {
             task,

--- a/ecc2/src/session/migrations.rs
+++ b/ecc2/src/session/migrations.rs
@@ -1,0 +1,427 @@
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+
+pub const LATEST_SCHEMA_VERSION: i64 = 2;
+
+const BASELINE_PAYLOAD: &str = "ecc-state-store-legacy-baseline-v1";
+const FLEET_SCHEMA_SQL: &str = r#"
+CREATE TABLE feature_fleets (
+    id TEXT PRIMARY KEY,
+    schema_version TEXT NOT NULL,
+    title TEXT NOT NULL,
+    repo_root TEXT NOT NULL,
+    base_branch TEXT NOT NULL,
+    base_oid TEXT NOT NULL,
+    manifest_digest TEXT NOT NULL,
+    manifest_json TEXT NOT NULL,
+    revision INTEGER NOT NULL DEFAULT 1 CHECK(revision > 0),
+    lifecycle_state TEXT NOT NULL DEFAULT 'planned'
+        CHECK(lifecycle_state IN ('planned', 'running', 'reviewing', 'integrating', 'completed', 'failed')),
+    blockers_json TEXT NOT NULL DEFAULT '[]',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE fleet_features (
+    fleet_id TEXT NOT NULL REFERENCES feature_fleets(id) ON DELETE CASCADE,
+    feature_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    task TEXT NOT NULL,
+    dependencies_json TEXT NOT NULL DEFAULT '[]',
+    owns_json TEXT NOT NULL DEFAULT '[]',
+    contracts_json TEXT NOT NULL DEFAULT '[]',
+    checks_json TEXT NOT NULL DEFAULT '[]',
+    lifecycle_state TEXT NOT NULL DEFAULT 'planned'
+        CHECK(lifecycle_state IN ('planned', 'running', 'reviewing', 'integrating', 'completed', 'failed')),
+    blockers_json TEXT NOT NULL DEFAULT '[]',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (fleet_id, feature_id)
+);
+
+CREATE TABLE fleet_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    fleet_id TEXT NOT NULL REFERENCES feature_fleets(id) ON DELETE CASCADE,
+    fleet_revision INTEGER NOT NULL,
+    event_kind TEXT NOT NULL,
+    entity_kind TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    payload_json TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX idx_fleet_features_state
+    ON fleet_features(fleet_id, lifecycle_state, feature_id);
+CREATE INDEX idx_fleet_events_revision
+    ON fleet_events(fleet_id, fleet_revision, id);
+"#;
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct AppliedMigration {
+    pub version: i64,
+    pub name: String,
+    pub checksum: String,
+    pub applied_at: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MigrationSpec {
+    version: i64,
+    name: &'static str,
+    payload: &'static str,
+}
+
+const MIGRATIONS: [MigrationSpec; 2] = [
+    MigrationSpec {
+        version: 1,
+        name: "legacy_schema_baseline",
+        payload: BASELINE_PAYLOAD,
+    },
+    MigrationSpec {
+        version: 2,
+        name: "feature_fleet_planning_v1",
+        payload: FLEET_SCHEMA_SQL,
+    },
+];
+
+// Applied migrations are immutable: never rewrite a name or payload after merge.
+// Schema changes must append the next contiguous version.
+pub fn run_all<F>(connection: &Connection, apply_legacy_baseline: F) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    bootstrap(connection)?;
+    connection
+        .execute_batch("BEGIN IMMEDIATE")
+        .context("begin schema migration transaction")?;
+
+    let result = apply_pending(connection, apply_legacy_baseline).and_then(|_| {
+        connection
+            .execute_batch("COMMIT")
+            .context("commit schema migration transaction")
+    });
+    if let Err(error) = result {
+        let _ = connection.execute_batch("ROLLBACK");
+        anyhow::bail!("schema migration failed: {error:#}");
+    }
+    Ok(())
+}
+
+pub fn applied_migrations(connection: &Connection) -> Result<Vec<AppliedMigration>> {
+    bootstrap(connection)?;
+    let mut statement = connection.prepare(
+        "SELECT version, name, checksum, applied_at
+         FROM schema_migrations
+         ORDER BY version",
+    )?;
+    let migrations = statement
+        .query_map([], |row| {
+            Ok(AppliedMigration {
+                version: row.get(0)?,
+                name: row.get(1)?,
+                checksum: row.get(2)?,
+                applied_at: row.get(3)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(migrations)
+}
+
+fn bootstrap(connection: &Connection) -> Result<()> {
+    connection.execute_batch(
+        "CREATE TABLE IF NOT EXISTS schema_migrations (
+            version INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            checksum TEXT NOT NULL,
+            applied_at TEXT NOT NULL
+        );",
+    )?;
+    Ok(())
+}
+
+fn applied_by_version(connection: &Connection) -> Result<BTreeMap<i64, AppliedMigration>> {
+    Ok(applied_migrations(connection)?
+        .into_iter()
+        .map(|migration| (migration.version, migration))
+        .collect())
+}
+
+fn validate_existing(existing: &BTreeMap<i64, AppliedMigration>) -> Result<()> {
+    if let Some(version) = existing.keys().next_back() {
+        if *version > LATEST_SCHEMA_VERSION {
+            anyhow::bail!(
+                "Database schema version {version} is newer than supported version {LATEST_SCHEMA_VERSION}"
+            );
+        }
+    }
+
+    for version in existing.keys() {
+        if !MIGRATIONS
+            .iter()
+            .any(|migration| migration.version == *version)
+        {
+            anyhow::bail!("Unknown database migration version {version}");
+        }
+    }
+    for (index, version) in existing.keys().enumerate() {
+        let expected = index as i64 + 1;
+        if *version != expected {
+            anyhow::bail!(
+                "Database migration history is not contiguous: expected version {expected}, found {version}"
+            );
+        }
+    }
+
+    for migration in MIGRATIONS {
+        let Some(applied) = existing.get(&migration.version) else {
+            continue;
+        };
+        let expected_checksum = migration_checksum(migration);
+        if applied.name != migration.name || applied.checksum != expected_checksum {
+            anyhow::bail!(
+                "Migration {} checksum or name mismatch; database may be modified",
+                migration.version
+            );
+        }
+    }
+    Ok(())
+}
+
+fn apply_pending<F>(connection: &Connection, apply_legacy_baseline: F) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    let existing = applied_by_version(connection)?;
+    validate_existing(&existing)?;
+    let mut legacy = Some(apply_legacy_baseline);
+
+    for migration in MIGRATIONS {
+        if existing.contains_key(&migration.version) {
+            continue;
+        }
+        if migration.version == 1 {
+            legacy
+                .take()
+                .context("legacy baseline migration callback unavailable")?()
+            .with_context(|| format!("apply migration {}", migration.name))?;
+        } else {
+            connection
+                .execute_batch(migration.payload)
+                .with_context(|| format!("apply migration {}", migration.name))?;
+        }
+        connection
+            .execute(
+                "INSERT INTO schema_migrations(version, name, checksum, applied_at)
+                 VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![
+                    migration.version,
+                    migration.name,
+                    migration_checksum(migration),
+                    chrono::Utc::now().to_rfc3339()
+                ],
+            )
+            .with_context(|| format!("record migration {}", migration.version))?;
+    }
+    Ok(())
+}
+
+fn migration_checksum(migration: MigrationSpec) -> String {
+    let content = format!(
+        "{}\n{}\n{}",
+        migration.version, migration.name, migration.payload
+    );
+    Sha256::digest(content.as_bytes())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        applied_migrations, migration_checksum, run_all, LATEST_SCHEMA_VERSION, MIGRATIONS,
+    };
+    use rusqlite::Connection;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Barrier};
+    use std::time::Duration;
+
+    #[test]
+    fn migrations_are_numbered_and_idempotent() {
+        let connection = Connection::open_in_memory().expect("database");
+        run_all(&connection, || Ok(())).expect("first migration pass");
+        run_all(&connection, || panic!("applied migration must not rerun"))
+            .expect("second migration pass");
+
+        let applied = applied_migrations(&connection).expect("applied migrations");
+        assert_eq!(
+            applied
+                .iter()
+                .map(|entry| entry.version)
+                .collect::<Vec<_>>(),
+            (1..=LATEST_SCHEMA_VERSION).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn simultaneous_processes_apply_the_baseline_once() {
+        let db_path =
+            std::env::temp_dir().join(format!("ecc2-migration-race-{}.db", uuid::Uuid::new_v4()));
+        let barrier = Arc::new(Barrier::new(2));
+        let baseline_runs = Arc::new(AtomicUsize::new(0));
+        let handles = (0..2)
+            .map(|_| {
+                let db_path = db_path.clone();
+                let barrier = Arc::clone(&barrier);
+                let baseline_runs = Arc::clone(&baseline_runs);
+                std::thread::spawn(move || -> anyhow::Result<()> {
+                    let connection = Connection::open(db_path)?;
+                    connection.busy_timeout(Duration::from_secs(5))?;
+                    barrier.wait();
+                    run_all(&connection, || {
+                        baseline_runs.fetch_add(1, Ordering::SeqCst);
+                        connection
+                            .execute("CREATE TABLE IF NOT EXISTS legacy_marker(id INTEGER)", [])?;
+                        Ok(())
+                    })
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle
+                .join()
+                .expect("migration thread should not panic")
+                .expect("migration process should succeed");
+        }
+        assert_eq!(baseline_runs.load(Ordering::SeqCst), 1);
+
+        let connection = Connection::open(&db_path).expect("database");
+        assert_eq!(
+            applied_migrations(&connection).expect("migrations").len(),
+            LATEST_SCHEMA_VERSION as usize
+        );
+        drop(connection);
+        let _ = std::fs::remove_file(db_path);
+    }
+
+    #[test]
+    fn rejects_checksum_mismatch_and_newer_database() {
+        let connection = Connection::open_in_memory().expect("database");
+        run_all(&connection, || Ok(())).expect("migrations");
+        connection
+            .execute(
+                "UPDATE schema_migrations SET checksum = 'tampered' WHERE version = 1",
+                [],
+            )
+            .expect("tamper checksum");
+        let error = run_all(&connection, || Ok(())).expect_err("checksum mismatch");
+        assert!(error.to_string().contains("checksum"));
+
+        let newer = Connection::open_in_memory().expect("database");
+        run_all(&newer, || Ok(())).expect("migrations");
+        newer
+            .execute(
+                "INSERT INTO schema_migrations(version, name, checksum, applied_at)
+                 VALUES (?1, 'future', 'future', '2026-01-01T00:00:00Z')",
+                [LATEST_SCHEMA_VERSION + 1],
+            )
+            .expect("future migration");
+        let error = run_all(&newer, || Ok(())).expect_err("newer database rejected");
+        assert!(error.to_string().contains("newer"));
+    }
+
+    #[test]
+    fn rejects_unknown_historical_migration() {
+        let connection = Connection::open_in_memory().expect("database");
+        connection
+            .execute_batch(
+                "CREATE TABLE schema_migrations (
+                    version INTEGER PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    checksum TEXT NOT NULL,
+                    applied_at TEXT NOT NULL
+                );
+                INSERT INTO schema_migrations(version, name, checksum, applied_at)
+                VALUES (0, 'unknown', 'unknown', '2026-01-01T00:00:00Z');",
+            )
+            .expect("unknown migration");
+
+        let error = run_all(&connection, || Ok(())).expect_err("unknown migration rejected");
+        assert!(error.to_string().contains("Unknown database migration"));
+    }
+
+    #[test]
+    fn rejects_a_gap_in_migration_history() {
+        let connection = Connection::open_in_memory().expect("database");
+        let migration = MIGRATIONS[1];
+        connection
+            .execute_batch(
+                "CREATE TABLE schema_migrations (
+                    version INTEGER PRIMARY KEY,
+                    name TEXT NOT NULL,
+                    checksum TEXT NOT NULL,
+                    applied_at TEXT NOT NULL
+                );",
+            )
+            .expect("migration table");
+        connection
+            .execute(
+                "INSERT INTO schema_migrations(version, name, checksum, applied_at)
+                 VALUES (?1, ?2, ?3, '2026-01-01T00:00:00Z')",
+                rusqlite::params![
+                    migration.version,
+                    migration.name,
+                    migration_checksum(migration)
+                ],
+            )
+            .expect("out-of-order migration");
+
+        let error = run_all(&connection, || Ok(())).expect_err("migration gap rejected");
+        assert!(error.to_string().contains("not contiguous"));
+    }
+
+    #[test]
+    fn failed_migration_rolls_back_schema_and_version_record() {
+        let connection = Connection::open_in_memory().expect("database");
+        let error = run_all(&connection, || {
+            connection.execute("CREATE TABLE should_rollback(id INTEGER)", [])?;
+            anyhow::bail!("injected migration failure")
+        })
+        .expect_err("migration should fail");
+
+        assert!(error.to_string().contains("injected migration failure"));
+        let table_count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'should_rollback'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("table lookup");
+        assert_eq!(table_count, 0);
+    }
+
+    #[test]
+    fn database_keeps_blockers_orthogonal_to_lifecycle() {
+        let connection = Connection::open_in_memory().expect("database");
+        run_all(&connection, || Ok(())).expect("migrations");
+
+        let error = connection
+            .execute(
+                "INSERT INTO feature_fleets(
+                    id, schema_version, title, repo_root, base_branch, base_oid,
+                    manifest_digest, manifest_json, lifecycle_state, created_at, updated_at
+                 ) VALUES (
+                    'fleet', 'ecc.feature-fleet.v1', 'Fleet', '/repo', 'main',
+                    '1111111111111111111111111111111111111111', 'digest', '{}',
+                    'blocked', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'
+                 )",
+                [],
+            )
+            .expect_err("blocked is not a lifecycle state");
+        assert!(error.to_string().contains("CHECK constraint failed"));
+    }
+}

--- a/ecc2/src/session/mod.rs
+++ b/ecc2/src/session/mod.rs
@@ -1,5 +1,6 @@
 pub mod daemon;
 pub mod manager;
+pub(crate) mod migrations;
 pub mod output;
 pub mod runtime;
 pub mod store;

--- a/ecc2/src/session/store.rs
+++ b/ecc2/src/session/store.rs
@@ -166,6 +166,12 @@ impl StateStore {
     }
 
     fn init_schema(&self) -> Result<()> {
+        super::migrations::run_all(&self.conn, || self.apply_legacy_schema_v1())
+    }
+
+    // Frozen procedural baseline for migration 1. Append a numbered migration
+    // instead of changing this schema after Feature Fleet PR 1 lands.
+    fn apply_legacy_schema_v1(&self) -> Result<()> {
         self.conn.execute_batch(
             "
             CREATE TABLE IF NOT EXISTS sessions (
@@ -437,6 +443,10 @@ impl StateStore {
         self.ensure_session_board_columns()?;
         self.refresh_session_board_meta()?;
         Ok(())
+    }
+
+    pub(crate) fn connection(&self) -> &Connection {
+        &self.conn
     }
 
     fn ensure_session_columns(&self) -> Result<()> {
@@ -5178,6 +5188,14 @@ mod tests {
         assert!(column_names
             .iter()
             .any(|column| column == "last_heartbeat_at"));
+        let migration_versions = crate::session::migrations::applied_migrations(db.connection())?
+            .into_iter()
+            .map(|migration| migration.version)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            migration_versions,
+            (1..=crate::session::migrations::LATEST_SCHEMA_VERSION).collect::<Vec<_>>()
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## What Changed

- introduce numbered, checksum-verified SQLite migrations with a transactional legacy-schema baseline and cross-process-safe admission
- add an experimental `ecc fleet` surface in `feature_fleet/cli.rs` with `plan`, `create`, and `status`
- add a fleet-scoped `--state-db` override so dogfood runs do not mutate a project or normal ECC state
- record a typed `repository_dirty` Git blocker when the pinned OID omits working-tree or submodule changes
- validate strict TOML/JSON manifests, normalize semantic ordering, and bind them to a SHA-256 digest
- build deterministic feature DAGs and conservatively detect concurrent path/contract collisions
- persist fleets, features, typed blockers, pinned base OIDs, revisions, and semantic events atomically
- model lifecycle independently from blockers; every blocker carries a required resolution action
- define structured verification data without shell parsing and require explicit repository-trust intent
- add a runnable three-feature example and focused ECC2 README guidance

## Why This Change

This is PR 1 of the ECC 2.2 Feature Fleet sequence: a cohesive local workflow for planning multiple dependent features before any agent or worktree is launched. It establishes durable identity and safety invariants first, while leaving the three existing worktree/orchestration surfaces available as legacy workflows.

## Scope Boundary

This PR intentionally does **not** launch sessions, create fleet worktrees, execute checks, integrate branches, or clean up fleet resources.

- PR 2: revisioned admission, fleet-owned sessions, pinned-OID worktrees, dependency composition, and recovery
- PR 3: structured verification execution, evidence freshness, scope reconciliation, and the integration train
- PR 4: TUI, PR handoff, documentation expansion, and telemetry/export contracts

Local capabilities remain MIT. Hosted operation and advanced orchestration remain separate private/paid surfaces.

## Testing Done

- [x] Manual testing completed against Cadence Stage 1
- [x] Automated Rust tests pass locally (`cargo test --no-default-features`): 486 passed
- [x] Edge cases considered and tested
- [x] Focused tests cover migration rollback/idempotence/concurrency, legacy DB adoption, digest stability, invalid manifests, DAG cycles, collisions, atomic persistence, pinned-OID behavior, isolated state, and clean/dirty repository detection
- [x] `cargo clippy --no-default-features --all-targets` completes with no warnings in new Feature Fleet or migration code (the repository still reports pre-existing warnings)
- [x] `git diff --check`
- [ ] `node tests/run-all.js` (not applicable; ECC2 Rust-only change)

## Type of Change

- [x] `feat:` New feature
- [ ] `fix:` Bug fix
- [ ] `refactor:` Code refactoring
- [x] `docs:` Documentation
- [x] `test:` Tests

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] Manifest size/counts, branch names, repository-relative paths, executable tokens, environment names, timeouts, and output limits are validated
- [x] SQL writes use parameterized queries
- [x] Git resolution uses argument arrays, `--end-of-options`, and scrubbed inherited repository context
- [x] No verification command is shell-parsed or executed in this slice
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format
- [x] No dependency or package manifest changes

## Documentation

- [x] Updated `ecc2/README.md`
- [x] Added `ecc2/examples/feature-fleet.toml`
- [x] Added comments for migration immutability and the frozen legacy baseline
