### PR TITLE
fix(hooks): treat HTTP 404 MCP probes as reachable

### DIFF
--- a/scripts/hooks/mcp-health-check.js
+++ b/scripts/hooks/mcp-health-check.js
@@ -28,8 +28,11 @@ const MAX_BACKOFF_MS = 10 * 60 * 1000;
 // Claude Code's stored OAuth bearer token. Treat auth-gated responses as
 // reachable so the real MCP client can attempt the authenticated call. A
 // Streamable HTTP MCP server can also return 406 to a bare GET that omits
-// Accept: text/event-stream; that still proves the endpoint is alive.
-const HEALTHY_HTTP_CODES = new Set([200, 201, 202, 204, 301, 302, 303, 304, 307, 308, 400, 401, 403, 405, 406]);
+// Accept: text/event-stream; that still proves the endpoint is alive. Some
+// POST-only Streamable HTTP servers (e.g. Paper Desktop) answer a bare GET
+// with 404 instead; a routed HTTP response of any kind proves reachability,
+// so treat 404 as alive and let the real MCP client validate the endpoint.
+const HEALTHY_HTTP_CODES = new Set([200, 201, 202, 204, 301, 302, 303, 304, 307, 308, 400, 401, 403, 404, 405, 406]);
 const RECONNECT_STATUS_CODES = new Set([401, 403, 429, 503]);
 const FAILURE_PATTERNS = [
   { code: 401, pattern: /\b401\b|unauthori[sz]ed|auth(?:entication)?\s+(?:failed|expired|invalid)/i },

--- a/tests/hooks/mcp-health-check.test.js
+++ b/tests/hooks/mcp-health-check.test.js
@@ -888,6 +888,77 @@ async function runTests() {
     }
   })) passed++; else failed++;
 
+  if (await asyncTest('treats HTTP 404 probe responses as healthy POST-only Streamable HTTP servers', async () => {
+    const tempDir = createTempDir();
+    const configPath = path.join(tempDir, 'claude.json');
+    const statePath = path.join(tempDir, 'mcp-health.json');
+    const serverScript = path.join(tempDir, 'http-404-server.js');
+    const portFile = path.join(tempDir, 'server-port.txt');
+
+    // Mirrors Paper Desktop: the Streamable HTTP endpoint only routes POST and
+    // answers a bare GET probe with 404, which still proves reachability.
+    fs.writeFileSync(
+      serverScript,
+      [
+        "const fs = require('fs');",
+        "const http = require('http');",
+        "const portFile = process.argv[2];",
+        "const server = http.createServer((req, res) => {",
+        "  if (req.method === 'POST' && req.url === '/mcp') {",
+        "    res.writeHead(200, { 'Content-Type': 'text/event-stream' });",
+        "    res.end('event: message\\ndata: {}\\n\\n');",
+        "    return;",
+        "  }",
+        "  res.writeHead(404, { 'Content-Type': 'text/plain' });",
+        "  res.end('not found');",
+        "});",
+        "server.listen(0, '127.0.0.1', () => {",
+        "  fs.writeFileSync(portFile, String(server.address().port));",
+        "});",
+        "setInterval(() => {}, 1000);"
+      ].join('\n')
+    );
+
+    const serverProcess = spawn(process.execPath, [serverScript, portFile], {
+      stdio: 'ignore'
+    });
+
+    try {
+      const port = waitForFile(portFile).trim();
+      await waitForHttpReady(`http://127.0.0.1:${port}/mcp`);
+
+      writeConfig(configPath, {
+        mcpServers: {
+          http404: {
+            type: 'http',
+            url: `http://127.0.0.1:${port}/mcp`
+          }
+        }
+      });
+
+      const input = { tool_name: 'mcp__http404__get_guide', tool_input: {} };
+      const result = runHook(input, {
+        CLAUDE_HOOK_EVENT_NAME: 'PreToolUse',
+        ECC_MCP_CONFIG_PATH: configPath,
+        ECC_MCP_HEALTH_STATE_PATH: statePath,
+        ECC_MCP_HEALTH_TIMEOUT_MS: '2000'
+      });
+
+      assert.strictEqual(
+        result.code,
+        0,
+        `Expected HTTP 404 probe to be treated as healthy: ${hookFailureDetails(result, statePath)}`
+      );
+      assert.strictEqual(result.stdout.trim(), JSON.stringify(input), 'Expected original JSON on stdout');
+
+      const state = readState(statePath);
+      assert.strictEqual(state.servers.http404.status, 'healthy', 'Expected POST-only HTTP MCP server to be marked healthy');
+    } finally {
+      serverProcess.kill('SIGTERM');
+      cleanupTempDir(tempDir);
+    }
+  })) passed++; else failed++;
+
   if (await asyncTest('treats HTTP 401 probe responses as healthy reachable OAuth-protected servers', async () => {
     const tempDir = createTempDir();
     const configPath = path.join(tempDir, 'claude.json');


### PR DESCRIPTION
## Problem

`mcp-health-check.js` probes HTTP MCP servers with a bare `GET`. Some Streamable HTTP servers route only `POST /mcp` and answer a bare `GET` with **404**. The preflight scores that as down and blocks every tool call for that server:

```
[MCPHealthCheck] paper is unavailable (HTTP 404). Blocking get_guide so Claude can fall back to non-MCP tools.
```

This is not transient. The backoff is 30s, after which the hook re-probes, gets 404 again, and re-blocks — so the server is unusable indefinitely while being perfectly healthy.

Reproduced against Paper Desktop 0.5.3 (`http://127.0.0.1:29979/mcp`):

| Request | Result |
|---|---|
| `GET /mcp` | `404` |
| `POST /mcp` (initialize) | `200`, `serverInfo: {"name":"paper-desktop","version":"0.5.3"}` |

## Fix

Add `404` to `HEALTHY_HTTP_CODES`.

A routed HTTP response of *any* status proves the endpoint is reachable, which is the only thing this preflight claims to check — the comment above the set already says so, and `400`/`401`/`403`/`405`/`406` are all in the set for exactly this reason. Reachability is the hook's job; endpoint validity is the real MCP client's job.

## Test

Adds `treats HTTP 404 probe responses as healthy POST-only Streamable HTTP servers`, mirroring the existing HTTP-400 case. It stands up a server that 404s on `GET` and 200s on `POST /mcp` — the Paper shape.

Verified it is a real regression test, not a tautology:

| Code state | `tests/hooks/mcp-health-check.test.js` |
|---|---|
| Without the fix | **22 passed, 1 failed** — the new test fails with `exit=2`, `lastError: "HTTP 404"` |
| With the fix | **23 passed, 0 failed** |

## Notes

- No other suite touches `HEALTHY_HTTP_CODES`; the diff is limited to that constant, its explanatory comment, and the new test.
- This is the same class of bug as #1979 (406) and #1345 / #2023 (400). Those statuses are in the set today; 404 is the remaining gap for POST-only endpoints.