### PR TITLE
fix(observer): pass absolute analysis paths

### DIFF
--- a/skills/continuous-learning-v2/agents/observer-loop.sh
+++ b/skills/continuous-learning-v2/agents/observer-loop.sh
@@ -153,10 +153,17 @@ analyze_observations() {
   analysis_count=$(wc -l < "$analysis_file" 2>/dev/null || echo 0)
   echo "[$(date)] Using last $analysis_count of $obs_count observations for analysis" >> "$LOG_FILE"
 
-  # Use relative path from PROJECT_DIR for cross-platform compatibility (#842).
-  # On Windows (Git Bash/MSYS2), absolute paths from mktemp may use MSYS-style
-  # prefixes (e.g. /c/Users/...) that the Claude subprocess cannot resolve.
-  analysis_relpath=".observer-tmp/$(basename "$analysis_file")"
+  # Claude Code resolves relative paths against the user's home directory on
+  # macOS/Linux, even though the observer changes to PROJECT_DIR first. Use
+  # the absolute path there so the analyzer reads the file that was sampled.
+  # Keep the relative path on Windows (Git Bash/MSYS2), where absolute paths
+  # from mktemp can contain /c/ prefixes that the Claude subprocess cannot
+  # resolve (#842, #2673).
+  if [ "${CLV2_IS_WINDOWS:-false}" = "true" ]; then
+    analysis_relpath=".observer-tmp/$(basename "$analysis_file")"
+  else
+    analysis_relpath="$analysis_file"
+  fi
 
   prompt_file="$(mktemp "${observer_tmp_dir}/ecc-observer-prompt.XXXXXX")"
   cat > "$prompt_file" <<PROMPT

--- a/tests/hooks/observer-memory.test.js
+++ b/tests/hooks/observer-memory.test.js
@@ -220,7 +220,20 @@ test('prompt references analysis_file not full OBSERVATIONS_FILE', () => {
   assert.ok(heredocStart > 0, 'Should find prompt heredoc start');
   assert.ok(heredocEnd > heredocStart, 'Should find prompt heredoc end');
   const promptSection = content.substring(heredocStart, heredocEnd);
-  assert.ok(promptSection.includes('${analysis_relpath}'), 'Prompt should point Claude at the sampled analysis file (via relative path), not the full observations file');
+  assert.ok(promptSection.includes('${analysis_relpath}'), 'Prompt should point Claude at the sampled analysis file, not the full observations file');
+});
+
+test('observer uses an absolute analysis path outside Windows', () => {
+  const content = fs.readFileSync(observerLoopPath, 'utf8');
+  assert.ok(
+    content.includes('if [ "${CLV2_IS_WINDOWS:-false}" = "true" ]') &&
+      content.includes('analysis_relpath="$analysis_file"'),
+    'macOS and Linux must pass the absolute analysis path to Claude'
+  );
+  assert.ok(
+    content.includes('analysis_relpath=".observer-tmp/$(basename "$analysis_file")"'),
+    'Windows must retain the MSYS-compatible relative analysis path'
+  );
 });
 
 test('observer-loop wait helper retries SIGUSR1-interrupted waits while claude child is alive', () => {


### PR DESCRIPTION
## Summary

Closes #2673.

The observer hook now receives an absolute analysis-file path on non-Windows systems, avoiding Claude resolving the relative path against HOME and silently archiving an empty observation. Windows keeps its existing relative-path behavior. Added regression coverage for both platforms.

## Validation

- node tests/hooks/observer-memory.test.js (32 passed)
- git diff --check
- bash syntax check unavailable on this Windows host (bash is not installed)