### PR TITLE
feat(docker): support codex oauth login in networked harness

### DIFF
--- a/docker/plugin-setup/codex-auth-relay.js
+++ b/docker/plugin-setup/codex-auth-relay.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+/**
+ * Codex OAuth login relay for the hardened harness.
+ *
+ * `codex login` binds its callback server to 127.0.0.1:1455 inside the
+ * container. A Docker port publish forwards to the container interface, not
+ * loopback, so the host browser's redirect to http://localhost:1455 is
+ * refused. This bridges the published interface to loopback:
+ *
+ *   host 127.0.0.1:1455 -> container 0.0.0.0:1456 (this relay) -> 127.0.0.1:1455
+ *
+ * Run inside the networked session before `codex login`:
+ *   node /ecc/docker/plugin-setup/codex-auth-relay.js &
+ *
+ * Env: ECC_RELAY_LISTEN (default 1456), ECC_RELAY_TARGET (default 1455).
+ */
+
+'use strict';
+
+const net = require('net');
+
+const listenPort = Number(process.env.ECC_RELAY_LISTEN || 1456);
+const targetPort = Number(process.env.ECC_RELAY_TARGET || 1455);
+
+net.createServer(client => {
+  const upstream = net.connect(targetPort, '127.0.0.1');
+  client.pipe(upstream).pipe(client);
+  const drop = () => {
+    client.destroy();
+    upstream.destroy();
+  };
+  client.on('error', drop);
+  upstream.on('error', drop);
+}).listen(listenPort, '0.0.0.0', () => {
+  console.log(`codex-auth-relay: 0.0.0.0:${listenPort} -> 127.0.0.1:${targetPort}`);
+});

--- a/docker/plugin-setup/compose.yaml
+++ b/docker/plugin-setup/compose.yaml
@@ -76,6 +76,9 @@ services:
     profiles:
       - networked
     network_mode: default
+    # Codex OAuth callback bridge: host browser -> codex-auth-relay.js -> loopback.
+    ports:
+      - "127.0.0.1:1455:1456"
     image: ecc-plugin-setup:debian
 
   real-cli-ubuntu:

--- a/skills/docker-patterns/SKILL.md
+++ b/skills/docker-patterns/SKILL.md
@@ -416,6 +416,27 @@ explicit Compose `--env NAME` flag, understand that the value is inspectable
 and can be exfiltrated for the container lifetime, and remove the exact named
 container immediately after.
 
+### Authenticate Codex Inside the Networked Session
+
+`codex login` binds its OAuth callback server to `127.0.0.1:1455` inside the
+container. A Docker port publish forwards to the container interface, not
+loopback, so the host browser's redirect to `http://localhost:1455` is refused
+without a bridge. The `real-cli-networked` service publishes host
+`127.0.0.1:1455` to container port `1456`; bridge that port to loopback before
+logging in:
+
+```bash
+npm install --global @openai/codex   # the harness image does not ship codex
+node /ecc/docker/plugin-setup/codex-auth-relay.js &
+codex login
+```
+
+Complete the sign-in in the host browser. Each attempt mints a fresh
+`state`/`code`, so always follow the newest printed link. The token stays in
+the disposable container's `~/.codex/auth.json`; removing the named container
+revokes that copy. Only one container can hold host port 1455 at a time
+because the OAuth redirect targets a fixed port.
+
 Run the same focused suite natively on the host:
 
 ```bash


### PR DESCRIPTION
Follow-up to #2625.

`codex login` binds its OAuth callback server to `127.0.0.1:1455` **inside** the container. A Docker port publish forwards to the container interface, not loopback, so the host browser's redirect to `http://localhost:1455/auth/callback` is refused and sign-in cannot complete.

## Changes

- `docker/plugin-setup/codex-auth-relay.js` — small node TCP relay bridging the published interface (`0.0.0.0:1456`) to the loopback login server (`127.0.0.1:1455`); ports overridable via `ECC_RELAY_LISTEN` / `ECC_RELAY_TARGET`
- `compose.yaml` — publish `127.0.0.1:1455 -> 1456` on the **opt-in `real-cli-networked` service only**; the no-network default services are untouched
- `skills/docker-patterns/SKILL.md` — document the login flow, fresh `state`/`code` retry, token lifetime in the disposable container, and the fixed-port (one container at a time) constraint

## Validation

- `node --check` on the relay
- `docker compose -f docker/plugin-setup/compose.yaml config --quiet`
- `npx markdownlint-cli skills/docker-patterns/SKILL.md`
- Flow proven end-to-end in a live sandbox: browser `localhost:1455` -> published port -> relay -> loopback callback server, sign-in completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)