### PR TITLE
docs(rules): clarify 800-line review ceiling

### DIFF
--- a/rules/common/code-review.md
+++ b/rules/common/code-review.md
@@ -28,7 +28,7 @@ Before marking code complete:
 
 - [ ] Code is readable and well-named
 - [ ] Functions are focused (<50 lines)
-- [ ] Files are cohesive (<800 lines)
+- [ ] Source files are cohesive (under the 800-line soft maintainability ceiling, or include a reason for a deliberate exception)
 - [ ] No deep nesting (>4 levels)
 - [ ] Errors are handled explicitly
 - [ ] No hardcoded secrets or credentials
@@ -54,7 +54,7 @@ Before marking code complete:
 |-------|---------|--------|
 | CRITICAL | Security vulnerability or data loss risk | **BLOCK** - Must fix before merge |
 | HIGH | Bug or significant quality issue | **WARN** - Should fix before merge |
-| MEDIUM | Maintainability concern | **INFO** - Consider fixing |
+| MEDIUM | Maintainability concern, including an unexplained source file over the soft 800-line ceiling | **INFO** - Consider fixing |
 | LOW | Style or minor suggestion | **NOTE** - Optional |
 
 ## Agent Usage

--- a/rules/common/coding-style.md
+++ b/rules/common/coding-style.md
@@ -36,7 +36,8 @@ Rationale: Immutable data prevents hidden side effects, makes debugging easier, 
 
 MANY SMALL FILES > FEW LARGE FILES:
 - High cohesion, low coupling
-- 200-400 lines typical, 800 max
+- 200-400 lines typical, with 800 lines as a soft maintainability ceiling for source files
+- Test, generated, and vendored files may exceed the ceiling when their size is justified by their role
 - Extract utilities from large modules
 - Organize by feature/domain, not by type
 


### PR DESCRIPTION
## What Changed
- clarify that 800 lines is a soft maintainability ceiling for source files
- document justified exceptions for test, generated, and vendored files
- align the code-review severity wording with the coding-style guidance

## Why This Change
Closes #2580 by removing the conflicting reading where coding-style.md described 800 lines as a hard maximum while code-review.md treated it as a non-blocking maintainability note. The rules now consistently distinguish source files from test/generated/vendor files.

## Testing Done
- 
ode scripts/ci/validate-rules.js (122 rule files validated)
- 
ode scripts/ci/check-unicode-safety.js
- git diff --check
- Markdownlint unavailable locally (dependency not installed)

## Type of Change
- [x] docs: Documentation

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] Follows conventional commits format