### PR TITLE
fix(ci): restore green main for the Itô skill test suite

### DIFF
--- a/tests/ci/ito-basket-compare-skill.test.js
+++ b/tests/ci/ito-basket-compare-skill.test.js
@@ -46,7 +46,7 @@ function main() {
   const skill = fs.readFileSync(SKILL_PATH, "utf8");
   const tests = [
     ["has valid discoverable frontmatter and representative trigger phrases", () => {
-      assert.match(skill, /^---\nname: ito-basket-compare\ndescription: [^\n]+\nmetadata:\n  origin: ECC\n---\n/);
+      assert.match(skill, /^---\nname: ito-basket-compare\ndescription: [^\n]+\nmetadata:\n {2}origin: ECC\n---\n/);
       for (const phrase of ["compare this basket", "basket vs", "gap analysis", "stale assumptions", "watchlist"]) {
         assert.match(skill.toLowerCase(), new RegExp(phrase));
       }

--- a/tests/ci/ito-inference-skill.test.js
+++ b/tests/ci/ito-inference-skill.test.js
@@ -110,7 +110,7 @@ const results = [
       {
         id: "capability:ito-compute",
         family: "capability",
-        description: "Authenticated Itô GPU inventory, RFQ, status, and explicitly gated node-qualification workflows through the separately installed canonical CLI.",
+        description: "Authenticated Itô GPU inventory, RFQ, status, device revocation, and explicitly gated node-qualification workflows through the separately installed canonical CLI.",
         modules: ["ito-compute"],
       }
     );

--- a/tests/ci/ito-trade-planner-skill.test.js
+++ b/tests/ci/ito-trade-planner-skill.test.js
@@ -34,7 +34,7 @@ function main() {
   const skill = read('skills/ito-trade-planner/SKILL.md');
   const tests = [
     ['has portable discovery metadata and representative triggers', () => {
-      assert.match(skill, /^---\nname: ito-trade-planner\ndescription: [^\n]+\nmetadata:\n  origin: ECC\n---/);
+      assert.match(skill, /^---\nname: ito-trade-planner\ndescription: [^\n]+\nmetadata:\n {2}origin: ECC\n---/);
       for (const trigger of ['trade plan', 'planning worksheet', 'venue comparison', 'basket adjustment']) {
         assert.match(skill, new RegExp(trigger, 'i'), `missing trigger phrase: ${trigger}`);
       }


### PR DESCRIPTION
`main` has been red since the Itô skill series landed. Two independent problems, both in test files rather than in shipped behavior. One commit, test-only changes.

## What was broken

**1. Stale expectation — `tests/ci/ito-inference-skill.test.js`**

The test asserted a hardcoded copy of the `capability:ito-compute` description. #2706 added device revocation to the lifecycle and updated `manifests/install-components.json:200` accordingly, but this expectation was not updated alongside it:

```
- Authenticated Itô GPU inventory, RFQ, status, and explicitly gated node-qualification workflows…
+ Authenticated Itô GPU inventory, RFQ, status, device revocation, and explicitly gated node-qualification workflows…
```

The manifest is the shipped artifact and its value is correct, so the test expectation is what was wrong. Synced it rather than touching the manifest.

**2. `no-regex-spaces` in three Itô test files**

`ito-trade-planner`, `ito-basket-compare`, and the frontmatter assertions matched YAML indentation using two literal spaces inside a regex literal. Replaced with an explicit ` {2}` quantifier, which matches identically.

## One of these was invisible in CI

`npm run lint` is `eslint . && markdownlint ...`. ESLint reported only `ito-trade-planner-skill.test.js` and stopped, so the `ito-basket-compare-skill.test.js` occurrence never appeared in any log. Fixing only what CI printed would have left `main` red on the very next run.

That `&&` also means the markdownlint half of the chain had not actually executed for some time. It passes — verified separately under the exact CI glob.

## Verification

- Full suite on this branch: **3707/3707**, exit 0
- Repo-wide `eslint .`: clean
- `markdownlint '**/*.md' --ignore node_modules`: clean
- The three affected test files individually: 3/3, 6/3, 7/7 passing

Test-only; no skill, manifest, or runtime behavior is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)