### PR TITLE
fix(plugin): export only plugin function for opencode loader compatibility

### DIFF
--- a/.opencode/index.ts
+++ b/.opencode/index.ts
@@ -35,46 +35,6 @@
  */
 
 // Export the main plugin
-export { ECCHooksPlugin, default } from "./plugins/index.js"
-
-// Export individual components for selective use
-export * from "./plugins/index.js"
-
-// Version export
-export const VERSION = "1.6.0"
-
-// Plugin metadata
-export const metadata = {
-  name: "ecc-universal",
-  version: VERSION,
-  description: "ECC plugin for OpenCode",
-  author: "affaan-m",
-  features: {
-    agents: 13,
-    commands: 31,
-    skills: 37,
-    configAssets: true,
-    hookEvents: [
-      "file.edited",
-      "tool.execute.before",
-      "tool.execute.after",
-      "session.created",
-      "session.idle",
-      "session.deleted",
-      "file.watcher.updated",
-      "permission.ask",
-      "todo.updated",
-      "shell.env",
-      "experimental.session.compacting",
-    ],
-    customTools: [
-      "run-tests",
-      "check-coverage",
-      "security-audit",
-      "format-code",
-      "lint-check",
-      "git-summary",
-      "changed-files",
-    ],
-  },
-}
+// opencode's legacy plugin loader iterates every module export and throws if
+// any is not a plugin function, so only the plugin function may be exported.
+export { default } from "./plugins/index.js"

--- a/tests/scripts/build-opencode.test.js
+++ b/tests/scripts/build-opencode.test.js
@@ -89,6 +89,7 @@ function main() {
           for (const hook of expectedHooks) {
             assert.strictEqual(typeof plugin[hook], "function", "missing hook: " + hook)
           }
+          assert.ok(plugin.tool && typeof plugin.tool === "object", "plugin record must expose a tool object")
           assert.deepStrictEqual(
             Object.keys(plugin.tool).sort(),
             ["changed-files", "dependency-analyzer"],

--- a/tests/scripts/build-opencode.test.js
+++ b/tests/scripts/build-opencode.test.js
@@ -49,11 +49,44 @@ function main() {
       const check = `
         const assert = require("assert")
         const { pathToFileURL } = require("url")
-        const file = process.argv[1]
-        import(pathToFileURL(file).href).then((mod) => {
+
+        async function main() {
+          let mod
+          try {
+            mod = await import(pathToFileURL(process.argv[1]).href)
+          } catch (error) {
+            console.error(error)
+            process.exit(1)
+          }
           assert.deepStrictEqual(Object.keys(mod).sort(), ["default"])
           assert.strictEqual(typeof mod.default, "function")
-        }).catch((error) => {
+
+          const plugin = await mod.default({
+            client: { app: { log: () => {} } },
+            $: async () => { throw new Error("$ must not be called during plugin init") },
+            directory: process.cwd(),
+            worktree: process.cwd(),
+          })
+          assert.ok(plugin && typeof plugin === "object", "default export must return a plugin record")
+          const expectedHooks = [
+            "file.edited",
+            "tool.execute.after",
+            "tool.execute.before",
+            "session.created",
+            "session.idle",
+            "session.deleted",
+            "file.watcher.updated",
+            "todo.updated",
+            "shell.env",
+            "experimental.session.compacting",
+            "permission.ask",
+          ]
+          for (const hook of expectedHooks) {
+            assert.strictEqual(typeof plugin[hook], "function", "missing hook: " + hook)
+          }
+        }
+
+        main().catch((error) => {
           console.error(error)
           process.exit(1)
         })

--- a/tests/scripts/build-opencode.test.js
+++ b/tests/scripts/build-opencode.test.js
@@ -45,6 +45,25 @@ function main() {
       assert.strictEqual(result.status, 0, result.stderr)
       assert.ok(fs.existsSync(distEntry), ".opencode/dist/index.js should exist after build")
     }],
+    ["built OpenCode entry exports only the plugin function", () => {
+      const check = `
+        const assert = require("assert")
+        const { pathToFileURL } = require("url")
+        const file = process.argv[1]
+        import(pathToFileURL(file).href).then((mod) => {
+          assert.deepStrictEqual(Object.keys(mod).sort(), ["default"])
+          assert.strictEqual(typeof mod.default, "function")
+        }).catch((error) => {
+          console.error(error)
+          process.exit(1)
+        })
+      `
+      const result = spawnSync(process.execPath, ["-e", check, distEntry], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      })
+      assert.strictEqual(result.status, 0, result.stderr)
+    }],
     ["npm pack includes the compiled OpenCode dist payload", () => {
       const result = spawnSync("npm", ["pack", "--dry-run", "--json"], {
         cwd: repoRoot,

--- a/tests/scripts/build-opencode.test.js
+++ b/tests/scripts/build-opencode.test.js
@@ -61,12 +61,17 @@ function main() {
           assert.deepStrictEqual(Object.keys(mod).sort(), ["default"])
           assert.strictEqual(typeof mod.default, "function")
 
+          let shellCalls = 0
           const plugin = await mod.default({
             client: { app: { log: () => {} } },
-            $: async () => { throw new Error("$ must not be called during plugin init") },
+            $: async () => {
+              shellCalls += 1
+              throw new Error("$ must not be called during plugin init")
+            },
             directory: process.cwd(),
             worktree: process.cwd(),
           })
+          assert.strictEqual(shellCalls, 0, "$ must not be called during plugin init")
           assert.ok(plugin && typeof plugin === "object", "default export must return a plugin record")
           const expectedHooks = [
             "file.edited",
@@ -83,6 +88,18 @@ function main() {
           ]
           for (const hook of expectedHooks) {
             assert.strictEqual(typeof plugin[hook], "function", "missing hook: " + hook)
+          }
+          assert.deepStrictEqual(
+            Object.keys(plugin.tool).sort(),
+            ["changed-files", "dependency-analyzer"],
+            "plugin.tool must expose exactly the custom tools"
+          )
+          for (const toolName of ["changed-files", "dependency-analyzer"]) {
+            const toolDefinition = plugin.tool[toolName]
+            assert.ok(toolDefinition && typeof toolDefinition === "object", "missing tool: " + toolName)
+            assert.strictEqual(typeof toolDefinition.description, "string", toolName + " must declare a description")
+            assert.ok(toolDefinition.args && typeof toolDefinition.args === "object", toolName + " must declare args")
+            assert.strictEqual(typeof toolDefinition.execute, "function", toolName + " must declare an execute function")
           }
         }
 


### PR DESCRIPTION
## Problem

opencode's legacy plugin loader (getLegacyPlugins) iterates every module export and throws 'Plugin export is not a function' if any export is not a plugin function. The ecc-universal bundle exported VERSION (string) and metadata (object) alongside the plugin function, which breaks plugin loading in opencode.

## Fix

Export only the plugin function from the entry point. ECCHooksPlugin remains reachable via the default export, so all hooks and custom tools stay available.

## Verification

- import() of the rebuilt dist exposes exactly one export: default (typeof function).
- Verified loading in opencode - plugin initializes without the 'Plugin export is not a function' error.