### PR TITLE
fix(install): exclude ECC skills from antigravity install target

### DIFF
--- a/scripts/lib/install-targets/antigravity-project.js
+++ b/scripts/lib/install-targets/antigravity-project.js
@@ -7,7 +7,7 @@ const {
   normalizeRelativePath,
 } = require('./helpers');
 
-const SUPPORTED_SOURCE_PREFIXES = ['rules', 'commands', 'agents', 'skills', '.agents', 'AGENTS.md'];
+const SUPPORTED_SOURCE_PREFIXES = ['rules', 'commands', 'agents', '.agents', 'AGENTS.md'];
 
 function supportsAntigravitySourcePath(sourceRelativePath) {
   const normalizedPath = normalizeRelativePath(sourceRelativePath);

--- a/tests/lib/install-manifests.test.js
+++ b/tests/lib/install-manifests.test.js
@@ -846,7 +846,7 @@ function runTests() {
             id: 'unsupported-antigravity',
             kind: 'skills',
             description: 'Unsupported',
-            paths: ['.cursor', 'skills/example'],
+            paths: ['.cursor', 'skills/example', 'commands/example'],
             targets: ['antigravity'],
             dependencies: [],
             defaultInstall: false,
@@ -875,8 +875,12 @@ function runTests() {
         'Unsupported antigravity paths should be filtered from planned operations'
       );
       assert.ok(
-        plan.operations.some(operation => operation.sourceRelativePath === 'skills/example'),
-        'Supported antigravity skill paths should still be planned'
+        plan.operations.every(operation => operation.sourceRelativePath !== 'skills/example'),
+        'ECC skills should be filtered: antigravity .agent/skills holds ECC agents'
+      );
+      assert.ok(
+        plan.operations.some(operation => operation.sourceRelativePath === 'commands/example'),
+        'Supported antigravity source paths should still be planned'
       );
     } finally {
       cleanupTestRepo(repoRoot);

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -580,7 +580,10 @@ function runTests() {
       assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'rules', 'common-coding-style.md')));
       assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'skills', 'architect.md')));
       assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'workflows', 'plan.md')));
-      assert.ok(fs.existsSync(path.join(projectDir, '.agent', 'skills', 'tdd-workflow', 'SKILL.md')));
+      // .agent/skills is where antigravity keeps its agents, and ECC agents are
+      // already mapped there. Installing ECC skills into the same directory made
+      // the two collide, so skills are no longer an antigravity source path.
+      assert.ok(!fs.existsSync(path.join(projectDir, '.agent', 'skills', 'tdd-workflow', 'SKILL.md')));
 
       const state = readJson(path.join(projectDir, '.agent', 'ecc-install-state.json'));
       assert.strictEqual(state.request.profile, 'core');


### PR DESCRIPTION
Rebased extract of #2665, carrying only the antigravity fix. Original commit and authorship preserved (@reevesc88); #2665 also contained the AgentShield workflow, which is blocked on a broken upstream action (see #2669).

## The bug

Antigravity maps ECC `agents/` into `.agent/skills/` — its own directory for agents. But `skills` was also in `SUPPORTED_SOURCE_PREFIXES`, and with no dedicated branch it fell through to the generic scaffold and landed in the same place. Both trees wrote to one directory:

```
# before
agents       -> /workspace/app/.agent/skills
skills       -> /workspace/app/.agent/skills

# after
agents       -> /workspace/app/.agent/skills
```

## Tests

Two existing tests encoded the collision rather than catching it, so both are updated:

- `install-manifests` used `skills/example` as its example of a *supported* antigravity path. It now asserts skills are filtered, with `commands/example` covering the positive case so the test still proves supported paths survive filtering.
- `install-apply` asserted `.agent/skills/tdd-workflow/SKILL.md` exists — pinning an ECC skill and ECC agents (`architect.md`) to the same directory. Inverted, with the reason recorded inline.

`node tests/run-all.js`: 3404/3408 pass. The 4 failures (`dry-run`, `path-safety`, `ecc`) reproduce identically on a pristine `origin/main` worktree — macOS `/private/tmp` symlink artifacts, unrelated to this change.

Closes #2665

🤖 Generated with [Claude Code](https://claude.com/claude-code)