### PR TITLE
fix(gan): allow Playwright tools in evaluator

### DIFF
--- a/agents/gan-evaluator.md
+++ b/agents/gan-evaluator.md
@@ -1,7 +1,7 @@
 ---
 name: gan-evaluator
 description: "GAN Harness — Evaluator agent. Tests the live running application via Playwright, scores against rubric, and provides actionable feedback to the Generator."
-tools: Read, Write, Bash, Grep, Glob
+tools: Read, Write, Bash, Grep, Glob, mcp__playwright__browser_navigate, mcp__playwright__browser_click, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_snapshot, mcp__playwright__browser_type, mcp__playwright__browser_fill_form
 model: sonnet
 color: red
 ---
@@ -34,6 +34,12 @@ You are the QA Engineer and Design Critic. You test the **live running applicati
 - DO compare against what a professional human developer would ship
 
 ## Evaluation Workflow
+
+Before testing, record the mode that is actually available. The requested mode
+is not proof that its tools were available: if the Playwright MCP tools cannot
+be called, switch to the documented `screenshot` or `code-only` fallback and
+report that degradation instead of silently scoring a static review as a live
+browser evaluation.
 
 ### Step 1: Read the Rubric
 ```
@@ -128,6 +134,14 @@ Write feedback to `gan-harness/feedback/feedback-NNN.md`:
 # Evaluation — Iteration NNN
 
 ## Scores
+
+## Evaluation Mode
+
+**Achieved:** `playwright` | `screenshot` | `code-only`
+
+State the mode that was actually completed (not merely the mode requested by
+the harness). If the requested mode was unavailable, briefly explain why and
+which fallback was used.
 
 | Criterion | Score | Weight | Weighted |
 |-----------|-------|--------|----------|

--- a/tests/ci/gan-evaluator-tools.test.js
+++ b/tests/ci/gan-evaluator-tools.test.js
@@ -1,0 +1,34 @@
+/**
+ * Regression coverage for the GAN evaluator's live-browser capability.
+ *
+ * Run with: node tests/ci/gan-evaluator-tools.test.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const evaluatorPath = path.join(__dirname, '..', '..', 'agents', 'gan-evaluator.md');
+const content = fs.readFileSync(evaluatorPath, 'utf8');
+const frontmatter = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+
+assert.ok(frontmatter, 'gan-evaluator.md should have frontmatter');
+const toolsLine = frontmatter[1].match(/^tools:\s*(.+)$/m);
+assert.ok(toolsLine, 'gan-evaluator.md should declare tools');
+
+const tools = new Set(toolsLine[1].split(',').map(tool => tool.trim()));
+for (const tool of [
+  'mcp__playwright__browser_navigate',
+  'mcp__playwright__browser_click',
+  'mcp__playwright__browser_take_screenshot',
+  'mcp__playwright__browser_snapshot',
+  'mcp__playwright__browser_type',
+  'mcp__playwright__browser_fill_form',
+]) {
+  assert.ok(tools.has(tool), `gan-evaluator.md should grant ${tool}`);
+}
+
+assert.match(content, /\*\*Achieved:\*\* `playwright` \| `screenshot` \| `code-only`/);
+assert.match(content, /mode that was actually completed/);
+
+console.log('GAN evaluator tools and achieved-mode contract are present.');


### PR DESCRIPTION
## Summary

Closes #2675.

The GAN evaluator instructions now grant the Playwright browser tools they already require and explicitly record whether browser evaluation was achieved or fell back. Added a regression test for the frontmatter tool list and achieved-mode requirement.

## Validation

- standalone regression test passed
- node scripts/ci/validate-agents.js (67 files)
- git diff --check