### PR TITLE
fix(hooks): use valid wildcard matchers

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -36,7 +36,7 @@
         "id": "pre:edit-write:suggest-compact"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -73,7 +73,7 @@
         "id": "pre:config-protection"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -98,7 +98,7 @@
     ],
     "PreCompact": [
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -111,7 +111,7 @@
     ],
     "SessionStart": [
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -122,7 +122,7 @@
         "id": "session:start"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -135,7 +135,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -147,7 +147,7 @@
         "id": "post:dispatcher:sync"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -162,7 +162,7 @@
     ],
     "PostToolUseFailure": [
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -175,7 +175,7 @@
     ],
     "Stop": [
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -186,7 +186,7 @@
         "id": "stop:plan-canvas-pending"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -198,7 +198,7 @@
         "id": "stop:format-typecheck"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -209,7 +209,7 @@
         "id": "stop:check-console-log"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -222,7 +222,7 @@
         "id": "stop:session-end"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -235,7 +235,7 @@
         "id": "stop:evaluate-session"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -248,7 +248,7 @@
         "id": "stop:cost-tracker"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -263,7 +263,7 @@
     ],
     "SessionEnd": [
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -2492,7 +2492,7 @@ async function runTests() {
         ['post:dispatcher:sync', 'post:dispatcher:async'],
         'PostToolUse should have one sync and one async dispatcher'
       );
-      assert.ok(postEntries.every(entry => entry.matcher === '*'));
+      assert.ok(postEntries.every(entry => entry.matcher === '.*'));
 
       const preCommand = Array.isArray(preBash[0].hooks[0].command) ? preBash[0].hooks[0].command.join(' ') : preBash[0].hooks[0].command;
 
@@ -2501,6 +2501,22 @@ async function runTests() {
       assert.ok(postEntries[0].hooks[0].command.endsWith('" sync'));
       assert.ok(postEntries[1].hooks[0].command.includes('posttooluse-dispatcher.js'));
       assert.ok(postEntries[1].hooks[0].command.endsWith('" async'));
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('all string hook matchers are valid regular expressions', () => {
+      const hooksPath = path.join(__dirname, '..', '..', 'hooks', 'hooks.json');
+      const hooks = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+
+      for (const [eventName, hookArray] of Object.entries(hooks.hooks)) {
+        for (const entry of hookArray) {
+          if (typeof entry.matcher !== 'string') continue;
+          assert.doesNotThrow(() => new RegExp(entry.matcher), `${eventName}/${entry.id || 'hook'} should use a valid regex matcher`);
+        }
+      }
     })
   )
     passed++;


### PR DESCRIPTION
## What Changed
- Replace every `matcher: *` in the plugin `hooks/hooks.json` with the valid catch-all regex `matcher: .*`.
- Add a regression test that compiles every string matcher so invalid regular expressions cannot silently reach Claude Code's hook loader.

## Why This Change
Claude Code treats hook matchers as regular expressions. `*` is invalid (`Nothing to repeat`), so affected groups were silently omitted from `/hooks`. The valid `.*` pattern preserves the intended match-all behavior and keeps all existing hook groups loadable.

Closes #2748

## Testing Done
- `node scripts/ci/validate-hooks.js` — passed (`Validated 22 hook matchers`)
- Direct JSON/regex validation — passed (`Validated 22 string matchers`)
- `corepack yarn eslint tests/hooks/hooks.test.js` — passed
- `node tests/hooks/hooks.test.js` — attempted; the existing full hook suite exceeded 5 minutes on this Windows runner before completion, so no pass is claimed.

## Type of Change
- [x] `fix:` Bug fix
- [x] `test:` Tests

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format