### PR TITLE
feat: add OpenSpec validators, spec-miner registration, real fixtures

### DIFF
--- a/manifests/install-components.json
+++ b/manifests/install-components.json
@@ -399,6 +399,14 @@
       ]
     },
     {
+      "id": "agent:spec-miner",
+      "family": "agent",
+      "description": "Behavioral spec extraction agent for brownfield codebases.",
+      "modules": [
+        "agents-core"
+      ]
+    },
+    {
       "id": "agent:tdd-guide",
       "family": "agent",
       "description": "Test-driven development guidance agent.",

--- a/scripts/ci/check-spec-freshness.js
+++ b/scripts/ci/check-spec-freshness.js
@@ -1,0 +1,411 @@
+#!/usr/bin/env node
+/**
+ * Check OpenSpec freshness at FILE level.
+ *
+ * ── v1 contract ─────────────────────────────────────────────────
+ * For each spec file under <root>/openspec/, parse its `<!-- enforced: -->`
+ * anchors and the `Last verified:` date, then ask git whether the anchor's
+ * TARGET FILE changed after that date. This is a FILE-LEVEL freshness check:
+ * the `::symbol` part of an anchor is recorded but never resolved — verifying
+ * that a symbol exists inside a file is out of scope for v1.
+ *
+ * Truthful verdicts (a spec resolves to the strongest of these):
+ *   FRESH       every enforced target exists, is inside the project, is
+ *               committed, and has not changed since `Last verified`
+ *   STALE       an enforced target changed after `Last verified`, or the
+ *               verification itself is older than ECC_SPEC_STALE_DAYS
+ *   ORPHANED    an enforced target file is missing from the tree or escapes
+ *               the project (via `..` or a symlink out of the root)
+ *   UNVERIFIED  no git / not a repo / SHALLOW clone / missing or invalid
+ *               `Last verified` date / target file never committed — i.e.
+ *               evidence is unavailable, NOT a sign of staleness
+ *   UNKNOWN     an enforced anchor does not parse to path::symbol
+ *
+ * Safety:
+ *   - git is always invoked through execFileSync with an argv array. Paths are
+ *     passed after `--`; the date is validated to YYYY-MM-DD first and passed
+ *     as a single argument. Nothing from spec Markdown reaches a shell.
+ *   - the project root must not be a symlink; every enforced target is resolved
+ *     through fs.realpathSync and must stay inside the real project root.
+ *   - shallow clones report UNVERIFIED — incomplete history is never
+ *     mislabelled ORPHANED or STALE.
+ *
+ * Exit contract:
+ *   0 = no stale specs (or ECC_SPEC_STALE_WARN_ONLY === "true")
+ *   1 = at least one stale spec (STALE only; ORPHANED/UNVERIFIED are reported,
+ *       not gating failures)
+ *   2 = configuration / input error
+ *
+ * Output: single JSON line to stdout {specs[], staleCount, totalCount}
+ * Diagnostics: all prose to stderr
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+// ── CLI args & env ──────────────────────────────────────────────
+
+function resolveProjectRoot() {
+  const rootIdx = process.argv.indexOf('--project-root');
+  if (rootIdx !== -1 && rootIdx + 1 < process.argv.length) {
+    return process.argv[rootIdx + 1];
+  }
+  if (process.env.ECC_SPEC_PROJECT_ROOT) {
+    return process.env.ECC_SPEC_PROJECT_ROOT;
+  }
+  return process.cwd();
+}
+
+function resolveStaleDays() {
+  const envVal = process.env.ECC_SPEC_STALE_DAYS;
+  if (envVal === undefined || envVal === '') {
+    return 30; // Default
+  }
+  // Strict integer (reject "1.5", "0x10", "+3", etc.), not parseInt coercion.
+  if (!/^\d+$/.test(envVal)) {
+    console.error(`FATAL: ECC_SPEC_STALE_DAYS must be an integer 1-365, got: "${envVal}"`);
+    process.exit(2);
+  }
+  const days = parseInt(envVal, 10);
+  if (days <= 0 || days > 365) {
+    console.error(`FATAL: ECC_SPEC_STALE_DAYS must be an integer 1-365, got: "${envVal}"`);
+    process.exit(2);
+  }
+  return days;
+}
+
+const WARN_ONLY = process.env.ECC_SPEC_STALE_WARN_ONLY === 'true';
+
+function die(message) {
+  console.error(`FATAL: ${message}`);
+  process.exit(2);
+}
+
+// ── Root validation (real-path contained) ───────────────────────
+
+const projectRootArg = resolveProjectRoot();
+const staleDays = resolveStaleDays();
+
+let rootStat;
+try {
+  rootStat = fs.lstatSync(projectRootArg);
+} catch (err) {
+  die(`Cannot access --project-root: ${projectRootArg} (${err.message})`);
+}
+if (!rootStat.isDirectory()) {
+  die(`--project-root is not a directory: ${projectRootArg}`);
+}
+if (rootStat.isSymbolicLink()) {
+  die(`--project-root must not be a symlink: ${projectRootArg}`);
+}
+
+const projectRoot = fs.realpathSync(projectRootArg);
+const openspecDir = path.join(projectRoot, 'openspec');
+
+// ── v1 parsing constants ────────────────────────────────────────
+
+const ENFORCED_RE = /<!--\s*enforced:\s*(.*?)\s*-->/g;
+const LAST_VERIFIED_RE = /^[>\s]*last\s+verified:\s*(.*)$/im;
+const DATE_RE = /(\d{4}-\d{2}-\d{2})/;
+
+/** Parse `path::symbol`; reject whitespace, absolute paths, `..`, backslashes. */
+function parseAnchor(raw) {
+  const trimmed = raw.trim();
+  if (trimmed === '' || /\s/.test(trimmed)) {
+    return { invalid: true, reason: 'must not contain whitespace' };
+  }
+  const sep = trimmed.indexOf('::');
+  if (sep <= 0 || sep === trimmed.length - 2) {
+    return { invalid: true, reason: 'expected <path>::<symbol>' };
+  }
+  const anchorPath = trimmed.slice(0, sep);
+  const symbol = trimmed.slice(sep + 2);
+  if (anchorPath.startsWith('/')) {
+    return { invalid: true, reason: 'path must be repo-relative (no leading "/")' };
+  }
+  if (anchorPath.includes('\\')) {
+    return { invalid: true, reason: 'path must use forward slashes' };
+  }
+  if (anchorPath.split('/').includes('..')) {
+    return { invalid: true, reason: 'path must not traverse outside the project ("../")' };
+  }
+  return { path: anchorPath, symbol };
+}
+
+/** Extract a validated calendar date (YYYY-MM-DD) from a `Last verified` value. */
+function parseVerifiedDate(rawValue) {
+  const m = rawValue.match(DATE_RE);
+  if (!m) return null;
+  const time = new Date(`${m[1]}T00:00:00Z`).getTime();
+  if (Number.isNaN(time)) return null;
+  return { date: m[1], time };
+}
+
+function isInside(base, candidate) {
+  const rel = path.relative(base, candidate);
+  return rel === '' || (!rel.startsWith(`..${path.sep}`) && rel !== '..' && !path.isAbsolute(rel));
+}
+
+// ── Git helpers (argv only, never a shell string) ───────────────
+
+let gitState = null;
+
+function gitProbe() {
+  if (gitState !== null) return gitState;
+  gitState = { available: false, repo: false, shallow: false };
+  try {
+    execFileSync('git', ['--version'], { stdio: 'ignore', cwd: projectRoot });
+    gitState.available = true;
+  } catch {
+    return gitState;
+  }
+  try {
+    execFileSync('git', ['rev-parse', '--git-dir'], { stdio: 'ignore', cwd: projectRoot });
+    gitState.repo = true;
+  } catch {
+    return gitState;
+  }
+  try {
+    const out = execFileSync('git', ['rev-parse', '--is-shallow-repository'], {
+      encoding: 'utf8',
+      cwd: projectRoot,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    gitState.shallow = out === 'true';
+  } catch {
+    gitState.shallow = false;
+  }
+  return gitState;
+}
+
+/** stdout of `git log --format=%H --after=<date> -- <path>` (empty when none). */
+function gitHashesAfter(date, anchorPath) {
+  const out = execFileSync(
+    'git',
+    ['log', '--format=%H', `--after=${date}`, '--', anchorPath],
+    { encoding: 'utf8', cwd: projectRoot, stdio: ['pipe', 'pipe', 'pipe'] }
+  );
+  return out.trim().split('\n').filter(Boolean);
+}
+
+function gitAllHashes(anchorPath) {
+  const out = execFileSync(
+    'git',
+    ['log', '--format=%H', '--', anchorPath],
+    { encoding: 'utf8', cwd: projectRoot, stdio: ['pipe', 'pipe', 'pipe'] }
+  );
+  return out.trim().split('\n').filter(Boolean);
+}
+
+/**
+ * File-level freshness for one enforced target.
+ * @returns {{ status: string, reason?: string }}
+ */
+function targetFreshness(anchorPath) {
+  const probe = gitProbe();
+  if (!probe.available || !probe.repo) {
+    return { status: 'UNVERIFIED', reason: 'git unavailable or not a repository' };
+  }
+  if (probe.shallow) {
+    return { status: 'UNVERIFIED', reason: 'shallow clone — history incomplete' };
+  }
+
+  const resolved = path.resolve(projectRoot, anchorPath);
+  if (!isInside(projectRoot, resolved)) {
+    return { status: 'ORPHANED', reason: `target escapes project root: ${anchorPath}` };
+  }
+
+  let real;
+  try {
+    real = fs.realpathSync(resolved);
+  } catch {
+    return { status: 'ORPHANED', reason: `target file not found: ${anchorPath}` };
+  }
+  if (!isInside(projectRoot, real)) {
+    return { status: 'ORPHANED', reason: `target resolves outside project (symlink): ${anchorPath}` };
+  }
+
+  let all;
+  try {
+    all = gitAllHashes(anchorPath);
+  } catch (err) {
+    return { status: 'UNVERIFIED', reason: `git error: ${err.message}` };
+  }
+  if (all.length === 0) {
+    return { status: 'UNVERIFIED', reason: `target has no git history: ${anchorPath}` };
+  }
+  return { status: 'FRESH' }; // changed-after is decided by the caller with the date
+}
+
+// ── Spec walking & parsing ──────────────────────────────────────
+
+function walkMdFiles(dir) {
+  const results = [];
+  if (!fs.existsSync(dir)) return results;
+  let stat;
+  try {
+    stat = fs.statSync(dir);
+  } catch {
+    return results;
+  }
+  if (!stat.isDirectory()) return results;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkMdFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+function parseSpecFile(filePath) {
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return { error: 'unreadable' };
+  }
+
+  const enforced = [];
+  let m;
+  const re = new RegExp(ENFORCED_RE.source, 'g');
+  while ((m = re.exec(content)) !== null) {
+    enforced.push(m[1].trim());
+  }
+
+  const lv = content.match(LAST_VERIFIED_RE);
+  const lastVerifiedRaw = lv ? lv[1].trim() : null;
+
+  return { enforced, lastVerifiedRaw, error: null };
+}
+
+/**
+ * @returns {{ status, path, lastVerified?, enforced?, reasons? }}
+ */
+function evaluateSpec(relPath, parsed) {
+  const { enforced, lastVerifiedRaw } = parsed;
+  const base = { path: relPath };
+
+  if (lastVerifiedRaw === null) {
+    return {
+      ...base,
+      status: 'UNVERIFIED',
+      enforced: enforced.length > 0 ? enforced : undefined,
+      reasons: ['missing "Last verified:" date'],
+    };
+  }
+
+  const verified = parseVerifiedDate(lastVerifiedRaw);
+  if (!verified) {
+    return {
+      ...base,
+      status: 'UNVERIFIED',
+      enforced: enforced.length > 0 ? enforced : undefined,
+      lastVerified: lastVerifiedRaw,
+      reasons: [`unparseable "Last verified:" value: "${lastVerifiedRaw}"`],
+    };
+  }
+
+  if (enforced.length === 0) {
+    return { ...base, status: 'FRESH', lastVerified: verified.date };
+  }
+
+  const ageDays = (Date.now() - verified.time) / 86400000;
+  const reasons = [];
+  const weights = { STALE: 4, ORPHANED: 3, UNVERIFIED: 2, UNKNOWN: 1, FRESH: 0 };
+  let status = 'FRESH';
+  const bump = (s) => {
+    if (weights[s] > weights[status]) status = s;
+  };
+
+  for (const raw of enforced) {
+    const anchor = parseAnchor(raw);
+    if (anchor.invalid) {
+      bump('UNKNOWN');
+      reasons.push(`invalid enforced anchor "${raw}" (${anchor.reason})`);
+      continue;
+    }
+    if (ageDays > staleDays) {
+      bump('STALE');
+      reasons.push(`Last verified ${Math.round(ageDays)} days ago (threshold: ${staleDays} days)`);
+    }
+    const verdict = targetFreshness(anchor.path);
+    if (verdict.status !== 'FRESH') {
+      bump(verdict.status);
+      reasons.push(`"${anchor.path}": ${verdict.reason}`);
+      continue;
+    }
+    // File exists & is committed: was it changed after the verification date?
+    let changed;
+    try {
+      changed = gitHashesAfter(verified.date, anchor.path).length > 0;
+    } catch (err) {
+      bump('UNVERIFIED');
+      reasons.push(`"${anchor.path}": git error: ${err.message}`);
+      continue;
+    }
+    if (changed) {
+      bump('STALE');
+      reasons.push(`"${anchor.path}" changed after last verified ${verified.date}`);
+    }
+  }
+
+  return {
+    ...base,
+    status,
+    enforced,
+    lastVerified: verified.date,
+    reasons: reasons.length > 0 ? reasons : undefined,
+  };
+}
+
+// ── Main ────────────────────────────────────────────────────────
+
+function main() {
+  if (!fs.existsSync(openspecDir)) {
+    console.log(JSON.stringify({ specs: [], staleCount: 0, totalCount: 0 }));
+    process.exit(0);
+  }
+
+  const mdFiles = walkMdFiles(openspecDir);
+  if (mdFiles.length === 0) {
+    console.log(JSON.stringify({ specs: [], staleCount: 0, totalCount: 0 }));
+    process.exit(0);
+  }
+
+  const specs = [];
+  for (const filePath of mdFiles) {
+    const parsed = parseSpecFile(filePath);
+    const relPath = path.relative(openspecDir, filePath);
+    if (parsed.error) {
+      specs.push({ path: relPath, status: 'UNKNOWN' });
+      console.error(`WARNING: could not parse ${relPath}: ${parsed.error}`);
+      continue;
+    }
+    specs.push(evaluateSpec(relPath, parsed));
+  }
+
+  const staleCount = specs.filter((s) => s.status === 'STALE').length;
+  const result = { specs, staleCount, totalCount: specs.length };
+
+  for (const spec of specs) {
+    if (spec.reasons) {
+      console.error(`INFO: ${spec.path}: ${spec.status} — ${spec.reasons.join('; ')}`);
+    }
+  }
+  console.error(`Checked ${specs.length} spec(s): ${staleCount} stale.`);
+
+  console.log(JSON.stringify(result));
+
+  if (staleCount > 0 && !WARN_ONLY) {
+    process.exit(1);
+  }
+  process.exit(0);
+}
+
+main();

--- a/scripts/ci/validate-openspec-syntax.js
+++ b/scripts/ci/validate-openspec-syntax.js
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+/**
+ * Validate OpenSpec markdown against the v1 schema contract.
+ *
+ * ── v1 schema contract (source of truth) ─────────────────────────
+ * Baseline spec file (contains Requirement/Invariant blocks):
+ *   - `### Requirement: <title>` MUST have at least one
+ *     `#### Scenario: <name>` child.
+ *   - `### Invariant: <title>` MUST carry an `<!-- enforced: -->` anchor.
+ *   - YAML frontmatter is OPTIONAL. When present it is not validated here.
+ * Delta file (contains `<!-- ADDED: -->`, `<!-- MODIFIED: -->`,
+ *   `<!-- REMOVED: -->` markers):
+ *   - Each DECLARED block MUST be non-empty. An empty block is an error even
+ *     when a later block has content.
+ *
+ * Metadata HTML comments — keys are an explicit allowlist:
+ *   id, entities, enforced, test, depends_on, triggers, verified_by,
+ *   status, removal_reason, deferred, uncertainty
+ *   - key on the allowlist              → metadata (no value rule beyond non-marker)
+ *   - key machine-shaped (`[a-z][a-z0-9_-]*`) but NOT on the allowlist
+ *                                        → ERROR (typo guard)
+ *   - everything else (`Note:`, `TODO:`, no colon) → ordinary comment, allowed
+ * ADDED/MODIFIED/REMOVED are structural delta markers, not metadata.
+ *
+ * Enforced anchor grammar:
+ *   <!-- enforced: <repo-relative/path.ext>::<symbol> -->
+ *   relative path + symbol, no whitespace, no leading "/", no "../" or
+ *   backslash traversal. This is the FILE-LEVEL anchor; symbol resolution is
+ *   out of scope for v1 (freshness checks target the file, not the symbol).
+ *
+ * Output: single JSON line to stdout {valid, errors[]}
+ * Diagnostics: all prose to stderr
+ * Exit: 0 = valid, 1 = one or more validation errors, 2 = config/input error
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+// ── CLI args & env ──────────────────────────────────────────────
+
+function resolveOpenspecRoot() {
+  const rootIdx = process.argv.indexOf('--openspec-root');
+  if (rootIdx !== -1 && rootIdx + 1 < process.argv.length) {
+    return process.argv[rootIdx + 1];
+  }
+  if (process.env.ECC_OPENSPEC_ROOT) {
+    return process.env.ECC_OPENSPEC_ROOT;
+  }
+  return process.cwd();
+}
+
+const openspecRoot = resolveOpenspecRoot();
+
+function die(message, exitCode) {
+  console.error(`FATAL: ${message}`);
+  process.exit(exitCode);
+}
+
+try {
+  const stat = fs.statSync(openspecRoot);
+  if (!stat.isDirectory()) {
+    die(`--openspec-root is not a directory: ${openspecRoot}`, 2);
+  }
+} catch (err) {
+  die(`Cannot access --openspec-root: ${openspecRoot} (${err.message})`, 2);
+}
+
+const openspecDir = path.join(openspecRoot, 'openspec');
+
+// ── v1 schema constants ─────────────────────────────────────────
+
+const METADATA_ALLOWLIST = new Set([
+  'id',
+  'entities',
+  'enforced',
+  'test',
+  'depends_on',
+  'triggers',
+  'verified_by',
+  'status',
+  'removal_reason',
+  'deferred',
+  'uncertainty',
+]);
+
+const MACHINE_KEY_RE = /^[a-z][a-z0-9_-]*$/;
+const REQUIREMENT_RE = /^###\s+Requirement:\s*(.+)$/;
+const INVARIANT_RE = /^###\s+Invariant:\s*(.+)$/;
+const SCENARIO_RE = /^####\s+Scenario:\s*/m;
+const HTML_COMMENT_RE = /<!--([\s\S]*?)-->/g;
+const ENFORCED_RE = /<!--\s*enforced:\s*(.*?)\s*-->/g;
+const DELTA_MARKER_RE = /<!--\s*(ADDED|MODIFIED|REMOVED)\s*:\s*-->/g;
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function walkMdFiles(dir) {
+  const results = [];
+  if (!fs.existsSync(dir)) return results;
+  let stat;
+  try {
+    stat = fs.statSync(dir);
+  } catch {
+    return results;
+  }
+  if (!stat.isDirectory()) return results;
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkMdFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/**
+ * Validate an enforced anchor string against the v1 grammar.
+ * @returns {{ path: string, symbol: string } | { invalid: true, reason: string }}
+ */
+function parseAnchor(raw) {
+  const trimmed = raw.trim();
+  if (trimmed === '' || /\s/.test(trimmed)) {
+    return { invalid: true, reason: 'must not contain whitespace' };
+  }
+  const sep = trimmed.indexOf('::');
+  if (sep <= 0 || sep === trimmed.length - 2) {
+    return { invalid: true, reason: 'expected <path>::<symbol>' };
+  }
+  const anchorPath = trimmed.slice(0, sep);
+  const symbol = trimmed.slice(sep + 2);
+  if (anchorPath.startsWith('/')) {
+    return { invalid: true, reason: 'path must be repo-relative (no leading "/")' };
+  }
+  if (anchorPath.includes('\\')) {
+    return { invalid: true, reason: 'path must use forward slashes' };
+  }
+  const segments = anchorPath.split('/');
+  if (segments.includes('..')) {
+    return { invalid: true, reason: 'path must not traverse outside the project ("../")' };
+  }
+  return { path: anchorPath, symbol };
+}
+
+const INVALID_ANCHOR_MSG = (rel, raw, reason) =>
+  `${rel}: Invalid enforced anchor "${raw}" (${reason}; expected <relative/path.ext>::<symbol>)`;
+
+/**
+ * Walk every HTML comment in a file and classify it.
+ * Returns { errors, metadata[] } — metadata entries not currently consumed by
+ * structural checks, but presence of an error means the file is invalid.
+ */
+function classifyComments(rel, content, errors) {
+  const meta = [];
+  let match;
+  const re = new RegExp(HTML_COMMENT_RE.source, 'g');
+  while ((match = re.exec(content)) !== null) {
+    const body = match[1].trim();
+    if (body === '') continue;
+    const colon = body.indexOf(':');
+    if (colon === -1) continue; // ordinary comment
+    const key = body.slice(0, colon).trim();
+    const value = body.slice(colon + 1).trim();
+
+    // Structural delta markers are not metadata.
+    if (key === 'ADDED' || key === 'MODIFIED' || key === 'REMOVED') continue;
+
+    if (METADATA_ALLOWLIST.has(key)) {
+      meta.push({ key, value });
+      continue;
+    }
+    if (MACHINE_KEY_RE.test(key)) {
+      errors.push(`${rel}: Unknown metadata key "${key}" (not in allowlist)`);
+      continue;
+    }
+    // Uppercase / prose keys (`Note:`, `TODO:`, `PR:`) are ordinary comments.
+  }
+  return meta;
+}
+
+/** Collect every enforced anchor string in the file (any location). */
+function collectEnforcedAnchors(content) {
+  const anchors = [];
+  let match;
+  const re = new RegExp(ENFORCED_RE.source, 'g');
+  while ((match = re.exec(content)) !== null) {
+    anchors.push(match[1].trim());
+  }
+  return anchors;
+}
+
+/**
+ * Split content into top-level sections by `### Requirement:` / `### Invariant:`
+ * headings. Returns [{ type, title, body }]. Text before the first heading is
+ * dropped from block validation (document preamble is allowed).
+ */
+function splitBlocks(content) {
+  const blocks = [];
+  const lines = content.split('\n');
+  let current = null;
+  for (const line of lines) {
+    let m = line.match(REQUIREMENT_RE);
+    if (m) {
+      current = { type: 'Requirement', title: m[1].trim(), body: [] };
+      blocks.push(current);
+      continue;
+    }
+    m = line.match(INVARIANT_RE);
+    if (m) {
+      current = { type: 'Invariant', title: m[1].trim(), body: [] };
+      blocks.push(current);
+      continue;
+    }
+    if (current) current.body.push(line);
+  }
+  return blocks;
+}
+
+/** Validate a baseline spec file (Requirement/Invariant blocks). */
+function validateBaseline(rel, content, errors) {
+  const blocks = splitBlocks(content);
+
+  for (const block of blocks) {
+    const body = block.body.join('\n');
+    if (block.type === 'Requirement' && !SCENARIO_RE.test(body)) {
+      errors.push(`${rel}: Requirement "${block.title}" has no Scenario`);
+    }
+    if (block.type === 'Invariant') {
+      const enforcedIn = collectEnforcedAnchors(body);
+      if (enforcedIn.length === 0) {
+        errors.push(`${rel}: Invariant "${block.title}" missing <!-- enforced: --> anchor`);
+      }
+    }
+  }
+}
+
+/** Validate a delta file: every declared ADDED/MODIFIED/REMOVED block is non-empty. */
+function validateDelta(rel, content, errors) {
+  // Each marker opens a block whose body runs from the END of that marker to
+  // the START of the next marker (or EOF). Using the next marker's end as the
+  // boundary would swallow the next marker's text into the current block.
+  const markers = [];
+  let match;
+  const re = new RegExp(DELTA_MARKER_RE.source, 'g');
+  while ((match = re.exec(content)) !== null) {
+    markers.push({
+      name: match[1],
+      bodyStart: match.index + match[0].length, // end of this marker's "-->"
+      markerStart: match.index, // start of this marker, used as the NEXT block's end
+    });
+  }
+
+  markers.forEach((m, i) => {
+    const blockEnd = i + 1 < markers.length ? markers[i + 1].markerStart : content.length;
+    const body = content.slice(m.bodyStart, blockEnd).trim();
+    if (body === '') {
+      errors.push(`${rel}: Empty ${m.name} block (declared but no content)`);
+    }
+  });
+}
+
+// ── Per-file validation ─────────────────────────────────────────
+
+function validateSpecFile(filePath) {
+  const errors = [];
+  const rel = path.relative(openspecDir, filePath);
+
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    return [`${rel}: Cannot read file: ${err.message}`];
+  }
+
+  if (content.trim() === '') {
+    return [`${rel}: Empty spec file`];
+  }
+
+  // Metadata allowlist + typo guard + ordinary-comment handling.
+  classifyComments(rel, content, errors);
+
+  // Every enforced anchor anywhere in the file must satisfy the grammar.
+  for (const raw of collectEnforcedAnchors(content)) {
+    const parsed = parseAnchor(raw);
+    if (parsed.invalid) {
+      errors.push(INVALID_ANCHOR_MSG(rel, raw, parsed.reason));
+    }
+  }
+
+  // Fresh regex per call: /g regexes are stateful across .test() calls.
+  const isDelta = new RegExp(DELTA_MARKER_RE.source, 'g').test(content);
+  if (isDelta) {
+    validateDelta(rel, content, errors);
+    return errors;
+  }
+
+  validateBaseline(rel, content, errors);
+  return errors;
+}
+
+// ── Main ────────────────────────────────────────────────────────
+
+function main() {
+  if (!fs.existsSync(openspecDir)) {
+    console.log(JSON.stringify({ valid: true, errors: [] }));
+    process.exit(0);
+  }
+
+  const mdFiles = walkMdFiles(openspecDir);
+  if (mdFiles.length === 0) {
+    console.log(JSON.stringify({ valid: true, errors: [] }));
+    process.exit(0);
+  }
+
+  const allErrors = [];
+  for (const filePath of mdFiles) {
+    const fileErrors = validateSpecFile(filePath);
+    allErrors.push(...fileErrors);
+  }
+
+  if (allErrors.length > 0) {
+    console.error(`Found ${allErrors.length} validation error(s):`);
+    for (const err of allErrors) {
+      console.error(`  - ${err}`);
+    }
+  } else {
+    console.error(`Validated ${mdFiles.length} spec file(s): no errors found.`);
+  }
+
+  console.log(JSON.stringify({ valid: allErrors.length === 0, errors: allErrors }));
+
+  process.exit(allErrors.length > 0 ? 1 : 0);
+}
+
+main();

--- a/tests/ci/check-spec-freshness.test.js
+++ b/tests/ci/check-spec-freshness.test.js
@@ -1,0 +1,384 @@
+'use strict';
+/**
+ * Tests for scripts/ci/check-spec-freshness.js
+ *
+ * v1 contract (file-level freshness):
+ * - git invoked via argv array (execFileSync), never via shell string
+ * - project root and every enforced target resolved through realpaths and
+ *   contained inside the project; symlinked root / escaping target rejected
+ * - shallow clones report UNVERIFIED (never ORPHANED/STALE)
+ * - truthful verdicts: FRESH / STALE / ORPHANED (target missing or escaping)
+ *   / UNVERIFIED (no git, not a repo, shallow, missing/invalid date,
+ *   target never committed)
+ * - ECC_SPEC_STALE_WARN_ONLY honored (=== "true") → stale no longer fails
+ *
+ * Date strategy: commits are made at offsets relative to "today" (daysAgo)
+ * because ECC_SPEC_STALE_DAYS is capped at 365 — a verification dated years in
+ * the past would always trip the age check and mask the change-detection tests.
+ *
+ * Uses the Node native test runner and real (mini) git repositories.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert');
+const { execSync, execFileSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'ci', 'check-spec-freshness.js');
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+function runChecker(projectRoot, envOverrides = {}) {
+  const env = { ...process.env, ...envOverrides };
+  for (const key of ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_COMMON_DIR', 'GIT_PREFIX']) {
+    delete env[key];
+  }
+  env.GIT_CONFIG_NOSYSTEM = '1';
+  env.GIT_CONFIG_GLOBAL = '/dev/null';
+  const opts = { encoding: 'utf8', env, stdio: ['pipe', 'pipe', 'pipe'] };
+  let isDir = false;
+  try {
+    isDir = fs.statSync(projectRoot).isDirectory();
+  } catch {
+    isDir = false;
+  }
+  if (isDir) {
+    // Run with the project as cwd so any (buggy) shell execution would land a
+    // marker inside the repo where the hostile-input tests can see it.
+    opts.cwd = projectRoot;
+  }
+  try {
+    const result = execFileSync(process.execPath, [SCRIPT, '--project-root', projectRoot], opts);
+    return { exitCode: 0, stdout: result, stderr: '' };
+  } catch (err) {
+    return {
+      exitCode: err.status || 1,
+      stdout: err.stdout || '',
+      stderr: err.stderr || '',
+    };
+  }
+}
+
+function parseJson(result) {
+  const line = result.stdout.trim().split('\n').pop();
+  return JSON.parse(line);
+}
+
+function git(repo, args) {
+  return execSync(`git ${args}`, { cwd: repo, stdio: ['pipe', 'pipe', 'pipe'] })
+    .toString()
+    .trim();
+}
+
+/** Init an isolated git repo (full history) and return its path. */
+function initRepo() {
+  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-fresh-'));
+  git(repo, 'init -q');
+  git(repo, 'config user.email "test@example.com"');
+  git(repo, 'config user.name "Test Runner"');
+  return repo;
+}
+
+/** Commit `content` as `relPath` at `date` (YYYY-MM-DD). */
+function commitFile(repo, relPath, content, date, message = `commit ${relPath}`) {
+  const full = path.join(repo, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+  git(repo, 'add -A');
+  const env = { ...process.env, GIT_AUTHOR_DATE: `${date}T00:00:00`, GIT_COMMITTER_DATE: `${date}T00:00:00` };
+  execSync(`git commit -q -m "${message}"`, { cwd: repo, env, stdio: ['pipe', 'pipe', 'pipe'] });
+}
+
+/** Write a spec under openspec/specs/<sub>/spec.md with enforced anchors + date. */
+function writeSpec(repo, sub, { lastVerified, anchors = [] }) {
+  const dir = path.join(repo, 'openspec', 'specs', sub);
+  fs.mkdirSync(dir, { recursive: true });
+  const anchorLines = anchors.map((a) => `<!-- enforced: ${a} -->`).join('\n');
+  const lv = lastVerified === undefined ? '' : `Last verified: ${lastVerified}\n`;
+  const content =
+    `---\ntitle: ${sub}\n---\n\n` +
+    `<!-- id: ${sub} -->\n\n` +
+    `${lv}` +
+    `### Requirement: ${sub} behavior\n\n` +
+    `#### Scenario: holds\n` +
+    `- **WHEN** trigger\n` +
+    `- **THEN** outcome\n\n` +
+    `${anchorLines}\n`;
+  fs.writeFileSync(path.join(dir, 'spec.md'), content);
+}
+
+function daysAgo(n) {
+  return new Date(Date.now() - n * 86400000).toISOString().split('T')[0];
+}
+
+let repos = [];
+function track(repo) {
+  repos.push(repo);
+  return repo;
+}
+
+after(() => {
+  for (const r of repos) {
+    try {
+      fs.rmSync(r, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  repos = [];
+});
+
+describe('check-spec-freshness (v1, file-level)', () => {
+  describe('container / config errors', () => {
+    it('returns valid for a missing openspec dir (exit 0)', () => {
+      const repo = track(initRepo());
+      const result = runChecker(repo);
+      assert.strictEqual(result.exitCode, 0);
+      assert.deepStrictEqual(parseJson(result).specs, []);
+    });
+
+    it('returns valid for an empty openspec dir (exit 0)', () => {
+      const repo = track(initRepo());
+      fs.mkdirSync(path.join(repo, 'openspec'), { recursive: true });
+      const result = runChecker(repo);
+      assert.strictEqual(result.exitCode, 0);
+    });
+
+    it('exits 2 for a non-existent project root', () => {
+      const result = runChecker(path.join(os.tmpdir(), 'ecc-missing-' + Date.now()));
+      assert.strictEqual(result.exitCode, 2);
+    });
+
+    it('exits 2 for a project root that is a file', () => {
+      const file = path.join(os.tmpdir(), 'ecc-file-' + Date.now());
+      fs.writeFileSync(file, 'x');
+      try {
+        const result = runChecker(file);
+        assert.strictEqual(result.exitCode, 2);
+      } finally {
+        fs.rmSync(file, { force: true });
+      }
+    });
+
+    it('exits 2 for a symlinked project root', () => {
+      const real = track(initRepo());
+      const link = path.join(os.tmpdir(), 'ecc-link-' + Date.now());
+      fs.symlinkSync(real, link);
+      try {
+        const result = runChecker(link);
+        assert.strictEqual(result.exitCode, 2, result.stderr);
+      } finally {
+        fs.rmSync(link, { force: true });
+      }
+    });
+
+    it('exits 2 for invalid ECC_SPEC_STALE_DAYS values', () => {
+      const repo = track(initRepo());
+      for (const bad of ['0', '-5', 'abc', '400', '1.5', '0x10']) {
+        const result = runChecker(repo, { ECC_SPEC_STALE_DAYS: bad });
+        assert.strictEqual(result.exitCode, 2, `expected exit 2 for "${bad}"`);
+      }
+    });
+
+    it('accepts the boundary ECC_SPEC_STALE_DAYS value 365', () => {
+      const repo = track(initRepo());
+      const result = runChecker(repo, { ECC_SPEC_STALE_DAYS: '365' });
+      assert.strictEqual(result.exitCode, 0);
+    });
+  });
+
+  describe('verdicts on a real repo with history', () => {
+    // Timeline: src/lib.js committed 300 days ago (v1) and 50 days ago (v2).
+    let repo;
+    before(() => {
+      repo = track(initRepo());
+      commitFile(repo, 'src/lib.js', 'v1\n', daysAgo(300), 'lib v1');
+      commitFile(repo, 'src/lib.js', 'v2\n', daysAgo(50), 'lib v2');
+    });
+
+    it('marks FRESH a spec verified after the last change', () => {
+      writeSpec(repo, 'fresh', { lastVerified: daysAgo(1), anchors: ['src/lib.js::run'] });
+      const result = runChecker(repo);
+      assert.strictEqual(result.exitCode, 0, result.stderr);
+      const spec = parseJson(result).specs.find((s) => s.path.includes('fresh'));
+      assert.strictEqual(spec.status, 'FRESH', JSON.stringify(spec));
+    });
+
+    it('marks STALE a spec whose enforced file changed after verification', () => {
+      // Verification 100 days ago: after v1 (300d), before v2 (50d); age 100d is
+      // under the 365-day cap, so STALE here is caused by the file change alone.
+      writeSpec(repo, 'stale-change', { lastVerified: daysAgo(100), anchors: ['src/lib.js::run'] });
+      const result = runChecker(repo, { ECC_SPEC_STALE_DAYS: '365' });
+      assert.strictEqual(result.exitCode, 1);
+      const spec = parseJson(result).specs.find((s) => s.path.includes('stale-change'));
+      assert.strictEqual(spec.status, 'STALE', JSON.stringify(spec));
+    });
+
+    it('marks STALE purely from an old verification date (age threshold)', () => {
+      // Verification 40 days ago (after the last commit 50d ago → no change),
+      // over the default 30-day threshold → STALE by age only.
+      writeSpec(repo, 'stale-age', { lastVerified: daysAgo(40), anchors: ['src/lib.js::run'] });
+      const result = runChecker(repo); // default threshold 30
+      const spec = parseJson(result).specs.find((s) => s.path.includes('stale-age'));
+      assert.strictEqual(spec.status, 'STALE', JSON.stringify(spec));
+    });
+
+    it('marks UNVERIFIED when Last verified is absent', () => {
+      writeSpec(repo, 'unverified', { anchors: ['src/lib.js::run'] });
+      const result = runChecker(repo);
+      const spec = parseJson(result).specs.find((s) => s.path.includes('unverified'));
+      assert.strictEqual(spec.status, 'UNVERIFIED', JSON.stringify(spec));
+    });
+
+    it('marks UNVERIFIED when Last verified is not a parseable date', () => {
+      writeSpec(repo, 'baddate', { lastVerified: 'not-a-date', anchors: ['src/lib.js::run'] });
+      const result = runChecker(repo);
+      const spec = parseJson(result).specs.find((s) => s.path.includes('baddate'));
+      assert.strictEqual(spec.status, 'UNVERIFIED', JSON.stringify(spec));
+    });
+
+    it('marks ORPHANED when the enforced target file does not exist', () => {
+      writeSpec(repo, 'orphaned', { lastVerified: daysAgo(1), anchors: ['src/missing.js::ghost'] });
+      const result = runChecker(repo);
+      const spec = parseJson(result).specs.find((s) => s.path.includes('orphaned'));
+      assert.strictEqual(spec.status, 'ORPHANED', JSON.stringify(spec));
+    });
+
+    it('marks UNVERIFIED (not ORPHANED) when the target has no git history', () => {
+      // File exists on disk but was never committed.
+      fs.writeFileSync(path.join(repo, 'src', 'untracked.js'), '// never committed\n');
+      writeSpec(repo, 'nohistory', { lastVerified: daysAgo(1), anchors: ['src/untracked.js::fn'] });
+      const result = runChecker(repo);
+      const spec = parseJson(result).specs.find((s) => s.path.includes('nohistory'));
+      assert.strictEqual(spec.status, 'UNVERIFIED', JSON.stringify(spec));
+    });
+
+    it('marks ORPHANED when an enforced target escapes via a symlink', () => {
+      const outside = path.join(os.tmpdir(), 'ecc-outside-' + Date.now() + '.txt');
+      fs.writeFileSync(outside, 'outside\n');
+      fs.mkdirSync(path.join(repo, 'src'), { recursive: true });
+      fs.symlinkSync(outside, path.join(repo, 'src', 'link.js'));
+      try {
+        writeSpec(repo, 'escape', { lastVerified: daysAgo(1), anchors: ['src/link.js::x'] });
+        const result = runChecker(repo);
+        const spec = parseJson(result).specs.find((s) => s.path.includes('escape'));
+        assert.strictEqual(spec.status, 'ORPHANED', JSON.stringify(spec));
+      } finally {
+        fs.rmSync(outside, { force: true });
+      }
+    });
+
+    it('emits stable JSON on stdout and diagnostics on stderr', () => {
+      const result = runChecker(repo, { ECC_SPEC_STALE_DAYS: '365' });
+      const parsed = parseJson(result);
+      assert.ok(Array.isArray(parsed.specs));
+      assert.ok(typeof parsed.staleCount === 'number');
+      assert.ok(typeof parsed.totalCount === 'number');
+      assert.strictEqual(parsed.totalCount, parsed.specs.length);
+      for (const s of parsed.specs) {
+        assert.ok(s.path);
+        assert.ok(['FRESH', 'STALE', 'ORPHANED', 'UNVERIFIED', 'UNKNOWN'].includes(s.status));
+      }
+    });
+  });
+
+  describe('warning mode / exit contract', () => {
+    let staleRepo;
+    before(() => {
+      staleRepo = track(initRepo());
+      commitFile(staleRepo, 'src/lib.js', 'v1\n', daysAgo(300), 'v1');
+      commitFile(staleRepo, 'src/lib.js', 'v2\n', daysAgo(50), 'v2');
+      writeSpec(staleRepo, 'stale', { lastVerified: daysAgo(100), anchors: ['src/lib.js::run'] });
+    });
+
+    it('exits 1 on stale by default', () => {
+      const result = runChecker(staleRepo, { ECC_SPEC_STALE_DAYS: '365' });
+      assert.strictEqual(result.exitCode, 1);
+    });
+
+    it('exits 0 on stale when ECC_SPEC_STALE_WARN_ONLY=true', () => {
+      const result = runChecker(staleRepo, {
+        ECC_SPEC_STALE_DAYS: '365',
+        ECC_SPEC_STALE_WARN_ONLY: 'true',
+      });
+      assert.strictEqual(result.exitCode, 0, result.stderr);
+      const parsed = parseJson(result);
+      assert.ok(parsed.specs.some((s) => s.status === 'STALE'), 'stale specs must still be reported');
+    });
+
+    it('does not honor non-"true" spellings of the warning flag', () => {
+      const result = runChecker(staleRepo, {
+        ECC_SPEC_STALE_DAYS: '365',
+        ECC_SPEC_STALE_WARN_ONLY: 'TRUE',
+      });
+      assert.strictEqual(result.exitCode, 1);
+    });
+  });
+
+  describe('hostile inputs (shell-escape proof)', () => {
+    it('does not execute a hostile enforced filename (no command substitution)', () => {
+      const repo = track(initRepo());
+      const hostileName = 'evil$(touch${IFS}ECCPWNMARK).js';
+      commitFile(repo, `src/${hostileName}`, '// evil\n', daysAgo(200), 'evil file');
+      writeSpec(repo, 'hostile', { lastVerified: daysAgo(400), anchors: [`src/${hostileName}::evil`] });
+
+      const marker = path.join(repo, 'ECCPWNMARK');
+      const result = runChecker(repo);
+      assert.strictEqual(fs.existsSync(marker), false, 'shell command substitution must not run');
+      // The hostile file genuinely changed after the verification date → STALE.
+      assert.strictEqual(result.exitCode, 1, result.stderr);
+    });
+
+    it('does not execute a hostile date string', () => {
+      const repo = track(initRepo());
+      commitFile(repo, 'src/lib.js', 'v1\n', daysAgo(50), 'v1');
+      const marker = path.join(repo, 'ECCDATEMARK');
+      // The date carries shell payload after a valid date prefix. The checker
+      // must only pass the extracted, validated date to git as one argv item —
+      // never hand the whole line to a shell.
+      writeSpec(repo, 'hostiledate', {
+        lastVerified: `${daysAgo(50)}; touch ECCDATEMARK`,
+        anchors: ['src/lib.js::run'],
+      });
+      const result = runChecker(repo);
+      assert.strictEqual(fs.existsSync(marker), false, 'hostile date must not execute');
+      assert.ok([0, 1].includes(result.exitCode), 'must not crash on hostile date');
+      assert.doesNotThrow(() => parseJson(result));
+    });
+  });
+
+  describe('shallow clones', () => {
+    it('reports UNVERIFIED (never ORPHANED/STALE) on shallow history', () => {
+      const full = track(initRepo());
+      commitFile(full, 'src/lib.js', 'v1\n', daysAgo(300), 'v1');
+      commitFile(full, 'src/lib.js', 'v2\n', daysAgo(50), 'v2');
+
+      const shallow = track(fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-shallow-')));
+      // file:// URL is required: git ignores --depth for plain local paths.
+      execFileSync('git', ['clone', '-q', '--depth', '1', `file://${full}`, shallow], {
+        stdio: 'ignore',
+      });
+
+      // A spec that would be FRESH or STALE on full history must be UNVERIFIED.
+      writeSpec(shallow, 'spec', { lastVerified: daysAgo(1), anchors: ['src/lib.js::run'] });
+      const result = runChecker(shallow);
+      const spec = parseJson(result).specs.find((s) => s.path.includes('spec'));
+      assert.ok(spec, 'expected a spec entry');
+      assert.strictEqual(spec.status, 'UNVERIFIED', JSON.stringify(spec));
+      assert.strictEqual(result.exitCode, 0, 'UNVERIFIED must not fail the check');
+    });
+  });
+
+  describe('no enforced anchors', () => {
+    it('marks a dated spec with no anchors as FRESH (nothing to verify)', () => {
+      const repo = track(initRepo());
+      commitFile(repo, 'src/lib.js', 'v1\n', daysAgo(50), 'v1');
+      writeSpec(repo, 'noanchors', { lastVerified: daysAgo(1), anchors: [] });
+      const result = runChecker(repo);
+      const spec = parseJson(result).specs.find((s) => s.path.includes('noanchors'));
+      assert.strictEqual(spec.status, 'FRESH', JSON.stringify(spec));
+    });
+  });
+});

--- a/tests/ci/validate-openspec-syntax.test.js
+++ b/tests/ci/validate-openspec-syntax.test.js
@@ -1,0 +1,414 @@
+'use strict';
+/**
+ * Tests for scripts/ci/validate-openspec-syntax.js
+ *
+ * Covers the v1 OpenSpec schema contract:
+ * - baseline specs (Requirement + Scenario, Invariant + enforced anchor)
+ * - per-block delta validation (every declared block must be non-empty)
+ * - metadata allowlist + unknown-key guard + ordinary comments allowed
+ * - enforced anchor grammar (path::symbol, repo-relative, no traversal)
+ *
+ * The validator expects <root>/openspec/ structure; fixtures are built inline
+ * as real files in a temp dir so each case is exercised end-to-end.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { execSync } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'ci', 'validate-openspec-syntax.js');
+
+function runValidator(openspecRoot) {
+  try {
+    const result = execSync(
+      `node "${SCRIPT}" --openspec-root "${openspecRoot}"`,
+      { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+    );
+    return {
+      exitCode: 0,
+      stdout: (result.stdout || result).trim(),
+      stderr: (result.stderr || '').trim(),
+    };
+  } catch (err) {
+    return {
+      exitCode: err.status || 1,
+      stdout: (err.stdout || '').trim(),
+      stderr: (err.stderr || '').trim(),
+    };
+  }
+}
+
+/** Create a temp project root with openspec/specs/ containing given files */
+function makeTempProject(files) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-vs-'));
+  const specsDir = path.join(root, 'openspec', 'specs');
+  fs.mkdirSync(specsDir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    const filePath = path.join(specsDir, name);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+  return root;
+}
+
+// ── Shared content builders ────────────────────────────────────
+
+function requirementSpec(extra = '') {
+  return (
+    '---\ntitle: Capability\n---\n\n' +
+    '### Requirement: Some Req\n' +
+    'The system SHALL do the thing.\n\n' +
+    '#### Scenario: happy path\n' +
+    '- **WHEN** x\n' +
+    '- **THEN** y\n\n' +
+    extra
+  );
+}
+
+function invariantSpec(anchor = 'src/lib.js::enforceCheck', extra = '') {
+  return (
+    '### Invariant: Some Invariant\n' +
+    'The system SHALL always hold.\n\n' +
+    `<!-- enforced: ${anchor} -->\n\n` +
+    extra
+  );
+}
+
+function deltaSpec(blocks) {
+  // blocks: array of { marker: 'ADDED'|'MODIFIED'|'REMOVED', body: string }
+  let out = '---\ntitle: Delta\n---\n\n';
+  for (const b of blocks) {
+    out += `<!-- ${b.marker}: -->\n${b.body}\n`;
+  }
+  return out;
+}
+
+describe('validate-openspec-syntax (v1 schema)', () => {
+  describe('container / exit codes', () => {
+    it('is valid when openspec dir is missing', () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-vs-missing-'));
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 0);
+        const parsed = JSON.parse(result.stdout.split('\n').pop());
+        assert.strictEqual(parsed.valid, true);
+        assert.deepStrictEqual(parsed.errors, []);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('is valid for an empty openspec directory', () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-vs-empty-'));
+      try {
+        fs.mkdirSync(path.join(root, 'openspec'));
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 0);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('exits 2 for a non-existent root', () => {
+      const result = runValidator('/tmp/nonexistent-openspec-root-' + Date.now());
+      assert.strictEqual(result.exitCode, 2);
+    });
+
+    it('exits 2 when root is a file, not a directory', () => {
+      const file = path.join(os.tmpdir(), 'ecc-vs-file-' + Date.now());
+      fs.writeFileSync(file, 'x');
+      try {
+        const result = runValidator(file);
+        assert.strictEqual(result.exitCode, 2);
+      } finally {
+        fs.rmSync(file, { force: true });
+      }
+    });
+  });
+
+  describe('valid baseline specs', () => {
+    it('passes a Requirement with a Scenario', () => {
+      const root = makeTempProject({ 'valid/spec.md': requirementSpec() });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 0, result.stderr);
+        const parsed = JSON.parse(result.stdout.split('\n').pop());
+        assert.strictEqual(parsed.valid, true);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('passes a spec without YAML frontmatter (frontmatter optional)', () => {
+      const root = makeTempProject({
+        'nofm/spec.md':
+          '# Spec: nofm\n\n' +
+          '### Requirement: Req\n' +
+          'SHALL pass.\n\n' +
+          '#### Scenario: s\n' +
+          '- **WHEN** a\n' +
+          '- **THEN** b\n',
+      });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 0, result.stderr);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('passes an Invariant with a well-formed enforced anchor', () => {
+      const root = makeTempProject({ 'inv/spec.md': invariantSpec() });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 0, result.stderr);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('passes allowlisted metadata on Requirement and Invariant', () => {
+      const root = makeTempProject({
+        'meta/spec.md':
+          requirementSpec(
+            '<!-- id: some-req -->\n' +
+            '<!-- entities: User, Order -->\n' +
+            '<!-- test: OrderTest.placesOrder() -->\n' +
+            '<!-- depends_on: Earlier Behavior -->\n' +
+            '<!-- triggers: Later Behavior -->\n'
+          ) +
+          invariantSpec('src/orders.js::rejectInvalid', '<!-- verified_by: OrderTest.rejects() -->\n')
+          + '<!-- deferred: file1.md, file2.md -->\n',
+      });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 0, result.stderr);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('structural validation', () => {
+    it('flags a Requirement with no Scenario', () => {
+      const root = makeTempProject({
+        'noscen/spec.md':
+          '### Requirement: Missing Scenario Req\n' +
+          'This requirement has no scenario.\n',
+      });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 1);
+        const parsed = JSON.parse(result.stdout.split('\n').pop());
+        const hit = parsed.errors.some((e) => e.includes('has no Scenario'));
+        assert.ok(hit, `expected missing-Scenario error, got: ${JSON.stringify(parsed.errors)}`);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('flags an Invariant with no enforced anchor', () => {
+      const root = makeTempProject({
+        'noenf/spec.md':
+          '### Invariant: No Anchor\n' +
+          'Must have an anchor.\n',
+      });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 1);
+        const parsed = JSON.parse(result.stdout.split('\n').pop());
+        const hit = parsed.errors.some((e) => e.includes('enforced'));
+        assert.ok(hit, `expected missing-enforced error, got: ${JSON.stringify(parsed.errors)}`);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('enforced anchor grammar', () => {
+    const CASES = [
+      ['spaces instead of ::', 'not a valid anchor'],
+      ['empty symbol', 'src/lib.js::'],
+      ['empty path', '::check'],
+      ['absolute path', '/etc/passwd::x'],
+      ['dot-dot traversal', '../secret.js::x'],
+      ['nested dot-dot traversal', 'src/../../secret.js::x'],
+      ['backslash path', 'src\\lib.js::x'],
+    ];
+
+    for (const [label, anchor] of CASES) {
+      it(`rejects ${label}`, () => {
+        const root = makeTempProject({ 'badanchor/spec.md': invariantSpec(anchor) });
+        try {
+          const result = runValidator(root);
+          assert.strictEqual(result.exitCode, 1, anchor);
+          const parsed = JSON.parse(result.stdout.split('\n').pop());
+          const hit = parsed.errors.some((e) => e.includes('Invalid enforced anchor'));
+          assert.ok(hit, `expected anchor error for "${anchor}", got: ${JSON.stringify(parsed.errors)}`);
+        } finally {
+          fs.rmSync(root, { recursive: true, force: true });
+        }
+      });
+    }
+
+    it('accepts a nested relative path anchor', () => {
+      const root = makeTempProject({
+        'nested/spec.md': invariantSpec('packages/core/src/checker.js::verify'),
+      });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 0, result.stderr);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('metadata comments', () => {
+    it('flags an unknown machine-shaped metadata key (typo guard)', () => {
+      const root = makeTempProject({
+        'unk/spec.md':
+          requirementSpec('<!-- enforcd: src/lib.js::check -->\n'),
+      });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 1);
+        const parsed = JSON.parse(result.stdout.split('\n').pop());
+        const hit = parsed.errors.some((e) => e.includes('Unknown metadata key'));
+        assert.ok(hit, `expected unknown-key error, got: ${JSON.stringify(parsed.errors)}`);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('allows ordinary prose comments even with a colon', () => {
+      const root = makeTempProject({
+        'prose/spec.md':
+          requirementSpec(
+            '<!-- Note: this is a human note, keep it -->\n' +
+            '<!-- TODO(team): address in follow-up -->\n'
+          ),
+      });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 0, result.stderr);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('allows colon-less comments anywhere', () => {
+      const root = makeTempProject({
+        'plain/spec.md': requirementSpec('<!-- just a comment -->\n'),
+      });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 0, result.stderr);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('delta files', () => {
+    it('passes a delta with three non-empty blocks', () => {
+      const root = makeTempProject({
+        'deltas/valid.md': deltaSpec([
+          { marker: 'ADDED', body: 'Added validation logic.' },
+          { marker: 'MODIFIED', body: 'Now uses structured errors.' },
+          { marker: 'REMOVED', body: 'Dropped legacy path.' },
+        ]),
+      });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 0, result.stderr);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects a delta where the FIRST block is empty but a later one has content', () => {
+      // Regression for: "content in any later block made all earlier empty blocks pass"
+      const root = makeTempProject({
+        'deltas/first-empty.md': deltaSpec([
+          { marker: 'ADDED', body: '' },
+          { marker: 'MODIFIED', body: 'Some real content.' },
+        ]),
+      });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 1);
+        const parsed = JSON.parse(result.stdout.split('\n').pop());
+        const hit = parsed.errors.some((e) => e.includes('Empty ADDED block'));
+        assert.ok(hit, `expected empty-ADDED error, got: ${JSON.stringify(parsed.errors)}`);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects a delta where every declared block is empty', () => {
+      const root = makeTempProject({
+        'deltas/all-empty.md': deltaSpec([
+          { marker: 'ADDED', body: '' },
+          { marker: 'REMOVED', body: '' },
+        ]),
+      });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 1);
+        const parsed = JSON.parse(result.stdout.split('\n').pop());
+        const added = parsed.errors.some((e) => e.includes('Empty ADDED block'));
+        const removed = parsed.errors.some((e) => e.includes('Empty REMOVED block'));
+        assert.ok(added, 'expected empty-ADDED error');
+        assert.ok(removed, 'expected empty-REMOVED error');
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects an empty file as an empty spec', () => {
+      const root = makeTempProject({ 'deltas/empty.md': '' });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 1);
+        const parsed = JSON.parse(result.stdout.split('\n').pop());
+        const hit = parsed.errors.some((e) => e.toLowerCase().includes('empty'));
+        assert.ok(hit, `expected empty error, got: ${JSON.stringify(parsed.errors)}`);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('output format', () => {
+    it('emits JSON on stdout only', () => {
+      const root = makeTempProject({ 'bad.md': '' });
+      try {
+        const result = runValidator(root);
+        assert.strictEqual(result.exitCode, 1);
+        const stdoutLines = result.stdout.split('\n').filter((l) => l.trim().length > 0);
+        for (const line of stdoutLines) {
+          assert.doesNotThrow(() => JSON.parse(line), `stdout must be JSON only: ${line}`);
+        }
+        assert.ok(result.stderr.length > 0, 'diagnostics should go to stderr');
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('reports valid:false with errors on stdout when invalid', () => {
+      const root = makeTempProject({ 'bad.md': '' });
+      try {
+        const result = runValidator(root);
+        const parsed = JSON.parse(result.stdout.split('\n').pop());
+        assert.strictEqual(parsed.valid, false);
+        assert.ok(Array.isArray(parsed.errors) && parsed.errors.length > 0);
+      } finally {
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  });
+});


### PR DESCRIPTION
# OpenSpec validator foundation (PR1)

Focused revision per review. Standalone **read-only** validators only — CI gating is intentionally **not** wired in this PR (follow-up once shallow-clone and exit semantics are stable). No README or unrelated changes.

## `validate-openspec-syntax.js` — v1 schema contract
- Documented in the script header; metadata keys are an **explicit allowlist** with a typo guard; ordinary prose comments are allowed
- Delta files validated **per block**: every declared `ADDED`/`MODIFIED`/`REMOVED` block must be non-empty (an empty first block no longer passes because a later block has content)
- `<!-- enforced: path/to/file.ext::symbol -->` anchors: repo-relative, reject whitespace / leading `/` / `..` traversal / backslashes
- YAML frontmatter optional

## `check-spec-freshness.js` — file-level freshness
- git invoked only via `execFileSync` argv arrays; paths after `--`, verified date validated then passed as a single argument — nothing from spec Markdown reaches a shell (hostile filename + date fixtures prove it)
- Project root and every enforced target resolved through realpaths and contained in the project; symlinked root / escaping target rejected
- Shallow clones → `UNVERIFIED` (never ORPHANED/STALE); truthful verdicts FRESH / STALE / ORPHANED (missing/escaping target) / UNVERIFIED
- Contract explicitly **file-level** (the `::symbol` is recorded, not resolved)
- `ECC_SPEC_STALE_WARN_ONLY` implemented so warning mode matches the exit contract; `ECC_SPEC_STALE_DAYS` validated as strict integer 1–365

## Fixtures & tests
- Both suites rebuilt around real, git-backed repos plus hostile-input, shallow-clone, path-escape, per-block-delta and metadata cases (27 + 23 tests)
- Removed the old unused on-disk fixture tree (tests construct real fixtures inline)

## Manifest
- `manifests/install-components.json`: register existing spec-miner agent

> Open question for maintainers (see PR thread): spec-miner currently emits `enforced: FileName.methodName()` anchors without a file path; the file-level freshness contract needs a repo-relative path. Whether to align spec-miner in this PR or as a follow-up.