### PR TITLE
fix(opencode): install to ~/.config/opencode instead of ~/.opencode

### DIFF
--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -38,7 +38,7 @@ Targets:
   antigravity  - Install rules, workflows, skills, and agents to ./.agent/
   codex        - Install shared agents/config into ~/.codex/
   gemini       - Install project-local Gemini config into ./.gemini/
-  opencode     - Install shared commands/hooks/config into ~/.opencode/
+  opencode     - Install shared commands/hooks/config into ~/.config/opencode/
   codebuddy    - Install commands, agents, skills, and flattened rules into ./.codebuddy/
   joycode      - Install commands, agents, skills, and flattened rules into ./.joycode/
   qwen         - Install commands, agents, skills, rules, and Qwen config into ~/.qwen/

--- a/scripts/lib/install-targets/opencode-home.js
+++ b/scripts/lib/install-targets/opencode-home.js
@@ -83,7 +83,7 @@ module.exports = createInstallTargetAdapter({
   id: 'opencode-home',
   target: 'opencode',
   kind: 'home',
-  rootSegments: ['.opencode'],
+  rootSegments: ['.config', 'opencode'],
   installStatePathSegments: ['ecc-install-state.json'],
   nativeRootRelativePath: '.opencode',
   validate: defaultValidateOpencodeHome,

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -971,8 +971,8 @@ function runTests() {
     assert.strictEqual(adapter.id, 'opencode-home');
     assert.strictEqual(adapter.target, 'opencode');
     assert.strictEqual(adapter.kind, 'home');
-    assert.strictEqual(root, path.join(homeDir, '.opencode'));
-    assert.strictEqual(statePath, path.join(homeDir, '.opencode', 'ecc-install-state.json'));
+    assert.strictEqual(root, path.join(homeDir, '.config', 'opencode'));
+    assert.strictEqual(statePath, path.join(homeDir, '.config', 'opencode', 'ecc-install-state.json'));
   })) passed++; else failed++;
 
   if (test('opencode adapter validate reports an error when compiled plugin is missing', () => {


### PR DESCRIPTION
## Summary

OpenCode natively uses `~/.config/opencode` per XDG conventions. The install target was writing to `~/.opencode`, which only worked on systems where that happened to be symlinked to `~/.config/opencode`. 

The MCP inventory reader (`scripts/lib/mcp-inventory/readers/opencode.js`) already looked in `~/.config/opencode`, so the installer and the reader were inconsistent.

## Changes

| File | Change |
|------|--------|
| `scripts/lib/install-targets/opencode-home.js:86` | `rootSegments: ['.opencode']` → `['.config', 'opencode']` |
| `scripts/install-apply.js:41` | Help text: `~/.opencode/` → `~/.config/opencode/` |
| `tests/lib/install-targets.test.js:974-975` | Assertions match new path |

The `nativeRootRelativePath: '.opencode'` stayed unchanged — that refers to the `.opencode/` source directory in the repo, not the install destination.

## Backward compatibility

Existing installs to `~/.opencode` (real dir or symlink) won't pick up future ECC installs automatically. Users can: `mv ~/.opencode ~/.config/opencode` if it's a real directory, or ensure the symlink exists.

## Verification

```
node --test tests/lib/install-targets.test.js  →  42/42 passed
```