### PR TITLE
fix(gateguard): cap session fact-force denials

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -905,6 +905,17 @@ function getFullDenialBudget() {
   return DEFAULT_FULL_DENIALS;
 }
 
+// Edit/Write fact forcing can be capped per session instead of denying every
+// new path forever. Keep the existing behavior when unset; hosts can opt in
+// to a session-wide ceiling without weakening the destructive-Bash gate.
+function getMaxDenialBudget() {
+  const raw = Number.parseInt(process.env.GATEGUARD_FACT_FORCE_MAX_DENIALS || '', 10);
+  if (Number.isInteger(raw) && raw >= 0) {
+    return raw;
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
 function getDenialCount(state) {
   const n = Number(state && state.fact_force_denials);
   return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0;
@@ -1204,6 +1215,9 @@ function run(rawInput) {
       if (!ok) {
         return allowWithStateWarning();
       }
+      if (denials > getMaxDenialBudget()) {
+        return rawInput;
+      }
       if (denials > getFullDenialBudget()) {
         const action = toolName === 'Edit' ? 'edit' : 'creation';
         return denyResult(condensedGateMsg(action, filePath, denials), { includeRecoveryHint: false });
@@ -1226,6 +1240,9 @@ function run(rawInput) {
         const { ok, denials } = markCheckedAndCountDenial(filePath);
         if (!ok) {
           return allowWithStateWarning();
+        }
+        if (denials > getMaxDenialBudget()) {
+          return rawInput;
         }
         if (denials > getFullDenialBudget()) {
           return denyResult(condensedGateMsg('edit', filePath, denials), { includeRecoveryHint: false });

--- a/skills/gateguard/SKILL.md
+++ b/skills/gateguard/SKILL.md
@@ -106,6 +106,12 @@ near-identical blocks cannot accumulate in the context window and
 amplify model repetition loops (#2142). Retrying the same file or
 command after presenting facts never re-triggers the gate.
 
+Set `GATEGUARD_FACT_FORCE_MAX_DENIALS` to cap the total number of new-path
+Edit/Write denials in a session. It is opt-in (unset preserves the existing
+behavior); after the configured number of denials new paths are allowed while
+destructive Bash remains gated independently. `GATEGUARD_FACT_FORCE_FULL_DENIALS`
+only controls message detail.
+
 ### Option B: Full package with config
 
 ```bash

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -2222,6 +2222,38 @@ function runTests() {
 
   clearState();
   if (
+    test('allows new paths after the session-wide denial budget', () => {
+      writeState({ checked: [], last_active: Date.now(), fact_force_denials: 3 });
+      const result = runHook(
+        { tool_name: 'Edit', tool_input: { file_path: '/src/after-budget.js' } },
+        { GATEGUARD_FACT_FORCE_MAX_DENIALS: '3' }
+      );
+      assert.strictEqual(result.code, 0);
+      const output = parseOutput(result.stdout);
+      assert.ok(!output || !output.hookSpecificOutput, 'paths after the budget should pass through');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('MultiEdit allows new paths after the session-wide denial budget', () => {
+      writeState({ checked: [], last_active: Date.now(), fact_force_denials: 3 });
+      const result = runHook(
+        { tool_name: 'MultiEdit', tool_input: { edits: [{ file_path: '/src/after-multi-budget.js', old_string: 'a', new_string: 'b' }] } },
+        { GATEGUARD_FACT_FORCE_MAX_DENIALS: '3' }
+      );
+      assert.strictEqual(result.code, 0);
+      const output = parseOutput(result.stdout);
+      assert.ok(!output || !output.hookSpecificOutput, 'MultiEdit paths after the budget should pass through');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
     test('malformed denial counter in state is treated as zero (full block, no crash)', () => {
       writeState({ checked: [], last_active: Date.now(), fact_force_denials: 'garbage' });
       const result = runHook({ tool_name: 'Edit', tool_input: { file_path: '/src/damp-malformed.js' } });


### PR DESCRIPTION
## Summary

Closes #2608.

Add an opt-in GATEGUARD_FACT_FORCE_MAX_DENIALS session ceiling for Edit/Write/MultiEdit first-touch gates. Once the configured number of denials is reached, new paths pass through while retries and destructive Bash behavior remain unchanged. Only a complete non-negative decimal integer sets the cap; anything else leaves the gate uncapped. Document the distinction from the existing full-message budget.

## Validation

Run locally on Windows with Node 24.20.0 at 09c8069:

- `node tests/hooks/gateguard-fact-force.test.js`: 207 passed, 0 failed
- `node --check scripts/hooks/gateguard-fact-force.js`: ok
- `git diff --check`: clean

The diff against `main` touches only `scripts/hooks/gateguard-fact-force.js`, `skills/gateguard/SKILL.md`, and `tests/hooks/gateguard-fact-force.test.js`. An accidental Yarn classic rewrite of `yarn.lock` in ef0a487 broke the hardened yarn install jobs; bc464fd restores the lockfile from `main`.
