### PR TITLE
fix(skill-stocktake): follow symlinks and match only SKILL.md in scans

### DIFF
--- a/skills/skill-stocktake/scripts/quick-diff.sh
+++ b/skills/skill-stocktake/scripts/quick-diff.sh
@@ -51,6 +51,17 @@ i=0
 
 process_dir() {
   local dir="$1"
+  local find_out="$tmpdir/.find-stdout"
+  local find_err="$tmpdir/.find-stderr"
+  # Capture find's exit status and stderr instead of discarding them: with -L,
+  # a broken symlink or unreadable directory makes find skip that entry AND
+  # exit non-zero, which would otherwise silently under-count skills.
+  if ! find -L "$dir" -name "SKILL.md" -type f >"$find_out" 2>"$find_err"; then
+    echo "Warning: find encountered errors while scanning $dir (broken symlinks or permission issues may cause skills to be missed):" >&2
+    cat "$find_err" >&2
+  fi
+  sort -o "$find_out" "$find_out"
+
   while IFS= read -r file; do
     local mtime dp is_new
     mtime=$(date -u -r "$file" +%Y-%m-%dT%H:%M:%SZ)
@@ -74,7 +85,7 @@ process_dir() {
       '{path:$path,mtime:$mtime,is_new:$is_new}' \
       > "$tmpdir/$i.json"
     i=$((i+1))
-  done < <(find -L "$dir" -name "SKILL.md" -type f 2>/dev/null | sort)
+  done < "$find_out"
 }
 
 [[ -d "$GLOBAL_DIR" ]] && process_dir "$GLOBAL_DIR"

--- a/skills/skill-stocktake/scripts/quick-diff.sh
+++ b/skills/skill-stocktake/scripts/quick-diff.sh
@@ -56,13 +56,15 @@ process_dir() {
   # Capture find's exit status and stderr instead of discarding them: with -L,
   # a broken symlink or unreadable directory makes find skip that entry AND
   # exit non-zero, which would otherwise silently under-count skills.
-  if ! find -L "$dir" -name "SKILL.md" -type f >"$find_out" 2>"$find_err"; then
+  # NUL-delimited (-print0 / sort -z / read -d '') so a path containing a
+  # literal newline can't desync record boundaries — paths here are untrusted.
+  if ! find -L "$dir" -name "SKILL.md" -type f -print0 >"$find_out" 2>"$find_err"; then
     echo "Warning: find encountered errors while scanning $dir (broken symlinks or permission issues may cause skills to be missed):" >&2
     cat "$find_err" >&2
   fi
-  sort -o "$find_out" "$find_out"
+  sort -z -o "$find_out" "$find_out"
 
-  while IFS= read -r file; do
+  while IFS= read -r -d '' file; do
     local mtime dp is_new
     mtime=$(date -u -r "$file" +%Y-%m-%dT%H:%M:%SZ)
     dp="${file/#$HOME/~}"

--- a/skills/skill-stocktake/scripts/quick-diff.sh
+++ b/skills/skill-stocktake/scripts/quick-diff.sh
@@ -74,7 +74,7 @@ process_dir() {
       '{path:$path,mtime:$mtime,is_new:$is_new}' \
       > "$tmpdir/$i.json"
     i=$((i+1))
-  done < <(find "$dir" -name "*.md" -type f 2>/dev/null | sort)
+  done < <(find -L "$dir" -name "SKILL.md" -type f 2>/dev/null | sort)
 }
 
 [[ -d "$GLOBAL_DIR" ]] && process_dir "$GLOBAL_DIR"

--- a/skills/skill-stocktake/scripts/scan.sh
+++ b/skills/skill-stocktake/scripts/scan.sh
@@ -118,7 +118,7 @@ scan_dir_to_json() {
       '{path:$path,name:$name,description:$description,use_7d:$use_7d,use_30d:$use_30d,mtime:$mtime}' \
       > "$tmpdir/$i.json"
     i=$((i+1))
-  done < <(find "$dir" -name "*.md" -type f 2>/dev/null | sort)
+  done < <(find -L "$dir" -name "SKILL.md" -type f 2>/dev/null | sort)
 
   if [[ $i -eq 0 ]]; then
     echo "[]"

--- a/skills/skill-stocktake/scripts/scan.sh
+++ b/skills/skill-stocktake/scripts/scan.sh
@@ -95,6 +95,17 @@ scan_dir_to_json() {
   fi
 
   local i=0
+  local find_out="$tmpdir/.find-stdout"
+  local find_err="$tmpdir/.find-stderr"
+  # Capture find's exit status and stderr instead of discarding them: with -L,
+  # a broken symlink or unreadable directory makes find skip that entry AND
+  # exit non-zero, which would otherwise silently under-count skills.
+  if ! find -L "$dir" -name "SKILL.md" -type f >"$find_out" 2>"$find_err"; then
+    echo "Warning: find encountered errors while scanning $dir (broken symlinks or permission issues may cause skills to be missed):" >&2
+    cat "$find_err" >&2
+  fi
+  sort -o "$find_out" "$find_out"
+
   while IFS= read -r file; do
     local name desc mtime u7 u30 dp
     name=$(extract_field "$file" "name")
@@ -118,7 +129,7 @@ scan_dir_to_json() {
       '{path:$path,name:$name,description:$description,use_7d:$use_7d,use_30d:$use_30d,mtime:$mtime}' \
       > "$tmpdir/$i.json"
     i=$((i+1))
-  done < <(find -L "$dir" -name "SKILL.md" -type f 2>/dev/null | sort)
+  done < "$find_out"
 
   if [[ $i -eq 0 ]]; then
     echo "[]"

--- a/skills/skill-stocktake/scripts/scan.sh
+++ b/skills/skill-stocktake/scripts/scan.sh
@@ -100,13 +100,15 @@ scan_dir_to_json() {
   # Capture find's exit status and stderr instead of discarding them: with -L,
   # a broken symlink or unreadable directory makes find skip that entry AND
   # exit non-zero, which would otherwise silently under-count skills.
-  if ! find -L "$dir" -name "SKILL.md" -type f >"$find_out" 2>"$find_err"; then
+  # NUL-delimited (-print0 / sort -z / read -d '') so a path containing a
+  # literal newline can't desync record boundaries — paths here are untrusted.
+  if ! find -L "$dir" -name "SKILL.md" -type f -print0 >"$find_out" 2>"$find_err"; then
     echo "Warning: find encountered errors while scanning $dir (broken symlinks or permission issues may cause skills to be missed):" >&2
     cat "$find_err" >&2
   fi
-  sort -o "$find_out" "$find_out"
+  sort -z -o "$find_out" "$find_out"
 
-  while IFS= read -r file; do
+  while IFS= read -r -d '' file; do
     local name desc mtime u7 u30 dp
     name=$(extract_field "$file" "name")
     desc=$(extract_field "$file" "description")

--- a/tests/scripts/skill-stocktake-discovery.test.js
+++ b/tests/scripts/skill-stocktake-discovery.test.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const scanScript = path.join(repoRoot, 'skills', 'skill-stocktake', 'scripts', 'scan.sh');
+const quickDiffScript = path.join(repoRoot, 'skills', 'skill-stocktake', 'scripts', 'quick-diff.sh');
+
+let passed = 0;
+let failed = 0;
+
+function test(description, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${description}`);
+    passed++;
+  } catch (error) {
+    console.log(`  ✗ ${description}: ${error.message}`);
+    failed++;
+  }
+}
+
+function writeSkill(skillDir, name) {
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: test fixture\n---\n# ${name}\n`,
+  );
+}
+
+function runBash(scriptPath, args, env) {
+  return spawnSync('bash', [scriptPath, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+}
+
+console.log('\nSkill stocktake discovery tests:');
+
+test('both scanners use canonical, error-visible, NUL-delimited discovery', () => {
+  for (const scriptPath of [scanScript, quickDiffScript]) {
+    const source = fs.readFileSync(scriptPath, 'utf8');
+    assert.match(source, /find -L "\$dir" -name "SKILL\.md" -type f -print0/);
+    assert.match(source, /sort -z -o "\$find_out" "\$find_out"/);
+    assert.match(source, /read -r -d '' file/);
+    assert.doesNotMatch(source, /find [^\n]*2>\/dev\/null/, `${path.basename(scriptPath)} still hides find errors`);
+  }
+});
+
+if (process.platform === 'win32') {
+  console.log('  ↷ POSIX symlink and newline-path integration cases skipped on Windows');
+} else {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-skill-stocktake-'));
+  try {
+    const projectSkills = path.join(tempRoot, 'project', '.claude', 'skills');
+    const directSkill = path.join(projectSkills, 'direct-skill');
+    const linkedTarget = path.join(tempRoot, 'shared', 'linked-skill');
+    const newlineSkill = path.join(projectSkills, 'newline\nskill');
+    const resultsPath = path.join(tempRoot, 'results.json');
+
+    writeSkill(directSkill, 'direct-skill');
+    writeSkill(linkedTarget, 'linked-skill');
+    writeSkill(newlineSkill, 'newline-skill');
+    fs.symlinkSync(linkedTarget, path.join(projectSkills, 'linked-skill'), 'dir');
+    fs.mkdirSync(path.join(directSkill, 'references'), { recursive: true });
+    fs.writeFileSync(path.join(directSkill, 'references', 'notes.md'), '# supporting notes\n');
+    fs.writeFileSync(
+      resultsPath,
+      JSON.stringify({ evaluated_at: '2099-01-01T00:00:00Z', skills: [] }),
+    );
+
+    const env = {
+      SKILL_STOCKTAKE_GLOBAL_DIR: path.join(tempRoot, 'missing-global'),
+      SKILL_STOCKTAKE_PROJECT_DIR: projectSkills,
+      SKILL_STOCKTAKE_OBSERVATIONS: path.join(tempRoot, 'missing-observations.jsonl'),
+    };
+
+    test('scan follows symlinked skills and ignores nested Markdown assets', () => {
+      const result = runBash(scanScript, [], env);
+      assert.strictEqual(result.status, 0, result.stderr);
+      const output = JSON.parse(result.stdout);
+      assert.strictEqual(output.scan_summary.project.count, 3);
+      assert.deepStrictEqual(
+        output.skills.map(skill => skill.name).sort(),
+        ['direct-skill', 'linked-skill', 'newline-skill'],
+      );
+    });
+
+    test('quick diff keeps newline-containing skill paths as one record', () => {
+      const result = runBash(quickDiffScript, [resultsPath], env);
+      assert.strictEqual(result.status, 0, result.stderr);
+      const output = JSON.parse(result.stdout);
+      assert.strictEqual(output.length, 3);
+      assert.strictEqual(
+        output.filter(entry => entry.path.includes('newline\nskill/SKILL.md')).length,
+        1,
+      );
+      assert.ok(output.every(entry => entry.is_new === true));
+    });
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

- `scan.sh:121` and `quick-diff.sh:77` both used `find "$dir" -name "*.md" -type f`, which had two defects:
  - No `-L`, so symlinked skill directories were invisible to the audit.
  - Matched `*.md` instead of `SKILL.md`, so any non-skill markdown file sitting in a skills directory was miscounted as a skill.
- Both call sites now use `find -L "$dir" -name "SKILL.md" -type f`.

## Repro

Built a temp directory containing: one real skill, one skill directory that's a symlink to an external target, and one stray non-skill `.md` file sitting in the skills dir.

**Before fix** (main, `scan.sh`):
```json
{
  "project_count": 2,
  "paths": [
    ".../actual-skill/SKILL.md",
    ".../NOTES.md"
  ]
}
```
The stray `NOTES.md` is wrongly counted as a skill, and the symlinked skill is invisible entirely.

**After fix**:
```json
{
  "project_count": 2,
  "paths": [
    ".../actual-skill/SKILL.md",
    ".../symlinked-skill/SKILL.md"
  ]
}
```
The symlinked skill is now correctly picked up and the stray markdown file is excluded. Same before/after behavior confirmed for `quick-diff.sh`.

## Test plan

- [x] `npm test` — 3385/3385 passed
- [x] `npm run lint` — clean
- [x] Manual repro against both `scan.sh` and `quick-diff.sh`, diffed against pre-fix behavior from `main`

Fixes #2598

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhDjpSfrbPpnpqT3CZBEX1