### PR TITLE
fix(commands): use `allowed-tools`, not `allowed_tools`, in command frontmatter

### DIFF
--- a/.claude/commands/add-language-rules.md
+++ b/.claude/commands/add-language-rules.md
@@ -1,7 +1,7 @@
 ---
 name: add-language-rules
 description: Workflow command scaffold for add-language-rules in everything-claude-code.
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /add-language-rules

--- a/.claude/commands/database-migration.md
+++ b/.claude/commands/database-migration.md
@@ -1,7 +1,7 @@
 ---
 name: database-migration
 description: Workflow command scaffold for database-migration in everything-claude-code.
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /database-migration

--- a/.claude/commands/feature-development.md
+++ b/.claude/commands/feature-development.md
@@ -1,7 +1,7 @@
 ---
 name: feature-development
 description: Workflow command scaffold for feature-development in everything-claude-code.
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /feature-development

--- a/commands/marketing-campaign.md
+++ b/commands/marketing-campaign.md
@@ -1,6 +1,6 @@
 ---
 description: Plan and execute a full marketing campaign. Accepts a product brief and returns positioning, landing page copy, email sequence, social posts, ad variants, video scripts, and a content calendar. Can also review existing copy for conversion quality.
-allowed_tools: ["Read", "Grep", "Glob", "WebSearch", "WebFetch", "Write"]
+allowed-tools: ["Read", "Grep", "Glob", "WebSearch", "WebFetch", "Write"]
 ---
 
 # /marketing-campaign

--- a/commands/skill-create.md
+++ b/commands/skill-create.md
@@ -1,7 +1,7 @@
 ---
 name: skill-create
 description: Analyze local git history to extract coding patterns and generate SKILL.md files. Local version of the Skill Creator GitHub App.
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /skill-create - Local Skill Generation

--- a/docs/es/commands/skill-create.md
+++ b/docs/es/commands/skill-create.md
@@ -1,7 +1,7 @@
 ---
 name: skill-create
 description: Analizar el historial local de git para extraer patrones de codificación y generar archivos SKILL.md. Versión local de la Skill Creator GitHub App.
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /skill-create - Generación Local de Skills

--- a/docs/ja-JP/commands/skill-create.md
+++ b/docs/ja-JP/commands/skill-create.md
@@ -1,7 +1,7 @@
 ---
 name: skill-create
 description: ローカルのgit履歴を分析してコーディングパターンを抽出し、SKILL.mdファイルを生成します。Skill Creator GitHub Appのローカル版です。
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /skill-create - ローカルスキル生成

--- a/docs/tr/commands/skill-create.md
+++ b/docs/tr/commands/skill-create.md
@@ -1,7 +1,7 @@
 ---
 name: skill-create
 description: Kodlama desenlerini çıkarmak ve SKILL.md dosyaları oluşturmak için yerel git geçmişini analiz et. Skill Creator GitHub App'ın yerel versiyonu.
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /skill-create - Yerel Skill Oluşturma

--- a/docs/zh-CN/commands/skill-create.md
+++ b/docs/zh-CN/commands/skill-create.md
@@ -1,7 +1,7 @@
 ---
 name: skill-create
 description: 分析本地Git历史以提取编码模式并生成SKILL.md文件。Skill Creator GitHub应用的本地版本。
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /skill-create - 本地技能生成


### PR DESCRIPTION
### What

Nine command files declare `allowed_tools:` with an underscore. Claude Code reads `allowed-tools` with a hyphen — as six other files in this repository already do.

### Why it matters

`allowed-tools` pre-approves the listed tools for the turn that invokes the command, so Claude can use them without stopping to ask. An unrecognized key gets none of that: Claude Code reports it as an unexpected frontmatter key and ignores it. So `/add-language-rules`, `/database-migration`, `/feature-development`, `/skill-create`, and `/marketing-campaign` currently prompt for permission on every `Bash`, `Write`, `Read`, `Grep`, and `Glob` call — the opposite of what the frontmatter was written to do.

The [frontmatter reference](https://code.claude.com/docs/en/skills#frontmatter-reference) spells it `allowed-tools`, as does every example on that page. Commands and skills share one frontmatter format — the docs note that `.claude/commands/deploy.md` and `.claude/skills/deploy/SKILL.md` "both create `/deploy` and work the same way."

### Verification

This repository already contains both spellings:

```
$ grep -rl "^allowed-tools:" --include='*.md' .      # correct — 6 files
.agents/skills/mle-workflow/SKILL.md
.agents/skills/eval-harness/SKILL.md
skills/videodb/SKILL.md
skills/inherit-legacy-style/SKILL.md
docs/ja-JP/skills/videodb/SKILL.md
docs/zh-CN/skills/videodb/SKILL.md

$ grep -rl "^allowed_tools:" --include='*.md' .      # the 9 this PR changes
.claude/commands/add-language-rules.md
.claude/commands/database-migration.md
.claude/commands/feature-development.md
commands/marketing-campaign.md
commands/skill-create.md
docs/es/commands/skill-create.md
docs/ja-JP/commands/skill-create.md
docs/tr/commands/skill-create.md
docs/zh-CN/commands/skill-create.md
```

The substitution is anchored to the frontmatter key, so no prose mention of `allowed_tools` was touched and every tool list is unchanged.

The four translated copies are included because `allowed_tools` is a frontmatter key rather than prose — identical in every language — and CONTRIBUTING.md asks that translated files be updated alongside the originals. Happy to split them into a separate PR if the translation workflow prefers that.

### How I found it

Running the repo through [AgentCompass](https://github.com/YoavLax/agent-compass), a deterministic static analyzer that scores how ready a repository is for AI coding agents. It flagged this as `agents.commands.frontmatter.valid`.

Reproduce it without installing anything: https://agentcompass.ashymeadow-b5411f47.eastus.azurecontainerapps.io/?repo=affaan-m/ECC

![AgentCompass findings for affaan-m/ECC](https://raw.githubusercontent.com/YoavLax/agent-compass/main/docs/img/affaan-ecc-allowed-tools.png)

<sub><img src="https://raw.githubusercontent.com/YoavLax/agent-compass/main/agentcompass.png" width="200" alt="AgentCompass"></sub>
