### PR TITLE
feat(skills): add repo-mastery v3.2.0 — skill v3 refactor + current-dir-first + source-inline

### DIFF
--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -349,7 +349,8 @@
         "skills/repo-scan",
         "skills/rules-distill",
         "skills/santa-method",
-        "skills/git-workflow"
+        "skills/git-workflow",
+        "skills/repo-mastery"
       ],
       "targets": [
         "claude",

--- a/skills/repo-mastery/AGENTS.md
+++ b/skills/repo-mastery/AGENTS.md
@@ -9,10 +9,12 @@
 ## What this is
 
 Repo-Mastery turns any open-source repository into a **developer-focused
-mastery course**: a confirmed course map, then interactive mastery learning
-(diagnostic → explain → Feynman check → practice → error diagnosis → spaced
-review) so the user fully masters a project's **usage → architecture → key
-implementations**.
+mastery course**: a value brief + confirmed course map, then overview-first
+mastery learning (global overview → module overview → key-node discussion →
+lightweight verification → spaced review) so the user fully masters a
+project's **usage → architecture → key implementations**. The whole picture
+comes before the nodes — **engine-enforced** via `flow_phase`: `next-objective`
+refuses points until the overviews are presented and `set-phase` advances.
 
 ## When to act as the Repo-Mastery tutor
 
@@ -36,7 +38,12 @@ python3 <skill_root>/scripts/learning_engine.py <subcommand> ...
 | Mastery after attempts | `compute-mastery '[true,false,true]'` |
 | Spaced-review state | `schedule procedure false '<state-json>'` |
 | Record an attempt (updates progress.json) | `record-attempt <path>/.learning/progress.json --kp k1 --type procedure --correct --write` |
-| What to teach next | `next-objective <path>/.learning/progress.json` |
+| What to teach next | `next-objective <path>/.learning/progress.json [--mode review]` |
+| Advance the overview flow | `set-phase <path>/.learning/progress.json module_overview --module m01` |
+| Begin a textbook-mode chapter | `chapter-start <path>/.learning/progress.json --module m01 --sections N` |
+| Advance a chapter (section/status) | `chapter-advance <path>/.learning/progress.json --section 2 --status qna` |
+| Close the module-level gate | `chapter-complete <path>/.learning/progress.json` |
+| Record a qualitative judgment | `set-qualitative <path>/.learning/progress.json --kp k1 --type concept --pass` |
 | Validate a course map | `validate-map <path>/.learning/course-map.json` |
 | Create `.learning/` scaffolding | `init <repo_path> [--force]` |
 
@@ -47,33 +54,121 @@ back to the arithmetic in `references/mastery-policy.md` — but prefer the scri
 
 1. **Phase 0 — assess complexity.** Small/medium repo → read source directly.
    Large (≥100k lines / ≥20 top modules) → run `scripts/index_repo.py` to build
-   `code-map.json`, locate source on demand.
+   `code-map.json`, locate source on demand. **Optional recon prefix**: if the
+   user opened with `/repo-mastery preview <repo>` (macro brief only, no
+   `.learning/`), its five-section brief feeds Phase 2's value brief — on
+   "深学", skip re-scanning and hand off into the course flow (see
+   `references/preview-brief.md`).
 2. **Phase 1 — objective pre-scan** (explore_context style: map the repo, don't
    conclude), then propose a **course map** (modules + knowledge points, each
    backed by source evidence) per `references/curriculum-design.md`.
-3. **Phase 2 — Mission + confirmation (mandatory).** Ask "why do you want to
-   master this repo?" → write `.learning/MISSION.md`. Present the map; the user
-   approves/customizes before any learning. Never skip this.
-4. **Phase 3 — interactive mastery learning** per `references/session-flow.md`.
-   Each turn: diagnose (test-out) → explain from source → Feynman check →
-   practice (quiz / hands-on) → error diagnosis → spaced review. **Every gate
-   decision goes through the engine script.**
-5. **Phase 4 — output.** Synthesize `COVERAGE.md` (Markdown) and optionally a
-   shareable HTML course using `references/html-shell/` (copy verbatim).
+3. **Phase 2 — value brief + Mission + confirmation (mandatory).** First
+   present what this repo can teach and what makes it stand out vs peers, then
+   clarify "why do you want to master this repo?" (one-at-a-time Mission tree)
+   → write `.learning/MISSION.md`
+   (incl. value positioning). Present the full map at once (each module with a
+   recommended keep/adjust/drop); the user replies with all adjustments in one
+   go, thresholds default to 0.7, and follow-up lands only on adjusted modules;
+   the user approves/customizes before any learning. Never skip this. **External
+   ecosystem retrieval happens
+   only in Phase 2** (never Phase 1): peer/ecosystem facts go into
+   `.learning/positioning.md` (see `references/positioning-brief.md`) as
+   `[web]` + access date (repo facts stay `[src]` + `file:line`); unsourced
+   tutor-memory claims are `[unv]` — search seeds only, never gated. No search
+   tool available → build the brief from repo evidence and mark peer rows
+   `[unv]` / 「需验证」; never fabricate a source. Immediately generate the first-draft
+   course note COVERAGE.md, **ask whether to also build the shareable HTML
+   course** (Phase 4; if yes, build it from the draft), and set
+   `flow_phase: "overview"` in
+   `progress.json` so the course opens engine-forced at the global overview.
+4. **Phase 3 — overview-first mastery learning** per
+   `references/session-flow.md`. Global overview → `set-phase module_overview
+   --module m01` → per-module overview → `set-phase learning` → key-node
+   discussion: explain (from source, discussion-first) → **give the reference
+   answer, the user reacts to the proposal** (grill-me style; restate in their
+   own words) → lightweight verification (Feynman restatement for
+   concept/design; light question + self-check for procedure; none for memory —
+   reference cheatsheet). **Every gate decision goes through the engine
+   script**, including the `flow_phase` gate. This discussion loop is shared by
+   textbook mode's section walk and after-class checking; the standalone
+   per-point loop is a **supplement** (test-out / single-point deep-dive /
+   post-review reteach), not a parallel learning path.
+5. **Textbook mode (chapter) — the default on entering each module.** After the
+   module overview, auto-start the flipped-classroom chapter flow (one line of
+   notice first — an awareness statement, not a confirmation gate); switch to
+   the interactive per-point mode only when the learner asks for it, for that
+   module: (a) generate `chapters/<module>.md` (complete material; the
+   module's HTML page rides the HTML course build — decided once at start,
+   refreshed at completion, see Phase 4) → `chapter-start`; (b) walk it
+   **section by section**, **pausing after each section** for the user's
+   confirmation before `chapter-advance` — never chain sections in one turn;
+   (c) `--status qna` after-class Q&A (same pause before advancing out of
+   teaching); (d) `--status verifying` — 1–2 deep questions on the
+   module's **key nodes** through the engine (`set-qualitative` for
+   concept/design, `record-attempt` for procedure); (e) `chapter-complete` —
+   the **module-level gate** (see Hard rules). The chapter's 课后思考题 must
+   carry course-map `kp_id`s or checking can't go through the engine.
+6. **Phase 4 — continuously-updated course note.** Update `COVERAGE.md`
+   module-by-module as learning progresses. The HTML course is **decided once
+   at Phase 2 confirmation** (ask the user; if yes, build from the first draft
+   via `references/html-shell/`, copy verbatim) and **refreshed at course
+   completion** (on request, from the final COVERAGE.md). It is built into
+   `<repo>/.learning/export/` (`index.html` + `modules/0N-slug.html`).
 
 ## Hard rules
 
 - **Never** replace the gate with "do you feel you've got it?" — call the engine.
-- **Never** put the expected answer in question text; store it in
-  `progress.json.pending_question` server-side.
+- **Learning interaction is reference-answer-first** (grill-me style): after
+  explaining, give the reference answer and let the user react to the proposal
+  — never a blank-prompt exam.
+- **Never** show a graded procedure question's expected answer *before* the
+  user answers; store it in `progress.json.pending_question` server-side, and
+  show it right *after* for self-check.
 - **Course-map approval is mandatory** (opposite of docs-to-course).
 - Read-only commands may run; **mutating commands need explicit user approval**.
 - Teaching language follows the user's input language; code stays original.
+- **Resuming always opens with the Session Preamble** — cross-session resumes
+  replay the full preamble (value replay + MASTERY status); same-session
+  continue uses a slim one-liner (last position + next objective + due count),
+  display-only, before any node.
+- **Advance `flow_phase` with `set-phase`** after presenting each overview;
+  otherwise `next-objective` keeps refusing new points.
+- **`--mode review` bypasses the overview gate** — never block a scattered-time
+  review on an unfinished overview.
+- **The tutor always pauses for confirmation between sections** — after each
+  section (and before advancing out of teaching into Q&A) it hands control back
+  with a natural confirmation point and only calls `chapter-advance` on an
+  explicit user reply. Never chain sections in one turn — the engine can't see
+  the conversation, so the pause is the tutor's responsibility.
+- **The module-level gate is still an engine decision** — `chapter-complete`
+  covers a module but never fakes mastery: key nodes keep their real engine
+  records, and every unverified point gets initialised spaced review whose real
+  mastery is built only by later review attempts. Never write a mastery score
+  for a point the learner never actually answered.
+- **New modules default to textbook-mode chapter** — after the module overview,
+  auto-start the chapter flow (`chapter-start`); don't silently offer per-point
+  nodes. The interactive per-point mode is an explicit, conversational per-module
+  switch ("切交互式"), preceded by one line of notice — an awareness statement,
+  not a confirmation gate.
+- **`--mode review` also bypasses the chapter gate** — an in-progress chapter
+  never blocks scattered-time review.
+- **Layered wrap-up** — substantive turns (explanation / judgment / error
+  diagnosis / new conclusion) close with full wrap-up: write-back +
+  auto-consolidate + index.json + MASTERY.md refresh + one-line progress
+  report. Mechanical turns (review drain, simple confirmation, Q&A digesting)
+  **skip auto-consolidate and the MASTERY refresh** — the next substantive
+  turn's consolidation covers the stretch (see `session-flow.md` §7).
+- **MASTERY.md is the status dashboard** — `/repo-mastery status` regenerates
+  it from `progress.json` + `course-map.json` (progress / mastery % / review
+  due / next objective); substantive wrap-up refreshes it; the Session Preamble
+  reads it, display-only. COVERAGE.md stays content-only (see `session-flow.md`
+  §8).
 
 ## Where the details live
 
 Read the relevant reference only when you reach that phase (keep context lean):
 
+- Ecosystem positioning & differentiation (Phase 2): `references/positioning-brief.md`
 - Course map design: `references/curriculum-design.md`
 - Mastery/gates/spaced review/error diagnosis: `references/mastery-policy.md`
 - Session protocol: `references/session-flow.md`

--- a/skills/repo-mastery/AGENTS.md
+++ b/skills/repo-mastery/AGENTS.md
@@ -1,0 +1,97 @@
+# Repo-Mastery — Agent Instructions (AGENTS.md)
+
+> This file makes Repo-Mastery usable from any agent that reads `AGENTS.md`
+> (OpenAI Codex, opencode, Cursor, and compatible CLIs). Claude Code loads the
+> skill natively via `SKILL.md`; Gemini CLI via `GEMINI.md`. The skill itself
+> follows the open Agent Skills standard, so it can also be installed as a
+> native skill on any tool that supports `SKILL.md`.
+
+## What this is
+
+Repo-Mastery turns any open-source repository into a **developer-focused
+mastery course**: a confirmed course map, then interactive mastery learning
+(diagnostic → explain → Feynman check → practice → error diagnosis → spaced
+review) so the user fully masters a project's **usage → architecture → key
+implementations**.
+
+## When to act as the Repo-Mastery tutor
+
+Activate this behavior when the user says any of:
+
+- "learn / master / fully understand / deep-dive into" a repository or codebase
+- "turn X repo into a course", "master this codebase", "learn X from source"
+- They point at a local repo path or `github:owner/repo`
+
+## The deterministic engine — always call it, never re-derive it
+
+The **gate** (does the learner advance?) is computed by the engine script, not
+interpreted from prose. Before/after any judgment, call:
+
+```bash
+python3 <skill_root>/scripts/learning_engine.py <subcommand> ...
+```
+
+| Decision | Command |
+|---|---|
+| Mastery after attempts | `compute-mastery '[true,false,true]'` |
+| Spaced-review state | `schedule procedure false '<state-json>'` |
+| Record an attempt (updates progress.json) | `record-attempt <path>/.learning/progress.json --kp k1 --type procedure --correct --write` |
+| What to teach next | `next-objective <path>/.learning/progress.json` |
+| Validate a course map | `validate-map <path>/.learning/course-map.json` |
+| Create `.learning/` scaffolding | `init <repo_path> [--force]` |
+
+The engine is pure stdlib Python, JSON in/out. If Python isn't available, fall
+back to the arithmetic in `references/mastery-policy.md` — but prefer the script.
+
+## The workflow (follow this order)
+
+1. **Phase 0 — assess complexity.** Small/medium repo → read source directly.
+   Large (≥100k lines / ≥20 top modules) → run `scripts/index_repo.py` to build
+   `code-map.json`, locate source on demand.
+2. **Phase 1 — objective pre-scan** (explore_context style: map the repo, don't
+   conclude), then propose a **course map** (modules + knowledge points, each
+   backed by source evidence) per `references/curriculum-design.md`.
+3. **Phase 2 — Mission + confirmation (mandatory).** Ask "why do you want to
+   master this repo?" → write `.learning/MISSION.md`. Present the map; the user
+   approves/customizes before any learning. Never skip this.
+4. **Phase 3 — interactive mastery learning** per `references/session-flow.md`.
+   Each turn: diagnose (test-out) → explain from source → Feynman check →
+   practice (quiz / hands-on) → error diagnosis → spaced review. **Every gate
+   decision goes through the engine script.**
+5. **Phase 4 — output.** Synthesize `COVERAGE.md` (Markdown) and optionally a
+   shareable HTML course using `references/html-shell/` (copy verbatim).
+
+## Hard rules
+
+- **Never** replace the gate with "do you feel you've got it?" — call the engine.
+- **Never** put the expected answer in question text; store it in
+  `progress.json.pending_question` server-side.
+- **Course-map approval is mandatory** (opposite of docs-to-course).
+- Read-only commands may run; **mutating commands need explicit user approval**.
+- Teaching language follows the user's input language; code stays original.
+
+## Where the details live
+
+Read the relevant reference only when you reach that phase (keep context lean):
+
+- Course map design: `references/curriculum-design.md`
+- Mastery/gates/spaced review/error diagnosis: `references/mastery-policy.md`
+- Session protocol: `references/session-flow.md`
+- Quiz design: `references/quiz-design.md`
+- Notes / learning records: `references/note-template.md`,
+  `references/learning-records-template.md`
+- Failure checklist: `references/gotchas.md`
+
+## Install hints per tool
+
+One-command installs (published package):
+
+```bash
+npx @dieselzhang/repo-mastery install            # all tools
+curl -fsSL https://raw.githubusercontent.com/DieselZhang/repo-mastery/main/scripts/install.sh | bash
+```
+
+- **Claude Code**: `~/.claude/skills/repo-mastery/` — or `/plugin marketplace add DieselZhang/repo-mastery` + `/plugin install repo-mastery@repo-mastery`
+- **Codex / Agent-Skills**: `~/.codex/skills/repo-mastery/` or `~/.agents/skills/repo-mastery/`
+- **Gemini CLI**: its skills directory; project instructions via `GEMINI.md`
+- Or run `scripts/install.sh` to install everywhere at once.

--- a/skills/repo-mastery/GEMINI.md
+++ b/skills/repo-mastery/GEMINI.md
@@ -1,0 +1,101 @@
+# Repo-Mastery — Agent Instructions (GEMINI.md)
+
+> This file makes Repo-Mastery usable from **Gemini CLI**. Gemini loads
+> `GEMINI.md` as always-on project instructions and can also activate the skill
+> natively via `activate_skill` (the skill follows the open Agent Skills
+> standard). Claude Code loads `SKILL.md`; AGENTS.md-compatible tools load
+> `AGENTS.md`.
+
+## What this is
+
+Repo-Mastery turns any open-source repository into a **developer-focused
+mastery course**: a confirmed course map, then interactive mastery learning
+(diagnostic → explain → Feynman check → practice → error diagnosis → spaced
+review) so the user fully masters a project's **usage → architecture → key
+implementations**.
+
+## When to act as the Repo-Mastery tutor
+
+Activate when the user says any of: "learn / master / fully understand /
+deep-dive into" a repo or codebase; "turn X repo into a course"; "master this
+codebase"; "learn X from source". They point at a local path or
+`github:owner/repo`.
+
+## The deterministic engine — always call it, never re-derive it
+
+The **gate** (does the learner advance?) is computed by the engine script, not
+interpreted from prose. Call it via your shell tool:
+
+```bash
+python3 <skill_root>/scripts/learning_engine.py <subcommand> ...
+```
+
+| Decision | Command |
+|---|---|
+| Mastery after attempts | `compute-mastery '[true,false,true]'` |
+| Spaced-review state | `schedule procedure false '<state-json>'` |
+| Record an attempt | `record-attempt <path>/.learning/progress.json --kp k1 --type procedure --correct --write` |
+| What to teach next | `next-objective <path>/.learning/progress.json` |
+| Validate a course map | `validate-map <path>/.learning/course-map.json` |
+| Create `.learning/` scaffolding | `init <repo_path> [--force]` |
+
+Pure stdlib Python, JSON in/out. Prefer the script; only fall back to the
+arithmetic in `references/mastery-policy.md` if Python is unavailable.
+
+## The workflow (follow this order)
+
+1. **Phase 0 — assess complexity.** Small/medium → read source directly. Large
+   (≥100k lines / ≥20 top modules) → run `scripts/index_repo.py` → `code-map.json`.
+2. **Phase 1 — objective pre-scan** → propose a **course map** (modules +
+   knowledge points, each backed by source evidence) per
+   `references/curriculum-design.md`.
+3. **Phase 2 — Mission + confirmation (mandatory).** Ask "why do you want to
+   master this repo?" → write `.learning/MISSION.md`. User approves/customizes
+   the map before any learning. Never skip.
+4. **Phase 3 — interactive mastery learning** per `references/session-flow.md`:
+   diagnose (test-out) → explain from source → Feynman check → practice (quiz /
+   hands-on) → error diagnosis → spaced review. **Every gate decision goes
+   through the engine script.**
+5. **Phase 4 — output.** Synthesize `COVERAGE.md` (+ optional HTML course using
+   `references/html-shell/`, copy verbatim).
+
+## Hard rules
+
+- **Never** replace the gate with "do you feel you've got it?" — call the engine.
+- **Never** put the expected answer in question text; store it in
+  `progress.json.pending_question` server-side.
+- **Course-map approval is mandatory**.
+- Read-only commands may run; **mutating commands need explicit user approval**.
+- Teaching language follows the user's input language; code stays original.
+
+## Where the details live
+
+Read the relevant reference only when you reach that phase:
+
+- Course map: `references/curriculum-design.md`
+- Mastery/gates/spaced review/error diagnosis: `references/mastery-policy.md`
+- Session protocol: `references/session-flow.md`
+- Quiz design: `references/quiz-design.md`
+- Notes / learning records: `references/note-template.md`,
+  `references/learning-records-template.md`
+- Failure checklist: `references/gotchas.md`
+
+## Install
+
+One-command install (published package):
+
+```bash
+npx @dieselzhang/repo-mastery install --only gemini     # Gemini only
+curl -fsSL https://raw.githubusercontent.com/DieselZhang/repo-mastery/main/scripts/install.sh | bash
+# set GEMINI_SKILLS_DIR if your Gemini skills dir differs
+```
+
+Or manually:
+
+```bash
+git clone https://github.com/DieselZhang/repo-mastery.git \
+  ~/.gemini/skills/repo-mastery
+```
+
+You can also copy this file to a project as `GEMINI.md` (or append the
+"Workflow" section) to enable repo-mastery tutoring in that project.

--- a/skills/repo-mastery/GEMINI.md
+++ b/skills/repo-mastery/GEMINI.md
@@ -9,10 +9,12 @@
 ## What this is
 
 Repo-Mastery turns any open-source repository into a **developer-focused
-mastery course**: a confirmed course map, then interactive mastery learning
-(diagnostic → explain → Feynman check → practice → error diagnosis → spaced
-review) so the user fully masters a project's **usage → architecture → key
-implementations**.
+mastery course**: a value brief + confirmed course map, then overview-first
+mastery learning (global overview → module overview → key-node discussion →
+lightweight verification → spaced review) so the user fully masters a
+project's **usage → architecture → key implementations**. The whole picture
+comes before the nodes — **engine-enforced** via `flow_phase`: `next-objective`
+refuses points until the overviews are presented and `set-phase` advances.
 
 ## When to act as the Repo-Mastery tutor
 
@@ -35,7 +37,12 @@ python3 <skill_root>/scripts/learning_engine.py <subcommand> ...
 | Mastery after attempts | `compute-mastery '[true,false,true]'` |
 | Spaced-review state | `schedule procedure false '<state-json>'` |
 | Record an attempt | `record-attempt <path>/.learning/progress.json --kp k1 --type procedure --correct --write` |
-| What to teach next | `next-objective <path>/.learning/progress.json` |
+| What to teach next | `next-objective <path>/.learning/progress.json [--mode review]` |
+| Advance the overview flow | `set-phase <path>/.learning/progress.json module_overview --module m01` |
+| Begin a textbook-mode chapter | `chapter-start <path>/.learning/progress.json --module m01 --sections N` |
+| Advance a chapter (section/status) | `chapter-advance <path>/.learning/progress.json --section 2 --status qna` |
+| Close the module-level gate | `chapter-complete <path>/.learning/progress.json` |
+| Record a qualitative judgment | `set-qualitative <path>/.learning/progress.json --kp k1 --type concept --pass` |
 | Validate a course map | `validate-map <path>/.learning/course-map.json` |
 | Create `.learning/` scaffolding | `init <repo_path> [--force]` |
 
@@ -46,32 +53,122 @@ arithmetic in `references/mastery-policy.md` if Python is unavailable.
 
 1. **Phase 0 — assess complexity.** Small/medium → read source directly. Large
    (≥100k lines / ≥20 top modules) → run `scripts/index_repo.py` → `code-map.json`.
+   **Optional recon prefix**: if the user opened with `/repo-mastery preview
+   <repo>` (macro brief only, no `.learning/`), its five-section brief feeds
+   Phase 2's value brief — on "深学", skip re-scanning and hand off (see
+   `references/preview-brief.md`).
 2. **Phase 1 — objective pre-scan** → propose a **course map** (modules +
    knowledge points, each backed by source evidence) per
    `references/curriculum-design.md`.
-3. **Phase 2 — Mission + confirmation (mandatory).** Ask "why do you want to
-   master this repo?" → write `.learning/MISSION.md`. User approves/customizes
-   the map before any learning. Never skip.
-4. **Phase 3 — interactive mastery learning** per `references/session-flow.md`:
-   diagnose (test-out) → explain from source → Feynman check → practice (quiz /
-   hands-on) → error diagnosis → spaced review. **Every gate decision goes
-   through the engine script.**
-5. **Phase 4 — output.** Synthesize `COVERAGE.md` (+ optional HTML course using
-   `references/html-shell/`, copy verbatim).
+3. **Phase 2 — value brief + Mission + confirmation (mandatory).** First
+   present what this repo can teach and what makes it stand out vs peers, then
+   clarify "why do you want to master this repo?" (one-at-a-time Mission tree)
+   → write `.learning/MISSION.md`
+   (incl. value positioning). Present the full map at once (each module with a
+   recommended keep/adjust/drop); the user replies with all adjustments in one
+   go, thresholds default to 0.7, and follow-up lands only on adjusted modules;
+   the user approves/customizes before any learning. Never skip this. **External
+   ecosystem retrieval happens
+   only in Phase 2** (never Phase 1): peer/ecosystem facts go into
+   `.learning/positioning.md` (see `references/positioning-brief.md`) as
+   `[web]` + access date (repo facts stay `[src]` + `file:line`); unsourced
+   tutor-memory claims are `[unv]` — search seeds only, never gated. No search
+   tool available → build the brief from repo evidence and mark peer rows
+   `[unv]` / 「需验证」; never fabricate a source. Immediately generate the first-draft
+   course note COVERAGE.md, **ask whether to also build the shareable HTML
+   course** (Phase 4; if yes, build it from the draft), and set
+   `flow_phase: "overview"` in
+   `progress.json` so the course opens engine-forced at the global overview.
+4. **Phase 3 — overview-first mastery learning** per
+   `references/session-flow.md`. Global overview → `set-phase module_overview
+   --module m01` → per-module overview → `set-phase learning` → key-node
+   discussion: explain (from source, discussion-first) → **give the reference
+   answer, the user reacts to the proposal** (grill-me style; restate in their
+   own words) → lightweight verification (Feynman restatement for
+   concept/design; light question + self-check for procedure; none for memory —
+   reference cheatsheet). **Every gate decision goes through the engine
+   script**, including the `flow_phase` gate. This discussion loop is shared by
+   textbook mode's section walk and after-class checking; the standalone
+   per-point loop is a **supplement** (test-out / single-point deep-dive /
+   post-review reteach), not a parallel learning path.
+5. **Textbook mode (chapter) — the default on entering each module.** After the
+   module overview, auto-start the flipped-classroom chapter flow (one line of
+   notice first — an awareness statement, not a confirmation gate); switch to
+   the interactive per-point mode only when the learner asks for it, for that
+   module: (a) generate
+   `chapters/<module>.md` (complete material; the module's HTML page
+   rides the HTML course build — decided once at start, refreshed at
+   completion, see Phase 4) → `chapter-start`; (b) walk it **section by
+   section**,
+   **pausing after each section** for the user's confirmation before
+   `chapter-advance` — never chain sections in one turn; (c) `--status qna`
+   after-class Q&A (same pause before advancing out of teaching);
+   (d) `--status verifying` — 1–2 deep questions on the module's **key nodes**
+   through the engine (`set-qualitative` for concept/design, `record-attempt`
+   for procedure); (e) `chapter-complete` — the **module-level gate** (see Hard
+   rules). The chapter's 课后思考题 must carry course-map `kp_id`s or checking
+   can't go through the engine.
+6. **Phase 4 — continuously-updated course note.** Update `COVERAGE.md`
+   module-by-module as learning progresses. The HTML course is **decided once
+   at Phase 2 confirmation** (ask the user; if yes, build from the first draft
+   via `references/html-shell/`, copy verbatim) and **refreshed at course
+   completion** (on request, from the final COVERAGE.md). It is built into
+   `<repo>/.learning/export/` (`index.html` + `modules/0N-slug.html`).
 
 ## Hard rules
 
 - **Never** replace the gate with "do you feel you've got it?" — call the engine.
-- **Never** put the expected answer in question text; store it in
-  `progress.json.pending_question` server-side.
+- **Learning interaction is reference-answer-first** (grill-me style): after
+  explaining, give the reference answer and let the user react to the proposal
+  — never a blank-prompt exam.
+- **Never** show a graded procedure question's expected answer *before* the
+  user answers; store it in `progress.json.pending_question` server-side, and
+  show it right *after* for self-check.
 - **Course-map approval is mandatory**.
 - Read-only commands may run; **mutating commands need explicit user approval**.
 - Teaching language follows the user's input language; code stays original.
+- **Resuming always opens with the Session Preamble** — cross-session resumes
+  replay the full preamble (value replay + MASTERY status); same-session
+  continue uses a slim one-liner (last position + next objective + due count),
+  display-only, before any node.
+- **Advance `flow_phase` with `set-phase`** after presenting each overview;
+  otherwise `next-objective` keeps refusing new points.
+- **`--mode review` bypasses the overview gate** — never block a scattered-time
+  review on an unfinished overview.
+- **The tutor always pauses for confirmation between sections** — after each
+  section (and before advancing out of teaching into Q&A) it hands control back
+  with a natural confirmation point and only calls `chapter-advance` on an
+  explicit user reply. Never chain sections in one turn — the engine can't see
+  the conversation, so the pause is the tutor's responsibility.
+- **The module-level gate is still an engine decision** — `chapter-complete`
+  covers a module but never fakes mastery: key nodes keep their real engine
+  records, and every unverified point gets initialised spaced review whose real
+  mastery is built only by later review attempts. Never write a mastery score
+  for a point the learner never actually answered.
+- **New modules default to textbook-mode chapter** — after the module overview,
+  auto-start the chapter flow (`chapter-start`); don't silently offer per-point
+  nodes. The interactive per-point mode is an explicit, conversational per-module
+  switch ("切交互式"), preceded by one line of notice — an awareness statement,
+  not a confirmation gate.
+- **`--mode review` also bypasses the chapter gate** — an in-progress chapter
+  never blocks scattered-time review.
+- **Layered wrap-up** — substantive turns (explanation / judgment / error
+  diagnosis / new conclusion) close with full wrap-up: write-back +
+  auto-consolidate + index.json + MASTERY.md refresh + one-line progress
+  report. Mechanical turns (review drain, simple confirmation, Q&A digesting)
+  **skip auto-consolidate and the MASTERY refresh** — the next substantive
+  turn's consolidation covers the stretch (see `session-flow.md` §7).
+- **MASTERY.md is the status dashboard** — `/repo-mastery status` regenerates
+  it from `progress.json` + `course-map.json` (progress / mastery % / review
+  due / next objective); substantive wrap-up refreshes it; the Session Preamble
+  reads it, display-only. COVERAGE.md stays content-only (see `session-flow.md`
+  §8).
 
 ## Where the details live
 
 Read the relevant reference only when you reach that phase:
 
+- Ecosystem positioning & differentiation (Phase 2): `references/positioning-brief.md`
 - Course map: `references/curriculum-design.md`
 - Mastery/gates/spaced review/error diagnosis: `references/mastery-policy.md`
 - Session protocol: `references/session-flow.md`

--- a/skills/repo-mastery/LICENSE
+++ b/skills/repo-mastery/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DieselZhang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/repo-mastery/SKILL.md
+++ b/skills/repo-mastery/SKILL.md
@@ -1,259 +1,81 @@
 ---
 name: repo-mastery
-description: "Turn any open-source repository into a developer-focused mastery course. Given a local repo path or GitHub URL, it builds a confirmed course map and drives interactive mastery learning (diagnostic, explanation, Feynman check, practice, spaced review) with hands-on tasks, note-taking, and dual-format (Markdown + HTML) course output — so you fully master a project's usage, architecture, and key implementations like a real course. Triggers: 'learn this repo', 'master this codebase', 'turn X into a course', 'deep-dive into X project'."
+description: "Turn any open-source repository into a developer-focused mastery course. Given a local repo path or GitHub URL, build a confirmed course map and drive overview-first learning (architecture picture, then key-node discussion, then spaced review) with hands-on tasks and a continuously-updated course note (Markdown + HTML). Triggers: 'learn this repo', 'master this codebase', 'turn X into a course', 'deep-dive into X project'."
 origin: personal
-version: 2.4.0
+version: 3.2.0
 tags: [learning, education, codebase, mastery, spaced-repetition]
 ---
 
 # Repo-Mastery — Master an Open-Source Project from Source
 
-> Turn any open-source repository into a **developer-focused mastery course**. Instead of "browsing code", you progressively master its **usage → architecture → key implementations**, with per-knowledge-point mastery gates, spaced review, and persistent notes.
-
 ## When to Activate
+- user wants to learn/master/deep-dive an open-source repo or codebase
+- user got new project source and wants systematic learning
+- user wants architecture + key implementations from source (not usage docs)
+- user wants progress to persist across sessions (spaced review + notes)
+- triggers: "learn this repo", "master this codebase", "turn X into a course"
 
-Use this skill whenever any of these applies:
+Do NOT activate for doc/README summaries, one-off code Q&A, or end-user tutorials — that is docs-to-course.
 
-- The user wants to "learn / master / fully understand / deep-dive into" an open-source repo or codebase.
-- The user just got a new project's source and wants systematic learning instead of random browsing.
-- The user wants to understand a project's **architecture and key implementations from source** (not just how to use it).
-- The user wants learning progress to **persist across sessions** (memory + spaced review).
-- The user says "turn X repo into a course", "learn X from source", "deep-dive into X project".
-
-Do **not** activate when: the user just wants a doc/README summary, a one-off code Q&A, or an end-user tutorial for a tool (that is `docs-to-course`'s job).
-
-## Prerequisites
-
-- **Claude Code** (the skill runtime).
-- **Target repository**: a local path, or a reachable `github:owner/repo` (the skill auto-runs `git clone --depth 1`).
-- **Python 3** — only needed by the large-repo indexing script `scripts/index_repo.py` (pure stdlib).
-- **Write permission**: creates `.learning/` inside the target repo (auto-gitignored) and a global `~/.repo-mastery/`.
-
-## Language
-
-Teaching language **follows the user's input language by default** (Chinese input → Chinese teaching; English input → English teaching). You can also pass an explicit language flag:
-
-```bash
-/repo-mastery start <path|github:owner/repo> --language zh    # force Chinese
-/repo-mastery start <path|github:owner/repo> --language en    # force English
-```
-
-Code, file paths, and identifiers always stay in their original form regardless of language.
-
-## Multi-Tool Support
-
-Repo-Mastery is not Claude Code-only. The skill follows the open **Agent
-Skills** standard (agentskills.io), so the same `SKILL.md` runs natively on
-**Claude Code**, **OpenAI Codex**, **Gemini CLI**, and any tool that loads
-`SKILL.md` skills.
-
-| Tool | Entry point | Install |
-|---|---|---|
-| Claude Code | `SKILL.md` (this file) | `~/.claude/skills/repo-mastery/` |
-| OpenAI Codex | `SKILL.md` + `agents/openai.yaml` | `~/.codex/skills/repo-mastery/` |
-| Gemini CLI | `GEMINI.md` + skills via `activate_skill` | its skills dir; or copy `GEMINI.md` into a project |
-| AGENTS.md tools (opencode, Cursor, …) | `AGENTS.md` | clone repo or copy `AGENTS.md` into the project |
-
-**The deterministic engine is real code, not prose** — `scripts/learning_engine.py`
-implements `compute-mastery`, the spaced-repetition scheduler, `record-attempt`,
-and `next-objective`. **Every gate decision MUST go through this script**, so
-mastery math is identical in every tool. See `AGENTS.md` / `GEMINI.md` for the
-per-tool protocol; `scripts/install.sh` installs to all tools at once.
-
-## Difference from docs-to-course
-
-This skill **does not read docs and targets developers**. The learner is you — a developer who wants to understand how an open-source project was built — not an end-user who wants to learn how to use it. Therefore:
-
-- **Input** is source code (local path or GitHub URL), not a docs site.
-- Learning goes **inside the implementation**: architecture, design decisions, core algorithms — that is the point, not "surface operations".
-- Driving mode is **interactive mastery learning**, not one-shot static course generation.
-- Output is **resumable learning state** + a complete course document (Markdown + HTML dual format).
-
-> Methodologically it stands on `docs-to-course`'s shoulders: the course-design arc, quiz philosophy, module-brief pre-extraction, and HTML course shell are absorbed from it; the mastery engine (deterministic gates, spaced repetition, error diagnosis) is adapted from DeepTutor's `learning/` module. See `docs/ARCHITECTURE.md` and `ADOPTION.md`.
-
-## Core Design Axiom (always hold)
-
-> **Intelligence at the exit, advancement at the gate.** You (the tutor) decide what to teach, how to question, how to explain — but whether the learner *may advance* is always a **deterministic engine decision**, never the LLM patting itself on the back.
-
-- Quantitative gate (memory / procedure types): `compute_mastery()` recency-weighted accuracy ≥ 0.9, capped by a confidence ceiling — **one lucky answer is not mastery**.
-- Qualitative gate (concept / design types): a Feynman-style explanation judged by the tutor (`mastery_assess`).
-- Advancement is computed **from what is already mastered** (`next_objective`), never from a stage counter. Knowledge points already proven are skipped (test-out path).
-
----
+## Setup
+- Target: local path or github:owner/repo (auto git clone --depth 1)
+- Python 3: only for the large-repo index (scripts/index_repo.py, pure stdlib)
+- Creates .learning/ in the target (auto-gitignored). ~/.repo-mastery/ (profile + index) is an OPT-IN profile — not read automatically; consulted only when the user explicitly asks for saved preferences. The current directory's .learning/ is the sole automatic state source.
+- Teaching language follows the user's input (--language zh|en to force); code, paths, identifiers keep original form
+- Runs on Claude Code / Codex / Gemini CLI / AGENTS.md tools (agentskills.io)
 
 ## Commands
+(6 commands — each: signature + one imperative line)
+/repo-mastery preview <path|url>    # zero-side-effect recon: macro brief in chat, no .learning/, no engine. Say "deep-dive" (or the user's language for "go deeper") to hand off into start.
+/repo-mastery start [path|url] [--language zh|en] [--fresh]   # value brief → map confirm → overview-first learning (textbook-mode chapter per module by default); path defaults to the current directory; --fresh restarts an existing course.
+/repo-mastery continue              # resume the current directory's .learning/ (session preamble first, then next-objective). If none, say so and guide to start on the current dir — never jump to a project from global memory.
+/repo-mastery review                # spaced review only: drain due reviews, bypass overview gate, never open new content.
+/repo-mastery note ["<text>"]       # consolidate discussion since last note into notes/<module>.md (categorized); <text> appended verbatim.
+/repo-mastery status                # refresh MASTERY.md one-page dashboard from progress.json + course-map.json.
 
-```bash
-/repo-mastery start <local-path | github:owner/repo> [--language zh|en]  # Main flow: map → confirm → learn → output
-/repo-mastery continue                                                  # Resume progress (back to next_objective)
-/repo-mastery review                                                    # Run spaced-review session (due items)
-/repo-mastery note "<text>"                                             # Manually append to the current module notes
-/repo-mastery status                                                    # Show progress (map_summary style)
-/repo-mastery report                                                    # Generate mastery report MASTERY.md
-/repo-mastery export [--html]                                           # Synthesize complete course doc (COVERAGE.md; --html adds HTML)
-```
+(Bare /repo-mastery routes by the current directory: has .learning/ → continue; no .learning/ → start a course on the current directory. The shared due-review pool: continue runs next-objective end-to-end and signposts due reviews; review drains them alone and bypasses the flow_phase overview gate. Preview is zero-side-effect: brief in chat, handoff on "deep-dive". Both continue and review loop next-objective, act on the returned action (overview | module_overview | chapter | answer_pending | review | complete), and stop on a non-review action.)
 
----
+(Gate invariant — always hold: advancement is a deterministic engine decision, never an LLM self-assessment; mastery is built from real attempts, never faked.)
 
-## Main Flow (`/repo-mastery start`)
+## Session Preamble (mandatory on every resume)
+- New course (current dir has no .learning/ / fresh start): start clean — do NOT read ~/.repo-mastery/ preferences or index.json; teaching language follows the user's current input.
+- Resume (current dir has .learning/): read the current dir's MISSION.md + positioning.md (value replay) → MASTERY.md (map + progress) → due review/chapter first. Display-only, no questions. Global memory (profile.md) is referenced only if the user explicitly asks ("use my saved preferences" / 「用我之前的偏好」).
+- Same-session: one line — "Last learned X, next objective Y, N reviews due" (Chinese example: 「上次学到 X，下一步 Y，due N 条复习」).
+- Then advance per next-objective. While flow_phase is overview/module_overview, next-objective refuses knowledge points (engine-enforced).
 
-### Phase 0 — Complexity Assessment (decide how to ingest)
+## Main Flow (/repo-mastery start)
+Phase 0 — Complexity: <100k lines small/medium (read directly); ≥100k or ≥20 top-level modules large (run scripts/index_repo.py → code-map.json). See references/index-script-spec.md; measure with find + wc -l when unsure.
+Phase 1 — Pre-scan → course-map candidates: objective map (README, entry, structure, build, core modules); generate candidates per references/curriculum-design.md. Repo-internal only (no ecosystem scan yet).
+Phase 2 — Value brief + Mission + map confirm: deliver the value brief (what this repo can teach + differentiation) per references/clarification-interview.md §0 + references/positioning-brief.md (external retrieval for peer facts; [src]/[web]/[unv] discipline); clarify Mission one question at a time with recommended answers; present the full module list at once, user replies all adjustments in one batch, follow-up only on adjusted modules; pass_threshold defaults 0.7. Learning starts only after approval. Then write .learning/ (MISSION.md, positioning.md, course-map.json), set-phase overview, generate first-draft COVERAGE.md.
+Phase 3 — Overview-first learning: next-objective is gated by flow_phase — present global overview (Phase 3.0) → set-phase module_overview --module m01 → present module overview → set-phase learning → per-point learning. In each module: textbook-mode chapter by default (see Textbook Mode); per-point interactive mode is a supplement (test-out / single-point deep-dive / post-review reteach), switched conversationally. Learning loop: explain from source → give reference answer → user reacts → judge (Feynman recital for concept/design; lightweight scenario question + self-check for procedure) → error diagnosis → spaced review. Reference answer first, never a blank prompt; expected answer shown after for graded procedure questions. Hands-on on demand (read-only commands run; mutating requires approval). Auto-consolidate substantive turns into notes/<module>.md. See references/session-flow.md, mastery-policy.md, quiz-design.md.
+Phase 4 — Continuously-generated course note: COVERAGE.md generated at Phase 2, updated per module; HTML course decided once at start (reuse references/html-shell/, copy verbatim), refreshed at completion. MASTERY.md is the status dashboard (regenerated by status).
 
-Make a quick scale judgment first, **then** choose how to digest the source:
-
-| Metric | Small / Medium | Large |
-|---|---|---|
-| Source lines (`src/` + non-test) | < 100k | ≥ 100k |
-| Top-level modules / packages | < 20 | ≥ 20 |
-| Dependency complexity / multi-language | simple | complex |
-
-- **Small / medium** → pure skill reads the source directly (Grep/Glob/Read + explore_context-style pre-scan), no Python dependency.
-- **Large** → first run `scripts/index_repo.py` to generate `code-map.json` (modules/dependencies/symbol locations; see `references/index-script-spec.md`), build the course map on top of it, and locate source on demand during learning instead of cramming the whole repo into context.
-- When unsure, measure with `find` + `wc -l`; do not guess.
-
-### Phase 1 — Pre-scan → Course Map Candidates
-
-Start with an **explore_context-style objective pre-scan**: calmly map the repo first (README, entry files, directory structure, build config, core modules) **without jumping to conclusions**. Then generate course-map candidates per `references/curriculum-design.md`:
-
-```jsonc
-{
-  "repo": "owner/name",
-  "summary": "an objective overview of the repo",
-  "modules": [
-    {
-      "id": "m01",
-      "name": "Build & environment",
-      "order": 1,
-      "pass_threshold": 0.7,
-      "knowledge_points": [
-        {"id": "kp01-01", "name": "Build and run from scratch", "type": "procedure"},
-        {"id": "kp01-02", "name": "Mental model of the directory structure", "type": "concept"}
-      ]
-    }
-  ]
-}
-```
-
-**Module arc** (absorbed from docs-to-course's "reference → route", adapted for source learning):
-
-> **First win (build) → overall architecture mental model → core workflows/modules → key implementations → hands-on labs → troubleshooting → deep references**
-
-This is a menu, not a checklist — pick 4–8 modules that fit the repo; fewer, deeper beats more, thinner. The knowledge point's `type` decides its gate (see `mastery-policy.md`).
-
-### Phase 2 — Course Map Confirmation & Customization (user decision, never skipped)
-
-First establish the **Mission** (absorbed from the teach skill's MISSION.md): clarify **"Why do you want to master this repo?"** (use it? modify it? explain it in interviews? borrow its design? …) as a **decision-tree interview** — see `references/clarification-interview.md`. Ask one question at a time, carry an evidence-based recommended answer with each, and look up any fact the repo can settle instead of asking. Write the settled answer to `<repo>/.learning/MISSION.md`; it grounds every later teaching decision (module choices, Feynman follow-ups, mastery priority). When the Mission changes, update it and write a learning record.
-
-Then **present the candidate map** to the user, explain each module, and walk each one as a decision (keep / adjust / drop) with your recommended answer:
-
-- ✅ User removes irrelevant modules / adds interesting ones / adjusts knowledge-point granularity.
-- ✅ User confirms each module's `pass_threshold` (default 0.7).
-- ✅ **Learning starts only after user approval.** This is mandatory — the opposite of docs-to-course's "don't get outline approval".
-
-> Confirmation questions are asked **one at a time** — never batched. Recommended answers belong to **decision questions only**; Phase 3 assessment (quiz / Feynman) never leaks the answer.
-
-After confirmation, write `<repo>/.learning/course-map.json` and initialize the `.learning/` structure (below).
-
-### Phase 3 — Interactive Mastery Learning
-
-Drive per `references/session-flow.md`. Core loop (per knowledge point):
-
-> **diagnostic (probe how much is known; test-out skip) → explain → Feynman check → practice (quiz / hands-on) → error diagnosis → spaced-review scheduling**
-
-- The next station is always decided by the **engine script** — run
-  `python3 scripts/learning_engine.py next-objective <path>/.learning/progress.json`
-  (priority: pending question → due review → first unmastered point → complete).
-- Quantitative gate (memory/procedure): pose a question, then record the attempt and
-  recompute mastery via `python3 scripts/learning_engine.py record-attempt ... --write`;
-  advance only when the script reports `passed_gate: true` (≥ 0.9).
-- Qualitative gate (concept/design): have the user do a Feynman recital; you judge `passed`; retry if not. (Qualitative results are stored in `progress.json.qualitative_mastery` and read by the engine's `next-objective`.)
-- **Hands-on on demand**: for procedure points, guide the user to actually run things (build/test/write a small demo). Read-only commands (`build`, `test`, `--help`) may run directly; **mutating operations (writing files, installing deps) require explicit user approval first**. The hands-on result is recorded as mastery evidence.
-- **Auto notes**: after each explanation/judgment, automatically append to `<repo>/.learning/notes/<module>.md` (format: `note-template.md`); the user can `/repo-mastery note "..."` at any time.
-- **Command convention**: only run read-only/no-side-effect commands by default; show any command that modifies the user's filesystem or installs dependencies and request approval.
-
-### Phase 4 — Synthesize the Complete Course Document (dual format)
-
-When learning completes (or the user runs `/repo-mastery export`), synthesize **course map + explanation notes + user practice records + mastery & blockers** into a complete course document:
-
-1. **Markdown full version** `COVERAGE.md`: complete content with source references, module explanations, mastery, blockers, and review schedule. This is the primary artifact.
-2. **HTML share version** (`/repo-mastery export --html`): **reuse the finished shell in `references/html-shell/`** (styles.css / main.js / _base.html / _footer.html / build.sh — copy verbatim, never regenerate), convert COVERAGE.md module content into `modules/0N-slug.html`, and assemble `index.html` with `build.sh`. Interactive elements (flow animations, group chat, glossary tooltips, scenario quizzes) follow the patterns in `references/html-shell/interactive-elements.md`.
-
-> Note: the HTML version's visuals serve "source understanding" — **architecture diagrams, dependency graphs, call chains are the core content**, the opposite of docs-to-course's "UI step-strips bias".
-
----
+## Textbook Mode (chapter) — default on entering each module
+Five steps (engine-gated):
+1. Generate chapters/<module>.md (intro → sections [each = one knowledge point: explain + source walk file:line + recap + review questions aligned to knowledge_point_ids] → chapter summary → cheatsheet) → chapter-start.
+   Each section's source walk pastes the relevant source (file:line locator + inline key fragment + collapsible `<details>` full source) — see `note-template.md`.
+2. Walk section by section; after each section STOP and wait for explicit user reply before chapter-advance --section N.
+3. Q&A (status=qna): user asks freely.
+4. Verification (status=verifying): 1-2 deep questions on key nodes → set-qualitative / record-attempt.
+5. Complete (chapter-complete): module-level gate — covered points get initialized spaced review (not fake mastery); module joins chapter_covered_modules; points still enter review queue. Status shows three states: 未掌握 / 已覆盖 · 待复习验证 / 已掌握 (not-yet-learned / Covered · awaiting review verification / mastered) — covered ≠ mastered.
 
 ## Data Structures
+<target-repo>/.learning/: MISSION.md, positioning.md, course-map.json, progress.json, MASTERY.md, records/, notes/ (incl .boundary.json), chapters/, briefs/, code-map.json, export/, .gitignore
+~/.repo-mastery/: profile.md, index.json   (opt-in profile — not read automatically; consulted only on explicit request)
 
-```text
-<target-repo>/.learning/                  ← travels with the repo; auto-gitignored
-  ├── MISSION.md           learning mission (why you want to master it; grounds teaching)
-  ├── course-map.json      course map (confirmed version)
-  ├── progress.json        LearningProgress (mastery / spaced review / blockers; see mastery-policy.md)
-  ├── records/NNNN-slug.md ADR-style learning records (understanding evolution)
-  ├── notes/<module>.md    structured notes (auto + /note append)
-  ├── briefs/<module>.md   module briefs (large repos, token-saving)
-  ├── code-map.json        large-repo index (optional)
-  └── .gitignore           contains ".learning/"
-~/.repo-mastery/                     ← global lightweight memory (no L1/L2/L3 layering)
-  ├── profile.md           cross-repo preferences / level / blocker summary
-  └── index.json           repos studied + state (last learned where)
-```
+Expected answers of pending questions live server-side in progress.json — never round-trip to the user before grading.
 
-Progress is stored in JSON, one record per knowledge point; the **expected answer of a pending question lives server-side (`progress.json`) and never round-trips to the user** — grading never drifts (absorbed from DeepTutor's `PendingQuestion`).
-
----
-
-## Reference Files (read per phase to keep context lean)
-
-- `references/curriculum-design.md` — **Phase 1**: designing the course map from source
-- `references/mastery-policy.md` — **Phase 3**: mastery, gates, spaced review, error diagnosis, fluency vs storage
-- `references/session-flow.md` — **Phase 3**: interactive learning session protocol (incl. Mission + ZPD)
-- `references/quiz-design.md` — **Phase 3**: quiz design (test application, not memory)
-- `references/module-brief-template.md` — **Phase 3, large repos**: pre-extract source snippets, save tokens
-- `references/note-template.md` — **Phase 3**: note format
-- `references/learning-records-template.md` — **All phases**: ADR-style learning record format
-- `references/gotchas.md` — **All phases**: failure-point checklist
-- `references/index-script-spec.md` — **Phase 0, large repos**: Python indexing script docs
-- `references/html-shell/` — **Phase 4**: HTML course shell (copy verbatim)
+## Reference Files (read per phase)
+- curriculum-design.md (P1), positioning-brief.md (P2), preview-brief.md (preview), clarification-interview.md (P2), mastery-policy.md (P3), session-flow.md (P3), quiz-design.md (P3), module-brief-template.md (P3 large), note-template.md (P3), learning-records-template.md (all), gotchas.md (all), index-script-spec.md (P0 large), example-walkthrough.md (any), html-shell/ (P4)
 
 ## Scripts
-
-- `scripts/learning_engine.py` — **the deterministic gate**. Call for mastery /
-  schedule / record-attempt / next-objective / validate-map / init. Mandatory in
-  every tool; never re-derive the math from prose.
-- `scripts/index_repo.py` — large-repo code index (`code-map.json`), pure stdlib.
-- `scripts/install.sh` — install the skill to Claude Code, Codex, and Gemini CLI
-  at once (`--only <tool>` / `--skip <tool>` / `--dry-run`).
-
-## Multi-tool entry points
-
-- `AGENTS.md` — portable protocol for AGENTS.md-compatible tools (Codex, opencode, Cursor).
-- `GEMINI.md` — protocol for Gemini CLI.
-- `agents/openai.yaml` — Codex/Agent-Skills UI metadata.
-
-## Anti-Patterns
-
-> The full failure checklist is in `references/gotchas.md`. These anti-patterns destroy learning quality outright — stop when you see one:
-
-- ❌ **Letting the LLM replace the gate** — never use "do you feel you've mastered it?" instead of `compute_mastery` / `mastery_assess`.
-- ❌ **Skipping course-map confirmation** — the user must approve/customize the map (with Mission); this is an explicit requirement.
-- ❌ **Leaking the expected answer** — the question text/options must never contain it; only `progress.json.pending_question` does.
-- ❌ **Confusing "worked once" with "mastered"** — one lucky answer / one successful run ≠ mastery; the confidence ceiling + spaced review are the real goal (fluency ≠ storage).
-- ❌ **Cramming the whole repo into context** — read only the files relevant to the current knowledge point; use `code-map.json` to locate on demand in large repos.
+- scripts/learning_engine.py — the deterministic gate. Call for compute-mastery / schedule / record-attempt / next-objective / set-phase / chapter-* / validate-map / init. Never re-derive the math.
+- scripts/index_repo.py — large-repo index (pure stdlib).
+- scripts/install.sh — install to Claude Code + Codex + Gemini CLI.
 
 ## Related Skills
+- docs-to-course: docs → end-user usage course (source of methodology).
+- understand-anything: knowledge-graph of a codebase (pair for architecture deep dives).
 
-- `docs-to-course` (codebase-to-course) — docs → end-user usage course (source of this skill's methodology & HTML shell).
-- `understand-anything` — builds a knowledge graph of a codebase (pair well for architecture deep dives).
-- `codebase-onboarding` — quick ramp on unfamiliar codebases (complements this skill's Phase 1 pre-scan).
-- `find-docs` — locate project docs; useful for enriching a module's "primary sources".
-
-## Verification (completion checks)
-
-When starting / ending a learning session, self-check with `references/gotchas.md` and confirm:
-
-- [ ] `.learning/` is gitignored; the target repo is not polluted.
-- [ ] `course-map.json` is the user-confirmed version.
-- [ ] `progress.json` written atomically, uncorrupted.
-- [ ] Notes appended and `~/.repo-mastery/index.json` updated each turn.
-- [ ] No expected-answer leakage; no unapproved mutating commands.
+## Verification
+Self-check with references/gotchas.md; confirm: .learning/ gitignored; course-map.json confirmed; progress.json atomic; notes on substantive turns + ~/.repo-mastery/index.json updated; no expected-answer leakage; no unapproved mutating commands.

--- a/skills/repo-mastery/SKILL.md
+++ b/skills/repo-mastery/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: repo-mastery
+description: "Turn any open-source repository into a developer-focused mastery course. Given a local repo path or GitHub URL, it builds a confirmed course map and drives interactive mastery learning (diagnostic, explanation, Feynman check, practice, spaced review) with hands-on tasks, note-taking, and dual-format (Markdown + HTML) course output — so you fully master a project's usage, architecture, and key implementations like a real course. Triggers: 'learn this repo', 'master this codebase', 'turn X into a course', 'deep-dive into X project'."
+origin: ECC
+version: 2.2.1
+tags: [learning, education, codebase, mastery, spaced-repetition]
+---
+
+# Repo-Mastery — Master an Open-Source Project from Source
+
+> Turn any open-source repository into a **developer-focused mastery course**. Instead of "browsing code", you progressively master its **usage → architecture → key implementations**, with per-knowledge-point mastery gates, spaced review, and persistent notes.
+
+## When to Activate
+
+Use this skill whenever any of these applies:
+
+- The user wants to "learn / master / fully understand / deep-dive into" an open-source repo or codebase.
+- The user just got a new project's source and wants systematic learning instead of random browsing.
+- The user wants to understand a project's **architecture and key implementations from source** (not just how to use it).
+- The user wants learning progress to **persist across sessions** (memory + spaced review).
+- The user says "turn X repo into a course", "learn X from source", "deep-dive into X project".
+
+Do **not** activate when: the user just wants a doc/README summary, a one-off code Q&A, or an end-user tutorial for a tool (that is `docs-to-course`'s job).
+
+## Prerequisites
+
+- **Claude Code** (the skill runtime) — the same skill also runs on OpenAI Codex and Gemini CLI (Agent Skills standard).
+- **Target repository**: a local path, or a reachable `github:owner/repo` (the skill auto-runs `git clone --depth 1`).
+- **Python 3** — needed by the deterministic engine (`scripts/learning_engine.py`) and the large-repo index (`scripts/index_repo.py`), both pure stdlib.
+- **Write permission**: creates `.learning/` inside the target repo (auto-gitignored) and a global `~/.repo-mastery/`.
+
+## Language
+
+Teaching language **follows the user's input language by default** (Chinese input → Chinese teaching; English input → English teaching). You can also pass an explicit language flag:
+
+```bash
+/repo-mastery start <path|github:owner/repo> --language zh    # force Chinese
+/repo-mastery start <path|github:owner/repo> --language en    # force English
+```
+
+Code, file paths, and identifiers always stay in their original form regardless of language.
+
+## Core Design Axiom (always hold)
+
+> **Intelligence at the exit, advancement at the gate.** You (the tutor) decide what to teach, how to question, how to explain — but whether the learner *may advance* is always a **deterministic engine decision**, never the LLM patting itself on the back.
+
+- Quantitative gate (memory / procedure types): `compute_mastery()` recency-weighted accuracy ≥ 0.9, capped by a confidence ceiling — **one lucky answer is not mastery**.
+- Qualitative gate (concept / design types): a Feynman-style explanation judged by the tutor (`mastery_assess`).
+- Advancement is computed **from what is already mastered** (`next_objective`), never from a stage counter. Knowledge points already proven are skipped (test-out path).
+
+**The gate is code, not prose** — run `scripts/learning_engine.py` for `compute-mastery`, `schedule`, `record-attempt`, `next-objective`, `validate-map`, and `init`. Every platform calls the same script, so mastery math never drifts.
+
+---
+
+## Commands
+
+```bash
+/repo-mastery start <local-path | github:owner/repo> [--language zh|en]  # Main flow: map → confirm → learn → output
+/repo-mastery continue                                                  # Resume progress (back to next_objective)
+/repo-mastery review                                                    # Run spaced-review session (due items)
+/repo-mastery note "<text>"                                             # Manually append to the current module notes
+/repo-mastery status                                                    # Show progress (map_summary style)
+/repo-mastery report                                                    # Generate mastery report MASTERY.md
+/repo-mastery export [--html]                                           # Synthesize complete course doc (COVERAGE.md; --html adds HTML)
+```
+
+---
+
+## Main Flow (`/repo-mastery start`)
+
+### Phase 0 — Complexity Assessment (decide how to ingest)
+
+Make a quick scale judgment first, **then** choose how to digest the source:
+
+| Metric | Small / Medium | Large |
+|---|---|---|
+| Source lines (`src/` + non-test) | < 100k | ≥ 100k |
+| Top-level modules / packages | < 20 | ≥ 20 |
+| Dependency complexity / multi-language | simple | complex |
+
+- **Small / medium** → pure skill reads the source directly (Grep/Glob/Read + explore_context-style pre-scan), no Python dependency.
+- **Large** → first run `scripts/index_repo.py` to generate `code-map.json` (modules/dependencies/symbol locations; see `references/index-script-spec.md`), build the course map on top of it, and locate source on demand instead of cramming the whole repo into context.
+- When unsure, measure with `find` + `wc -l`; do not guess.
+
+### Phase 1 — Pre-scan → Course Map Candidates
+
+Start with an **explore_context-style objective pre-scan**: calmly map the repo first (README, entry files, directory structure, build config, core modules) **without jumping to conclusions**. Then generate course-map candidates per `references/curriculum-design.md`:
+
+```jsonc
+{
+  "repo": "owner/name",
+  "summary": "an objective overview of the repo",
+  "modules": [
+    {
+      "id": "m01",
+      "name": "Build & environment",
+      "order": 1,
+      "pass_threshold": 0.7,
+      "knowledge_points": [
+        {"id": "kp01-01", "name": "Build and run from scratch", "type": "procedure"},
+        {"id": "kp01-02", "name": "Mental model of the directory structure", "type": "concept"}
+      ]
+    }
+  ]
+}
+```
+
+**Module arc** (absorbed from docs-to-course's "reference → route", adapted for source learning):
+
+> **First win (build) → overall architecture mental model → core workflows/modules → key implementations → hands-on labs → troubleshooting → deep references**
+
+This is a menu, not a checklist — pick 4–8 modules that fit the repo; fewer, deeper beats more, thinner. The knowledge point's `type` decides its gate (see `mastery-policy.md`).
+
+### Phase 2 — Course Map Confirmation & Customization (user decision, never skipped)
+
+First establish the **Mission** (absorbed from the teach skill's MISSION.md): ask the user one key question — **"Why do you want to master this repo?"** (use it? modify it? explain it in interviews? borrow its design? …). Write the answer to `<repo>/.learning/MISSION.md`; it grounds every later teaching decision (module choices, Feynman follow-ups, mastery priority). When the Mission changes, update it and write a learning record.
+
+Then **present the candidate map** to the user, explain each module, and:
+
+- ✅ User removes irrelevant modules / adds interesting ones / adjusts knowledge-point granularity.
+- ✅ User confirms each module's `pass_threshold` (default 0.7).
+- ✅ **Learning starts only after user approval.** This is mandatory — the opposite of docs-to-course's "don't get outline approval".
+
+After confirmation, write `<repo>/.learning/course-map.json` and initialize the `.learning/` structure (below).
+
+### Phase 3 — Interactive Mastery Learning
+
+Drive per `references/session-flow.md`. Core loop (per knowledge point):
+
+> **diagnostic (probe how much is known; test-out skip) → explain → Feynman check → practice (quiz / hands-on) → error diagnosis → spaced-review scheduling**
+
+- The next station is always decided by the **engine script** — run `python3 scripts/learning_engine.py next-objective <path>/.learning/progress.json` (priority: pending question → due review → first unmastered point → complete).
+- Quantitative gate (memory/procedure): pose a question, then record the attempt and recompute mastery via `python3 scripts/learning_engine.py record-attempt ... --write`; advance only when the script reports `passed_gate: true` (≥ 0.9).
+- Qualitative gate (concept/design): have the user do a Feynman recital; you judge `passed`; retry if not. (Qualitative results are stored in `progress.json.qualitative_mastery` and read by the engine's `next-objective`.)
+- **Hands-on on demand**: for procedure points, guide the user to actually run things (build/test/write a small demo). Read-only commands (`build`, `test`, `--help`) may run directly; **mutating operations (writing files, installing deps) require explicit user approval first**. The hands-on result is recorded as mastery evidence.
+- **Auto notes**: after each explanation/judgment, automatically append to `<repo>/.learning/notes/<module>.md` (format: `note-template.md`); the user can `/repo-mastery note "..."` at any time.
+- **Command convention**: only run read-only/no-side-effect commands by default; show any command that modifies the user's filesystem or installs dependencies and request approval.
+
+### Phase 4 — Synthesize the Complete Course Document (dual format)
+
+When learning completes (or the user runs `/repo-mastery export`), synthesize **course map + explanation notes + user practice records + mastery & blockers** into a complete course document:
+
+1. **Markdown full version** `COVERAGE.md`: complete content with source references, module explanations, mastery, blockers, and review schedule. This is the primary artifact.
+2. **HTML share version** (`/repo-mastery export --html`): **reuse the finished shell in `references/html-shell/`** (styles.css / main.js / _base.html / _footer.html / build.sh — copy verbatim, never regenerate), convert COVERAGE.md module content into `modules/0N-slug.html`, and assemble `index.html` with `build.sh`. Interactive elements (flow animations, group chat, glossary tooltips, scenario quizzes) follow the patterns in `references/html-shell/interactive-elements.md`.
+
+> Note: the HTML version's visuals serve "source understanding" — **architecture diagrams, dependency graphs, call chains are the core content**, the opposite of docs-to-course's "UI step-strips bias".
+
+---
+
+## Data Structures
+
+```text
+<target-repo>/.learning/                  ← travels with the repo; auto-gitignored
+  ├── MISSION.md           learning mission (why you want to master it; grounds teaching)
+  ├── course-map.json      course map (confirmed version)
+  ├── progress.json        LearningProgress (mastery / spaced review / blockers; see mastery-policy.md)
+  ├── records/NNNN-slug.md ADR-style learning records (understanding evolution)
+  ├── notes/<module>.md    structured notes (auto + /note append)
+  ├── briefs/<module>.md   module briefs (large repos, token-saving)
+  ├── code-map.json        large-repo index (optional)
+  └── .gitignore           contains ".learning/"
+~/.repo-mastery/                     ← global lightweight memory (no L1/L2/L3 layering)
+  ├── profile.md           cross-repo preferences / level / blocker summary
+  └── index.json           repos studied + state (last learned where)
+```
+
+Progress is stored in JSON, one record per knowledge point; the **expected answer of a pending question lives server-side (`progress.json`) and never round-trips to the user** — grading never drifts (absorbed from DeepTutor's `PendingQuestion`).
+
+---
+
+## Reference Files (read per phase to keep context lean)
+
+- `references/curriculum-design.md` — **Phase 1**: designing the course map from source
+- `references/mastery-policy.md` — **Phase 3**: mastery, gates, spaced review, error diagnosis, fluency vs storage
+- `references/session-flow.md` — **Phase 3**: interactive learning session protocol (incl. Mission + ZPD)
+- `references/quiz-design.md` — **Phase 3**: quiz design (test application, not memory)
+- `references/module-brief-template.md` — **Phase 3, large repos**: pre-extract source snippets, save tokens
+- `references/note-template.md` — **Phase 3**: note format
+- `references/learning-records-template.md` — **All phases**: ADR-style learning record format
+- `references/gotchas.md` — **All phases**: failure-point checklist
+- `references/index-script-spec.md` — **Phase 0, large repos**: Python indexing script docs
+- `references/html-shell/` — **Phase 4**: HTML course shell (copy verbatim)
+
+## Scripts
+
+- `scripts/learning_engine.py` — **the deterministic gate**. Call for mastery / schedule / record-attempt / next-objective / validate-map / init. Mandatory; never re-derive the math from prose.
+- `scripts/index_repo.py` — large-repo code index (`code-map.json`), pure stdlib.
+
+## Anti-Patterns
+
+> The full failure checklist is in `references/gotchas.md`. These anti-patterns destroy learning quality outright — stop when you see one:
+
+- ❌ **Letting the LLM replace the gate** — never use "do you feel you've got it?" instead of the engine script.
+- ❌ **Skipping course-map confirmation** — the user must approve/customize the map (with Mission); this is an explicit requirement.
+- ❌ **Leaking the expected answer** — the question text/options must never contain it; only `progress.json.pending_question` does.
+- ❌ **Confusing "worked once" with "mastered"** — one lucky answer / one successful run ≠ mastery; the confidence ceiling + spaced review are the real goal (fluency ≠ storage).
+- ❌ **Cramming the whole repo into context** — read only the files relevant to the current knowledge point; use `code-map.json` to locate on demand in large repos.
+
+## Related Skills
+
+- `docs-to-course` (codebase-to-course) — docs → end-user usage course (source of this skill's methodology & HTML shell).
+- `understand-anything` — builds a knowledge graph of a codebase (pair well for architecture deep dives).
+- `codebase-onboarding` — quick ramp on unfamiliar codebases (complements this skill's Phase 1 pre-scan).
+- `find-docs` — locate project docs; useful for enriching a module's "primary sources".
+
+## Verification (completion checks)
+
+When starting / ending a learning session, self-check with `references/gotchas.md` and confirm:
+
+- [ ] `.learning/` is gitignored; the target repo is not polluted.
+- [ ] `course-map.json` is the user-confirmed version.
+- [ ] `progress.json` written atomically, uncorrupted.
+- [ ] Notes appended and `~/.repo-mastery/index.json` updated each turn.
+- [ ] No expected-answer leakage; no unapproved mutating commands.

--- a/skills/repo-mastery/SKILL.md
+++ b/skills/repo-mastery/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: repo-mastery
 description: "Turn any open-source repository into a developer-focused mastery course. Given a local repo path or GitHub URL, it builds a confirmed course map and drives interactive mastery learning (diagnostic, explanation, Feynman check, practice, spaced review) with hands-on tasks, note-taking, and dual-format (Markdown + HTML) course output — so you fully master a project's usage, architecture, and key implementations like a real course. Triggers: 'learn this repo', 'master this codebase', 'turn X into a course', 'deep-dive into X project'."
-origin: ECC
-version: 2.2.1
+origin: personal
+version: 2.4.0
 tags: [learning, education, codebase, mastery, spaced-repetition]
 ---
 
@@ -24,9 +24,9 @@ Do **not** activate when: the user just wants a doc/README summary, a one-off co
 
 ## Prerequisites
 
-- **Claude Code** (the skill runtime) — the same skill also runs on OpenAI Codex and Gemini CLI (Agent Skills standard).
+- **Claude Code** (the skill runtime).
 - **Target repository**: a local path, or a reachable `github:owner/repo` (the skill auto-runs `git clone --depth 1`).
-- **Python 3** — needed by the deterministic engine (`scripts/learning_engine.py`) and the large-repo index (`scripts/index_repo.py`), both pure stdlib.
+- **Python 3** — only needed by the large-repo indexing script `scripts/index_repo.py` (pure stdlib).
 - **Write permission**: creates `.learning/` inside the target repo (auto-gitignored) and a global `~/.repo-mastery/`.
 
 ## Language
@@ -40,6 +40,37 @@ Teaching language **follows the user's input language by default** (Chinese inpu
 
 Code, file paths, and identifiers always stay in their original form regardless of language.
 
+## Multi-Tool Support
+
+Repo-Mastery is not Claude Code-only. The skill follows the open **Agent
+Skills** standard (agentskills.io), so the same `SKILL.md` runs natively on
+**Claude Code**, **OpenAI Codex**, **Gemini CLI**, and any tool that loads
+`SKILL.md` skills.
+
+| Tool | Entry point | Install |
+|---|---|---|
+| Claude Code | `SKILL.md` (this file) | `~/.claude/skills/repo-mastery/` |
+| OpenAI Codex | `SKILL.md` + `agents/openai.yaml` | `~/.codex/skills/repo-mastery/` |
+| Gemini CLI | `GEMINI.md` + skills via `activate_skill` | its skills dir; or copy `GEMINI.md` into a project |
+| AGENTS.md tools (opencode, Cursor, …) | `AGENTS.md` | clone repo or copy `AGENTS.md` into the project |
+
+**The deterministic engine is real code, not prose** — `scripts/learning_engine.py`
+implements `compute-mastery`, the spaced-repetition scheduler, `record-attempt`,
+and `next-objective`. **Every gate decision MUST go through this script**, so
+mastery math is identical in every tool. See `AGENTS.md` / `GEMINI.md` for the
+per-tool protocol; `scripts/install.sh` installs to all tools at once.
+
+## Difference from docs-to-course
+
+This skill **does not read docs and targets developers**. The learner is you — a developer who wants to understand how an open-source project was built — not an end-user who wants to learn how to use it. Therefore:
+
+- **Input** is source code (local path or GitHub URL), not a docs site.
+- Learning goes **inside the implementation**: architecture, design decisions, core algorithms — that is the point, not "surface operations".
+- Driving mode is **interactive mastery learning**, not one-shot static course generation.
+- Output is **resumable learning state** + a complete course document (Markdown + HTML dual format).
+
+> Methodologically it stands on `docs-to-course`'s shoulders: the course-design arc, quiz philosophy, module-brief pre-extraction, and HTML course shell are absorbed from it; the mastery engine (deterministic gates, spaced repetition, error diagnosis) is adapted from DeepTutor's `learning/` module. See `docs/ARCHITECTURE.md` and `ADOPTION.md`.
+
 ## Core Design Axiom (always hold)
 
 > **Intelligence at the exit, advancement at the gate.** You (the tutor) decide what to teach, how to question, how to explain — but whether the learner *may advance* is always a **deterministic engine decision**, never the LLM patting itself on the back.
@@ -47,8 +78,6 @@ Code, file paths, and identifiers always stay in their original form regardless 
 - Quantitative gate (memory / procedure types): `compute_mastery()` recency-weighted accuracy ≥ 0.9, capped by a confidence ceiling — **one lucky answer is not mastery**.
 - Qualitative gate (concept / design types): a Feynman-style explanation judged by the tutor (`mastery_assess`).
 - Advancement is computed **from what is already mastered** (`next_objective`), never from a stage counter. Knowledge points already proven are skipped (test-out path).
-
-**The gate is code, not prose** — run `scripts/learning_engine.py` for `compute-mastery`, `schedule`, `record-attempt`, `next-objective`, `validate-map`, and `init`. Every platform calls the same script, so mastery math never drifts.
 
 ---
 
@@ -79,7 +108,7 @@ Make a quick scale judgment first, **then** choose how to digest the source:
 | Dependency complexity / multi-language | simple | complex |
 
 - **Small / medium** → pure skill reads the source directly (Grep/Glob/Read + explore_context-style pre-scan), no Python dependency.
-- **Large** → first run `scripts/index_repo.py` to generate `code-map.json` (modules/dependencies/symbol locations; see `references/index-script-spec.md`), build the course map on top of it, and locate source on demand instead of cramming the whole repo into context.
+- **Large** → first run `scripts/index_repo.py` to generate `code-map.json` (modules/dependencies/symbol locations; see `references/index-script-spec.md`), build the course map on top of it, and locate source on demand during learning instead of cramming the whole repo into context.
 - When unsure, measure with `find` + `wc -l`; do not guess.
 
 ### Phase 1 — Pre-scan → Course Map Candidates
@@ -113,13 +142,15 @@ This is a menu, not a checklist — pick 4–8 modules that fit the repo; fewer,
 
 ### Phase 2 — Course Map Confirmation & Customization (user decision, never skipped)
 
-First establish the **Mission** (absorbed from the teach skill's MISSION.md): ask the user one key question — **"Why do you want to master this repo?"** (use it? modify it? explain it in interviews? borrow its design? …). Write the answer to `<repo>/.learning/MISSION.md`; it grounds every later teaching decision (module choices, Feynman follow-ups, mastery priority). When the Mission changes, update it and write a learning record.
+First establish the **Mission** (absorbed from the teach skill's MISSION.md): clarify **"Why do you want to master this repo?"** (use it? modify it? explain it in interviews? borrow its design? …) as a **decision-tree interview** — see `references/clarification-interview.md`. Ask one question at a time, carry an evidence-based recommended answer with each, and look up any fact the repo can settle instead of asking. Write the settled answer to `<repo>/.learning/MISSION.md`; it grounds every later teaching decision (module choices, Feynman follow-ups, mastery priority). When the Mission changes, update it and write a learning record.
 
-Then **present the candidate map** to the user, explain each module, and:
+Then **present the candidate map** to the user, explain each module, and walk each one as a decision (keep / adjust / drop) with your recommended answer:
 
 - ✅ User removes irrelevant modules / adds interesting ones / adjusts knowledge-point granularity.
 - ✅ User confirms each module's `pass_threshold` (default 0.7).
 - ✅ **Learning starts only after user approval.** This is mandatory — the opposite of docs-to-course's "don't get outline approval".
+
+> Confirmation questions are asked **one at a time** — never batched. Recommended answers belong to **decision questions only**; Phase 3 assessment (quiz / Feynman) never leaks the answer.
 
 After confirmation, write `<repo>/.learning/course-map.json` and initialize the `.learning/` structure (below).
 
@@ -129,8 +160,12 @@ Drive per `references/session-flow.md`. Core loop (per knowledge point):
 
 > **diagnostic (probe how much is known; test-out skip) → explain → Feynman check → practice (quiz / hands-on) → error diagnosis → spaced-review scheduling**
 
-- The next station is always decided by the **engine script** — run `python3 scripts/learning_engine.py next-objective <path>/.learning/progress.json` (priority: pending question → due review → first unmastered point → complete).
-- Quantitative gate (memory/procedure): pose a question, then record the attempt and recompute mastery via `python3 scripts/learning_engine.py record-attempt ... --write`; advance only when the script reports `passed_gate: true` (≥ 0.9).
+- The next station is always decided by the **engine script** — run
+  `python3 scripts/learning_engine.py next-objective <path>/.learning/progress.json`
+  (priority: pending question → due review → first unmastered point → complete).
+- Quantitative gate (memory/procedure): pose a question, then record the attempt and
+  recompute mastery via `python3 scripts/learning_engine.py record-attempt ... --write`;
+  advance only when the script reports `passed_gate: true` (≥ 0.9).
 - Qualitative gate (concept/design): have the user do a Feynman recital; you judge `passed`; retry if not. (Qualitative results are stored in `progress.json.qualitative_mastery` and read by the engine's `next-objective`.)
 - **Hands-on on demand**: for procedure points, guide the user to actually run things (build/test/write a small demo). Read-only commands (`build`, `test`, `--help`) may run directly; **mutating operations (writing files, installing deps) require explicit user approval first**. The hands-on result is recorded as mastery evidence.
 - **Auto notes**: after each explanation/judgment, automatically append to `<repo>/.learning/notes/<module>.md` (format: `note-template.md`); the user can `/repo-mastery note "..."` at any time.
@@ -183,14 +218,24 @@ Progress is stored in JSON, one record per knowledge point; the **expected answe
 
 ## Scripts
 
-- `scripts/learning_engine.py` — **the deterministic gate**. Call for mastery / schedule / record-attempt / next-objective / validate-map / init. Mandatory; never re-derive the math from prose.
+- `scripts/learning_engine.py` — **the deterministic gate**. Call for mastery /
+  schedule / record-attempt / next-objective / validate-map / init. Mandatory in
+  every tool; never re-derive the math from prose.
 - `scripts/index_repo.py` — large-repo code index (`code-map.json`), pure stdlib.
+- `scripts/install.sh` — install the skill to Claude Code, Codex, and Gemini CLI
+  at once (`--only <tool>` / `--skip <tool>` / `--dry-run`).
+
+## Multi-tool entry points
+
+- `AGENTS.md` — portable protocol for AGENTS.md-compatible tools (Codex, opencode, Cursor).
+- `GEMINI.md` — protocol for Gemini CLI.
+- `agents/openai.yaml` — Codex/Agent-Skills UI metadata.
 
 ## Anti-Patterns
 
 > The full failure checklist is in `references/gotchas.md`. These anti-patterns destroy learning quality outright — stop when you see one:
 
-- ❌ **Letting the LLM replace the gate** — never use "do you feel you've got it?" instead of the engine script.
+- ❌ **Letting the LLM replace the gate** — never use "do you feel you've mastered it?" instead of `compute_mastery` / `mastery_assess`.
 - ❌ **Skipping course-map confirmation** — the user must approve/customize the map (with Mission); this is an explicit requirement.
 - ❌ **Leaking the expected answer** — the question text/options must never contain it; only `progress.json.pending_question` does.
 - ❌ **Confusing "worked once" with "mastered"** — one lucky answer / one successful run ≠ mastery; the confidence ceiling + spaced review are the real goal (fluency ≠ storage).

--- a/skills/repo-mastery/agents/openai.yaml
+++ b/skills/repo-mastery/agents/openai.yaml
@@ -1,0 +1,16 @@
+# Codex (Agent Skills standard) UI metadata for repo-mastery.
+# See the Agent Skills standard (agentskills.io) for the schema.
+
+display_name: Repo-Mastery
+brand_color: "#0d9488"
+
+# The prompt shown when the user picks the skill in the Codex app.
+default_prompt: >-
+  Turn an open-source repository into a developer-focused mastery course
+  (usage → architecture → key implementations). Which repo do you want to
+  master? Give a local path or github:owner/repo.
+
+# Allow the skill to trigger from its description when a task matches,
+# not only when the user names it explicitly.
+policy:
+  allow_implicit_invocation: true

--- a/skills/repo-mastery/references/clarification-interview.md
+++ b/skills/repo-mastery/references/clarification-interview.md
@@ -1,4 +1,4 @@
-# Clarification Interview — Decision-Clarifying Confirmation (absorbed from the grilling skill)
+# Clarification Interview — Value Brief + Decision-Clarifying Confirmation (absorbed from the grilling skill)
 
 > **Read in**: Phase 2. This protocol turns the open confirmation steps (Mission + course-map sign-off) into a decision-tree clarification: every implicit assumption made explicit, until you and the learner share the same understanding. Absorbed from mattpocock's `grilling` skill (user entry `grill-me`); see `ADOPTION.md` §5.
 
@@ -6,19 +6,52 @@
 
 Phase 2 confirmation is a decision, not a formality. The goal is not to reach agreement quickly; it is to surface every implicit choice and make it explicit, so nothing important is silently assumed. The output is a confirmed `MISSION.md` + `course-map.json` the learner actually owns.
 
-## 2. Decision-tree walk
+## 0. Value brief first (what this repo can teach, and why it stands out)
 
-Treat the confirmation as a tree of decisions, resolving dependencies one by one — a parent decision settled before the choices that hang off it:
+Before any decision question, give the learner the **value brief** — the raw
+material the whole interview reacts to (learner field feedback: clarify what a
+project offers and what makes it better than peers *before* deciding what to
+study). Two parts, both grounded in the Phase 1 pre-scan:
 
-- Root (parent): **Mission** — why does the learner want to master this repo? (use it / modify it / explain it in interviews / borrow its design / …)
-- Branch: **module-level decisions** — keep / adjust / drop each candidate module; adjust granularity.
-- Leaf: **parameter decisions** — each module's `pass_threshold` (default 0.7), optional hands-on labs.
+1. **Teaching-capability inventory (what this repo can teach)** — list the
+   capability dimensions the course can cover: build/usage, architecture
+   mental model, key implementations, design tradeoffs, transferable skills.
+   Make it a menu the learner can pick from.
+2. **Differentiation (what makes it stand out vs peers)** — read from
+   `.learning/positioning.md` (the sourced comparison matrix produced by
+   `positioning-brief.md`, Phase 2), **never improvised on the spot**. Pick
+   2–3 matrix rows that fit the learner's direction (e.g. for DeepTutor vs
+   other tutor platforms: agent-native single loop + multi-engine RAG +
+   three-layer memory). Unsourced peer claims are marked "facts to verify", never presented
+   as fact.
 
-An early answer reshapes which questions come next. Do not fire questions in parallel; descend in dependency order.
+Present this as a proposal, then let the interview locate which dimension the
+learner actually cares about. The settled value positioning is written into
+`.learning/MISSION.md` (a "Value positioning" section) and drives how the
+course map is pruned.
 
-## 3. One question at a time
+**Two-pass production (see `positioning-brief.md`)** — the matrix is drafted
+*before* the Mission interview (generalized peer rows), then pruned/deepened
+*after* the Mission is settled toward what it cares about. So the value brief's
+differentiation can be sharpened between first draft and confirmed Mission; the
+full matrix never leaves `positioning.md`, only 2–4 rows surface here.
 
-Ask one question, wait for the answer, then continue. Asking multiple questions at once is bewildering — the learner cannot converge on a decision tree if every branch is presented simultaneously.
+## 2. Decision-tree walk — layered density
+
+Treat the confirmation as a tree of decisions, resolving dependencies one by one. **Depth vs breadth is layered**: the Mission root keeps the one-at-a-time decision-tree interview (it grounds the whole course); the map-level branches are confirmed in **one batch** (see §3).
+
+- Root (parent): **Value positioning + Mission** — from the value brief, which dimension matters to the learner, and why do they want to master this repo? (use it / modify it / explain it in interviews / borrow its design / …) **Asked one at a time** — the Mission shapes which module questions matter.
+- Branch: **module-level decisions** — present the **full candidate list at once**, each module with the tutor's recommended keep/adjust/drop, and take the user's adjustments in **one reply**; follow up (one at a time) **only on modules the user adjusted**. Granularity tweaks ride along with the affected module.
+- Leaf: **parameter decisions** — `pass_threshold` **defaults to 0.7 for all modules**; only asked/adjusted on explicit request (e.g. "make everything harder / this module easier"). Optional hands-on labs are offered, not interrogated.
+
+An early answer reshapes which questions come next. Do not fire the Mission tree in parallel; descend in dependency order.
+
+## 3. Layered density: one at a time vs batch
+
+- **Mission decision tree: one question at a time.** Ask, wait, continue. Firing the whole Mission tree at once is bewildering and the learner cannot converge.
+- **Course-map confirmation: one batch.** Present the full module list with recommendations and take all adjustments in a single reply ("keep m1 m2 m3, drop m4, add a hands-on point to m2"). Only the modules the user touched get follow-up questions (one at a time). Thresholds stay at the 0.7 default unless the user asks to change them.
+
+The learner chooses the density, not the tutor: a user who wants depth can react module by module; a user who wants speed replies once. Never force the slow path on a user who is converging fast, and never batch the Mission root — it is the one question whose answer reshapes everything.
 
 ## 4. Facts vs decisions (information retrieval)
 
@@ -28,7 +61,16 @@ If a *fact* can be found by exploring the environment (source code, README, call
 
 Every decision question comes with the tutor's own recommended answer, grounded in repo evidence — so the learner reacts to a proposal, not a blank prompt.
 
-**Boundary — never for assessment questions.** The recommended-answer habit applies only to decision questions (Mission, module choices, thresholds, "what next"). It must **never** leak into Phase 3 assessment (quiz / Feynman recital): `progress.json.pending_question.expected_answer` is the only place the answer lives, and it never round-trips to the learner (see `mastery-policy.md` §7 and `gotchas.md`).
+**Boundary — recommended answers stay with decision questions.** The
+recommended-answer habit of *this interview* applies only to decision questions
+(Mission, module choices, thresholds, "what next"). Phase 3's reference answer
+is a different thing: in learning it is the material the learner *reacts to* —
+shown right after explaining a point (concept/design), or right after answering
+a graded procedure question (self-check). The one place the answer is still
+withheld *before* the learner acts is a **graded procedure question**:
+`progress.json.pending_question.expected_answer` stays server-side until the
+user answers, then is shown for self-check (see `session-flow.md` §2–4 and
+`mastery-policy.md` §7).
 
 ## 6. Shared-understanding gate
 

--- a/skills/repo-mastery/references/clarification-interview.md
+++ b/skills/repo-mastery/references/clarification-interview.md
@@ -1,0 +1,39 @@
+# Clarification Interview — Decision-Clarifying Confirmation (absorbed from the grilling skill)
+
+> **Read in**: Phase 2. This protocol turns the open confirmation steps (Mission + course-map sign-off) into a decision-tree clarification: every implicit assumption made explicit, until you and the learner share the same understanding. Absorbed from mattpocock's `grilling` skill (user entry `grill-me`); see `ADOPTION.md` §5.
+
+## 1. Purpose
+
+Phase 2 confirmation is a decision, not a formality. The goal is not to reach agreement quickly; it is to surface every implicit choice and make it explicit, so nothing important is silently assumed. The output is a confirmed `MISSION.md` + `course-map.json` the learner actually owns.
+
+## 2. Decision-tree walk
+
+Treat the confirmation as a tree of decisions, resolving dependencies one by one — a parent decision settled before the choices that hang off it:
+
+- Root (parent): **Mission** — why does the learner want to master this repo? (use it / modify it / explain it in interviews / borrow its design / …)
+- Branch: **module-level decisions** — keep / adjust / drop each candidate module; adjust granularity.
+- Leaf: **parameter decisions** — each module's `pass_threshold` (default 0.7), optional hands-on labs.
+
+An early answer reshapes which questions come next. Do not fire questions in parallel; descend in dependency order.
+
+## 3. One question at a time
+
+Ask one question, wait for the answer, then continue. Asking multiple questions at once is bewildering — the learner cannot converge on a decision tree if every branch is presented simultaneously.
+
+## 4. Facts vs decisions (information retrieval)
+
+If a *fact* can be found by exploring the environment (source code, README, call chains, `course-map.json` evidence paths), look it up rather than asking. The *decisions* are the learner's — put each one to them and wait.
+
+## 5. Recommended answers (decision questions only)
+
+Every decision question comes with the tutor's own recommended answer, grounded in repo evidence — so the learner reacts to a proposal, not a blank prompt.
+
+**Boundary — never for assessment questions.** The recommended-answer habit applies only to decision questions (Mission, module choices, thresholds, "what next"). It must **never** leak into Phase 3 assessment (quiz / Feynman recital): `progress.json.pending_question.expected_answer` is the only place the answer lives, and it never round-trips to the learner (see `mastery-policy.md` §7 and `gotchas.md`).
+
+## 6. Shared-understanding gate
+
+When the confirmation is complete, summarize the settled decisions back and confirm before proceeding — then write them to `MISSION.md` and `course-map.json`. Learning starts only after the learner approves. If the Mission changes mid-course, update `MISSION.md` and write a learning record.
+
+## Difference from grilling
+
+`grilling` is stateless — it writes nothing and leaves no artifact. Repo-Mastery's clarification is stateful by design: the settled decisions land in `.learning/MISSION.md` and `course-map.json`, because they ground every later teaching decision.

--- a/skills/repo-mastery/references/curriculum-design.md
+++ b/skills/repo-mastery/references/curriculum-design.md
@@ -10,12 +10,29 @@ The spine of a code-learning course:
 
 > **First win (build) → overall architecture mental model → core workflows/modules → key implementations → hands-on labs → troubleshooting → deep references**
 
+## Overview-first: the whole picture before the nodes
+
+Learning should start with **the whole knowledge organization, then deep-dive
+into key nodes** (learner field feedback). Two levels of overview, both
+non-graded:
+
+- **Global overview (Phase 3.0)** — one-page architecture narrative (entry →
+  core data flow), a module map, key-implementation highlights, and a
+  differentiation summary ("what makes this project stand out vs peers"). This
+  is delivered before any per-point learning.
+- **Module overview (start of each module)** — that module's knowledge-point
+  map + its local cheatsheet, delivered before the module's nodes are taught.
+
+The course map is the backbone these overviews are built from; design it so a
+reader can grasp the whole skeleton from the module list alone.
+
 ## The module menu (a menu, not a checklist)
 
 Each candidate module comes from real repo evidence — files, directories, build config, README, issues. Pick 4–8; fewer, deeper is better.
 
 | # | Module | Where it comes from | Why a developer cares |
 |---|---|---|---|
+| 0 | **Ecosystem positioning & differentiation** | `.learning/positioning.md` (Phase 2 `positioning-brief.md`): one-liner positioning + 7-col comparison matrix + "when to pick it" | The developer's first question: what is this project, how does it trade off vs its natural peers, and when would I pick it. **Recommended, but droppable.** |
 | 1 | **Build & environment** | README quickstart, Dockerfile, Makefile, pyproject/package.json | Trust. Seeing it run gives every later code discussion a vehicle. **Almost always keep.** |
 | 2 | **Overall architecture mental model** | top-level dirs, entry files (main/app/__init__), dependency graph, README architecture section | Lets you predict behavior instead of memorizing code line by line. |
 | 3 | **Core workflows** | high-frequency entry APIs, CLI commands, main request-response paths | The "how to use it" body. |
@@ -29,6 +46,12 @@ Each candidate module comes from real repo evidence — files, directories, buil
 - Medium app: 1, 2, 3, 4, 5, 6. ~6 modules.
 - Large platform (multi-language/multi-entry/plugin ecosystem): all of 1–7; split "key implementations" into several modules if needed. Use the parallel build path.
 
+**Module 0 — keep or cut**: keep when the Mission is "borrow the design /
+explain in interviews / choose between tools"; cut when the Mission is "use it
+/ hack internals" and the learner wants architecture fast (the global
+overview's differentiation summary still covers the teaser). Never push module
+0 on a learner who said no.
+
 ## Knowledge points: granularity and type
 
 Break each module into **3–8 knowledge points**. Granularity rule of thumb: *each knowledge point should be a unit you can answer "do I know it or not" in one word*. One point = one judgeable interaction; never vague.
@@ -37,12 +60,34 @@ Every knowledge point must have a `type` (it decides the gate; see `mastery-poli
 
 | type | Meaning (for code learning) | Gate | Example |
 |---|---|---|---|
-| `memory` | remembered APIs/commands/key constants | quantitative (quiz) | "syntax of `deeptutor kb create`" |
 | `procedure` | can operate: build/run/call | quantitative + hands-on | "build and launch the project from scratch" |
 | `concept` | understand core concepts/data structures | qualitative (Feynman recital) | "understand the RAG retrieval flow" |
-| `design` | can explain why it's designed this way / extend it | qualitative + design tradeoff follow-ups | "why message queue instead of RPC" |
+| `design` | can explain why it's designed this way / extend it | qualitative + design tradeoff follow-ups | "why message queue instead of RAG" |
+
+> **`memory` is not a knowledge-point type anymore.** Parameter/command/API-spelling
+> trivia is numerous, project-specific, and doesn't build transferable skill
+> (learner field feedback: "specific parameter usage is never the point"). It
+> lives in each module's **reference notes** — the tutor auto-accumulates a
+> verbatim cheatsheet into `notes/<module>.md` (see `note-template.md`
+> "Command / config cheatsheet"). The engine still accepts `memory` in old maps
+> but treats it as reference-only and never gates on it.
 
 > A common mistake is over-coarse points ("understand the system architecture"). Split to judgeable units: "dependency direction between modules", "the complete call chain of a request", "config load precedence".
+
+## Module 0 knowledge points (ecosystem positioning, all `design`)
+
+Module 0 reuses the existing `design` qualitative channel — **zero engine
+changes**. Three points, ordered so each builds on the last:
+
+| kp | Point | What "mastered" means (Feynman restatement + tradeoff follow-ups) |
+|---|---|---|
+| `kp00-01` | Positioning & ecological niche | Restate the one-liner: what niche, for whom, what it refuses to be — and cite where in `positioning.md` the evidence lives (`[src]` / `[web]`). |
+| `kp00-02` | Key tradeoffs vs peers | Pick the matrix row the learner cares about most and walk the tradeoff: why this repo does X, what the peer does instead, the failure mode of each choice. |
+| `kp00-03` | When to pick it (transferable criterion) | State the decision rule that transfers across projects ("pick this when …; pick the peer when …"), not a memorized feature list. |
+
+The "when to pick it" column of `positioning.md` is the evidence anchor for
+`kp00-03`; the whole matrix stays in `positioning.md`, never re-written into a
+quiz or a reference answer.
 
 ## Generate from evidence, not invention
 

--- a/skills/repo-mastery/references/curriculum-design.md
+++ b/skills/repo-mastery/references/curriculum-design.md
@@ -1,0 +1,65 @@
+# Curriculum Design — Designing the Course Map from Source
+
+> **Read in**: Phase 1. Your job is to turn a source repo's *structure tree* into a learning *route*. The learner is you (a developer), and the goal is to fully understand the project: **usage → architecture → key implementations**.
+
+## The core move: reference → route (absorbed from docs-to-course)
+
+Source repos are organized for *lookup* (by module, by directory, by language convention). A course is organized for *learning* — each step earns the next. **Do not mirror the directory tree; re-sequence it.**
+
+The spine of a code-learning course:
+
+> **First win (build) → overall architecture mental model → core workflows/modules → key implementations → hands-on labs → troubleshooting → deep references**
+
+## The module menu (a menu, not a checklist)
+
+Each candidate module comes from real repo evidence — files, directories, build config, README, issues. Pick 4–8; fewer, deeper is better.
+
+| # | Module | Where it comes from | Why a developer cares |
+|---|---|---|---|
+| 1 | **Build & environment** | README quickstart, Dockerfile, Makefile, pyproject/package.json | Trust. Seeing it run gives every later code discussion a vehicle. **Almost always keep.** |
+| 2 | **Overall architecture mental model** | top-level dirs, entry files (main/app/__init__), dependency graph, README architecture section | Lets you predict behavior instead of memorizing code line by line. |
+| 3 | **Core workflows** | high-frequency entry APIs, CLI commands, main request-response paths | The "how to use it" body. |
+| 4 | **Key implementations (internals)** | core algorithms, data structures, async/concurrency mechanisms, plugin/extension points | **This skill's signature module** — docs-to-course explicitly avoids it; we specialize in it. |
+| 5 | **Hands-on labs** | test suites, examples dir, modifiable demos | Turns "understood" into "can do". |
+| 6 | **Troubleshooting & boundaries** | common issues, error paths, exception handling, config traps | Lets you stand on your own when things break. |
+| 7 | **Deep references** | API docs, contributing guide, internal design docs | Your self-service entry after the course. |
+
+**How to choose**:
+- Small CLI/lib: modules 1, 2, 3, 5, 6. ~5 modules.
+- Medium app: 1, 2, 3, 4, 5, 6. ~6 modules.
+- Large platform (multi-language/multi-entry/plugin ecosystem): all of 1–7; split "key implementations" into several modules if needed. Use the parallel build path.
+
+## Knowledge points: granularity and type
+
+Break each module into **3–8 knowledge points**. Granularity rule of thumb: *each knowledge point should be a unit you can answer "do I know it or not" in one word*. One point = one judgeable interaction; never vague.
+
+Every knowledge point must have a `type` (it decides the gate; see `mastery-policy.md`):
+
+| type | Meaning (for code learning) | Gate | Example |
+|---|---|---|---|
+| `memory` | remembered APIs/commands/key constants | quantitative (quiz) | "syntax of `deeptutor kb create`" |
+| `procedure` | can operate: build/run/call | quantitative + hands-on | "build and launch the project from scratch" |
+| `concept` | understand core concepts/data structures | qualitative (Feynman recital) | "understand the RAG retrieval flow" |
+| `design` | can explain why it's designed this way / extend it | qualitative + design tradeoff follow-ups | "why message queue instead of RPC" |
+
+> A common mistake is over-coarse points ("understand the system architecture"). Split to judgeable units: "dependency direction between modules", "the complete call chain of a request", "config load precedence".
+
+## Generate from evidence, not invention
+
+Every module/knowledge point must point to **concrete evidence in the repo**:
+
+- Module → top-level dir or core file path.
+- Knowledge point → specific file/function/doc section.
+- Key-implementation module → the file and entry function where that code lives.
+
+If you have no evidence for a module while designing the map, either go read it or leave it out. **Better one fewer module than one that's hollow.**
+
+## Pre-scan order (explore_context style)
+
+1. README / top-level docs — how the repo wants to be understood.
+2. Build config (pyproject.toml / package.json / Cargo.toml / Makefile / Dockerfile) — how it runs.
+3. Directory structure & entry files (`find` top-level + read `main`/`app`/`__init__.py`).
+4. Core modules — read the 3–5 heaviest at interface level.
+5. Tests & examples — see the real usage.
+
+**Stay objective**: this phase only *maps*; conclusions come in the explanation phase.

--- a/skills/repo-mastery/references/example-walkthrough.md
+++ b/skills/repo-mastery/references/example-walkthrough.md
@@ -1,0 +1,167 @@
+# Example Walkthrough — one full course, start to first module
+
+> Read in: any phase. A concrete end-to-end example so a fresh agent can see
+> the intended dialogue shape. Uses one real well-known repo — **sqlite/sqlite**
+> (the embedded database) — consistently. Protocol lines are English; learner
+> replies are quoted as the user actually types them (here Chinese, matching
+> the teaching language). The `[src]`/`[web]` tags illustrate the source
+> discipline, not real fact-checked claims.
+
+## 1. Preview (recon, zero side effects)
+
+```text
+User:  /repo-mastery preview sqlite/sqlite
+Tutor: macro brief in chat — five sections, nothing persisted:
+       1. What it is — embedded, single-file, public-domain SQL database;
+          ~260k lines of C, runs in-process (src/sqlite3.c).
+       2. Architecture — sqlite3_open → prepare (SQL → bytecode) → step (VDBE
+          loop) → pager/btree behind the cursor.
+       3. Differentiation vs peers — 3 rows, tagged:
+          · embedded & single-file vs client-server (MySQL/Postgres) — no
+            install, no network [web] https://www.sqlite.org/whentouse.html
+            (2026-08-12)
+          · B-tree storage vs LSM (RocksDB) — read-favor vs write-favor [unv]
+          · whole-db test discipline — millions of statements in CI [web]
+            https://www.sqlite.org/testing.html (2026-08-12)
+       4. Key highlights — pager/WAL crash safety, VDBE bytecode, portable VFS.
+       5. Deep-dive candidates — the storage core (pager/btree) and the query
+          executor (VDBE) are the richest modules to learn.
+Tutor: "That brief was scouting only — zero side effects, nothing written.
+        Say 'deep-dive' (or 「深学」) and I'll start the course from here."
+User:  「深学」
+```
+
+Cross-session: if the user says deep-dive in a *later* session, `/repo-mastery
+start` re-runs Phase 0/1/2 and the brief is regenerated at start time.
+
+## 2. Start: Phase 1–2 (pre-scan → value brief → Mission → map confirm)
+
+```text
+Tutor: /repo-mastery start sqlite/sqlite --language zh
+       Phase 0 — ~260k lines C → large → run `scripts/index_repo.py` → `code-map.json`.
+       Phase 1 — pre-scan (repo-internal only): README, main entry, build,
+       structure, core modules → course-map candidates per curriculum-design.md.
+       Phase 2 — value brief:
+         Teaching-capability inventory — crash safety via pager/WAL, bytecode
+         execution in VDBE, query planning, portable VFS.
+         Differentiation (2–4 rows, sourced) — the same three preview rows.
+       "Before we map the course — one question, with my recommendation:
+        what's your Mission?  (a) use it safely in a product, (b) modify the
+        storage engine, (c) borrow the architecture for your own engine.
+        I'd recommend (c): it pulls in pager, btree and VDBE — the deepest
+        material."
+User:  「想改存储引擎，加一个自定义 VFS」（= b + a bit of c）
+Tutor: Writes MISSION.md. "Mission locked: modify storage, add a custom VFS."
+       Presents the full module list at once (one batch, no drilling):
+         m00 sqlite-as-embedded-DB (positioning, droppable)
+         m01 build & first query  (open → prepare → step)
+         m02 pager & WAL         (page cache, journaling, crash safety)
+         m03 btree               (page format, cursor, B+tree ops)
+         m04 VDBE                (bytecode VM)
+         m05 query planning
+         m06 VFS / OS layer      (portable I/O — your Mission target)
+       "Reply with all adjustments in one batch. My recommendation: keep m00
+        (teaser only, skip deep-dive) and move m06 up to m02 since your
+        Mission targets the VFS."
+User:  「好，m06 提前到 m02，m00 只做概览不深入」
+Tutor: Re-orders map to m01, m06(VFS), m02(pager/WAL), m03(btree), m04(VDBE),
+       m05(planning). Writes .learning/: MISSION.md, positioning.md,
+       course-map.json; sets flow_phase=overview; generates first-draft
+       COVERAGE.md. "Course confirmed. pass_threshold 0.7."
+```
+
+## 3. Phase 3: global overview → module overview → first chapter
+
+```text
+Tutor: Phase 3.0 — one-page global overview (entry → core data flow → key
+       modules → differentiation teaser from positioning.md), written to
+       notes/overview.md. No grading, no interruption.
+       set-phase ... progress.json module_overview --module m01
+       Phase 3.1 — m01 "build & first query": knowledge-point map + local
+       cheatsheet (build flags, sqlite3_open_v2 flags). Then:
+       set-phase ... progress.json learning
+       "m01 defaults to textbook mode. Generating chapters/m01-build-runtime.md
+        and starting it — four sections: (1) open, (2) prepare, (3) step,
+        (4) statement lifecycle."
+       chapter-start --module m01 --sections 4
+       --- section 1 walk (open) ---
+       "Why care: every API call funnels through sqlite3_open_v2. Concept:
+        the connection owns a pager, and the pager owns the page cache.
+        Source walk (three-part, per note-template.md) — the tutor pastes
+        the source, not just a pointer:
+          · file:line locator:  src/sqlite3.c sqlite3_open_v2 →
+              sqlite3_open_internal → pager_open  (locate via
+              `code-map.json`'s symbol table, then Read the slice)
+          · inline key fragment (teaching core, 3-15 lines), pasted from
+              the file: sqlite3_open_v2() → allocates the pager →
+              pager_open() — the handoff that makes the connection own the
+              page cache
+          · <details> full source: the same slice verbatim, collapsed under
+              a `<details>` block so the learner can expand it when wanted
+        This section is done — any questions? If none, we move on."
+User:  「继续，理解了 open 的流程」
+Tutor: chapter-advance --section 1   (never before an explicit reply)
+       --- section 2 walk (prepare → bytecode) ---  ... STOP, confirm ...
+User:  「继续」
+Tutor: chapter-advance --section 2  → sections 3–4 walked the same way
+       → pause again before after-class Q&A:
+       "Sections done. Entering Q&A — ask anything."
+       chapter-advance --status qna
+User:  「prepare 的结果能缓存复用吗？」
+Tutor: answers + digests (auto-consolidates into notes/m01-*.md).
+       "Now after-class checking — two deep questions on the key nodes."
+       chapter-advance --status verifying
+User:  (restates open→prepare→step from source)
+Tutor: set-qualitative --kp m01-01 --type concept --pass
+       (a second procedure point: record-attempt --kp m01-03 --type procedure
+        --correct --question <qid> --write)
+       chapter-complete  → m01 covered; points scheduled for spaced review,
+       shown as "Covered · awaiting review verification", never as mastered.
+```
+
+## 4. Command examples (note / status / review / continue)
+
+```text
+/repo-mastery note          — interval consolidation since notes/.boundary.json:
+                              before → read boundary; extract the interval's Q&A
+                              conclusions, cheatsheet additions, Feynman records
+                              (dedup vs the auto diary); after → append an
+                              "Interval synthesis" recap + update the boundary.
+                              Also /repo-mastery note "用户原文" appends verbatim.
+/repo-mastery status        — regenerates MASTERY.md, one page:
+                              Progress (modules 1/6, verified points 2/24,
+                              current m02 chapter) · Mastery % by knowledge type ·
+                              Review due (count + earliest due_at) · Next objective.
+/repo-mastery review        — spaced review only: drains due reviews, bypasses
+                              the flow_phase overview gate, never opens new
+                              content. "2 reviews due — let's recall."
+/repo-mastery continue      — Session Preamble first (value replay + MASTERY.md
+                              progress + due signpost, display-only), then
+                              next-objective resumes. Bare /repo-mastery is
+                              the same.
+```
+
+## 5. Failure recovery (concrete, imperative)
+
+```text
+· set-phase failed →
+    1. read progress.json → flow_phase (the actual phase)
+    2. re-run next-objective (CLI subcommand) so the cursor resumes there
+    3. retry the matching set-phase (module_overview --module mNN while an
+       overview is unfinished, else learning)
+· chapter-advance rejected by the engine → read the error and branch:
+    (a) "no active chapter" → re-run chapter-start --module m01 --sections 4
+        first; (b) invalid --status → pass a valid teaching|qna|verifying.
+    Protocol rule too: after each section, pause and wait for an explicit
+    learner reply before advancing — never chain sections in one turn.
+· .boundary.json missing → the interval starts at the session/module start
+    (first note), not an invented earlier boundary. Consolidate from there,
+    then write {"module_id": ..., "last_consolidated_at": <now unix>}.
+· no search tool for the value brief → degraded repo-evidence mode: build the
+    brief from repo facts only, mark peer rows [unv], and never fabricate a
+    source.
+· next-objective returns complete → the course is done: show the final
+    COVERAGE.md summary (modules covered, verified points, mastery %), then
+    offer: refresh the HTML course from the final COVERAGE.md (HTML build
+    step), start over, or switch repos.
+```

--- a/skills/repo-mastery/references/gotchas.md
+++ b/skills/repo-mastery/references/gotchas.md
@@ -1,0 +1,47 @@
+# Gotchas — Failure-Point Checklist
+
+> **Read in**: all phases. Self-check with this list at the start of the main flow, on exceptions, and before Phase 4 output. Absorbed from docs-to-course's `gotchas.md`, with repo-mastery-specific traps added.
+
+## Course-map phase
+
+- [ ] **Over-coarse knowledge points** — "understand the system architecture" is not a judgeable unit. Split to "dependency direction between modules / complete request call chain / config load precedence".
+- [ ] **Modules without evidence** — every module in the map points to a real file/dir. No evidence → cut it; better fewer than hollow.
+- [ ] **Skipping Phase 2 confirmation** — the user must approve/customize the map (with Mission). This is an explicit requirement; don't skip.
+- [ ] **Concluding too early in the pre-scan** — Phase 1 only maps; conclusions belong to the explanation phase.
+
+## Learning-session phase
+
+- [ ] **Letting the LLM replace the gate** — never use "do you feel you've got it?" instead of `compute_mastery` / `mastery_assess`.
+- [ ] **Expected-answer leakage** — the question text/options must never contain the expected answer; it lives only in `progress.json.pending_question`.
+- [ ] **Dumping multiple concepts at once** — one knowledge point, one layer.
+- [ ] **Re-posing the same question** — when below 0.9, pose a different question to avoid memorizing the answer.
+- [ ] **Skipping error diagnosis** — answering the question directly without user self-attribution and an `error_records` entry corrupts review priority.
+- [ ] **Feynman that only asks "got it?"** — the qualitative gate must make the user actually recital; design type must probe tradeoffs.
+- [ ] **Cramming the whole repo into context** — read only the relevant files for the current point (locate via `code-map.json` in large repos).
+
+## Hands-on phase
+
+- [ ] **Running mutating commands without approval** — read-only commands may run directly; writing files / installing deps must be shown and approved first.
+- [ ] **Treating the user's demo as evidence without qualifying it** — a procedure point's hands-on pass = mastery evidence, but record the result; don't just say "nice".
+- [ ] **Non-verbatim commands** — commands/config the user will copy must be exact; don't invent flags.
+
+## Mission & learning-records phase
+
+- [ ] **Starting without the Mission** — Phase 2 must first ask "why do you want to master this repo" and write MISSION.md; skipping makes module choices groundless.
+- [ ] **Not updating a changed Mission** — when the learning goal shifts, update MISSION.md and write a learning record.
+- [ ] **Not writing a learning record when due** — when the user shows real understanding / states prior knowledge / a misconception gets corrected, write `records/NNNN-slug.md`; otherwise the ZPD baseline drifts.
+- [ ] **Not marking supersession after a correction** — mark the old record `Status: superseded by LR-NNNN` instead of deleting (the evolution history is useful).
+
+## Notes & data phase
+
+- [ ] **Rewriting whole notes** — notes append incrementally, never full rewrites (token economy).
+- [ ] **Rewriting user note text** — `/note` content is kept verbatim; the tutor only registers blockers.
+- [ ] **Non-atomic `progress.json` writes** — temp file + rename, or the learning state can corrupt.
+- [ ] **Forgetting to update global memory** — update `~/.repo-mastery/index.json` (where you left off) each turn, or `continue` breaks.
+
+## Phase 4 output phase
+
+- [ ] **Regenerating the HTML shell** — `styles.css` / `main.js` / `_footer.html` / `build.sh` are only copied verbatim from `references/html-shell/`, never rewritten.
+- [ ] **HTML biased to UI step-strips** — this skill's HTML course centers on architecture diagrams / dependency graphs / call chains, not UI screenshots.
+- [ ] **COVERAGE.md missing source references** — the complete course doc must carry `file:line` references, or it loses its "traceable back to source" value.
+- [ ] **Interactive elements using ad-hoc classes** — follow `html-shell/interactive-elements.md`'s class/data-* conventions; the CSS/JS won't cover invented classes.

--- a/skills/repo-mastery/references/gotchas.md
+++ b/skills/repo-mastery/references/gotchas.md
@@ -8,6 +8,8 @@
 - [ ] **Modules without evidence** — every module in the map points to a real file/dir. No evidence → cut it; better fewer than hollow.
 - [ ] **Skipping Phase 2 confirmation** — the user must approve/customize the map (with Mission). This is an explicit requirement; don't skip.
 - [ ] **Concluding too early in the pre-scan** — Phase 1 only maps; conclusions belong to the explanation phase.
+- [ ] **Batching confirmation questions** — ask one at a time (see `clarification-interview.md`); dumping the whole tree at once is bewildering.
+- [ ] **Blank-prompt decisions** — every decision question carries the tutor's evidence-based recommendation; assessment questions (Phase 3) never do.
 
 ## Learning-session phase
 
@@ -18,6 +20,8 @@
 - [ ] **Skipping error diagnosis** — answering the question directly without user self-attribution and an `error_records` entry corrupts review priority.
 - [ ] **Feynman that only asks "got it?"** — the qualitative gate must make the user actually recital; design type must probe tradeoffs.
 - [ ] **Cramming the whole repo into context** — read only the relevant files for the current point (locate via `code-map.json` in large repos).
+- [ ] **Substituting re-reading for retrieval** — rereading/summarizing creates an "illusion of learning" (recognition ≠ recall). Review must force recall (see `quiz-design.md`), never re-read.
+- [ ] **Consecutive same-type reviews** — interleave knowledge types in a review session; grinding one type trains discrimination poorly (`next_objective` prefers a different type from `last_review_type`).
 
 ## Hands-on phase
 

--- a/skills/repo-mastery/references/gotchas.md
+++ b/skills/repo-mastery/references/gotchas.md
@@ -2,26 +2,63 @@
 
 > **Read in**: all phases. Self-check with this list at the start of the main flow, on exceptions, and before Phase 4 output. Absorbed from docs-to-course's `gotchas.md`, with repo-mastery-specific traps added.
 
-## Course-map phase
+## Preview phase (recon)
+
+- [ ] **Preview creating `.learning/` or touching the engine** — `/repo-mastery
+  preview` is zero-side-effect recon: the macro brief lives in chat only; no
+  `.learning/` scaffold, no Mission/map confirmation, no engine calls. It ends
+  with zero artifacts (see `references/preview-brief.md` §3).
+- [ ] **Preview inventing peer differentiation** — preview's vs-peer rows follow
+  the same `[src]`/`[web]` discipline as `positioning-brief.md`; unsourced
+  claims are marked "facts to verify", never fabricated.
+- [ ] **Re-reconning in start after a preview** — a "deep-dive" hand-off reuses the
+  preview brief as Phase 2's value-brief input instead of rescanning the repo.
+
+## Course-map & clarification phase
 
 - [ ] **Over-coarse knowledge points** — "understand the system architecture" is not a judgeable unit. Split to "dependency direction between modules / complete request call chain / config load precedence".
 - [ ] **Modules without evidence** — every module in the map points to a real file/dir. No evidence → cut it; better fewer than hollow.
 - [ ] **Skipping Phase 2 confirmation** — the user must approve/customize the map (with Mission). This is an explicit requirement; don't skip.
 - [ ] **Concluding too early in the pre-scan** — Phase 1 only maps; conclusions belong to the explanation phase.
-- [ ] **Batching confirmation questions** — ask one at a time (see `clarification-interview.md`); dumping the whole tree at once is bewildering.
+- [ ] **Batching Mission decision-tree questions** — the Mission root is one-at-a-time (see `clarification-interview.md`); course-map adjustments, by contrast, are confirmed in **one batch** with follow-up only on adjusted modules.
 - [ ] **Blank-prompt decisions** — every decision question carries the tutor's evidence-based recommendation; assessment questions (Phase 3) never do.
+- [ ] **Clarifying without a value brief** — Phase 2 must first present what this repo can teach and what makes it stand out vs peers (see `clarification-interview.md` §0), before asking "what do you want to master". Skipping it makes the Mission groundless.
+- [ ] **Designing `memory` points as gate-able knowledge points** — parameter/command/API trivia is reference-note material (cheatsheet), never a knowledge point with a gate. Put it in the module's reference notes.
+- [ ] **Running the ecosystem scan in Phase 1** — Phase 1 stays repo-internal and objective; peer/ecosystem facts belong in Phase 2's `positioning.md`, never the pre-scan (see `SKILL.md` Phase 2 "External retrieval").
+- [ ] **Clarifying differentiation without a source** — the value brief's "stands out vs peers" is read from `.learning/positioning.md`, never improvised; an unsourced peer claim is marked "facts to verify", not a fact (see `clarification-interview.md` §0).
+- [ ] **Producing the positioning matrix only after the Mission** — the two-pass rule of `positioning-brief.md`: generalized draft *before* the Mission interview, prune/deepen *after*. Producing it once, post-Mission only, loses the pre-Mission breadth.
 
 ## Learning-session phase
 
 - [ ] **Letting the LLM replace the gate** — never use "do you feel you've got it?" instead of `compute_mastery` / `mastery_assess`.
-- [ ] **Expected-answer leakage** — the question text/options must never contain the expected answer; it lives only in `progress.json.pending_question`.
+- [ ] **Blank-prompt grinding** — learning interaction gives a reference answer and lets the user react to the proposal (grill-me style); never make the user answer from an empty prompt. For procedure's graded question the reference answer is shown right *after* answering, for self-check.
+- [ ] **Expected-answer leakage before grading** — for procedure's graded question the answer is never shown *before* the user answers (grading stays honest); shown right *after* for self-check. It lives only in `progress.json.pending_question`. (Concept/design's reference answer is part of the discussion, not hidden.)
 - [ ] **Dumping multiple concepts at once** — one knowledge point, one layer.
 - [ ] **Re-posing the same question** — when below 0.9, pose a different question to avoid memorizing the answer.
 - [ ] **Skipping error diagnosis** — answering the question directly without user self-attribution and an `error_records` entry corrupts review priority.
-- [ ] **Feynman that only asks "got it?"** — the qualitative gate must make the user actually recital; design type must probe tradeoffs.
+- [ ] **Feynman that only asks "got it?"** — the qualitative gate must make the user actually restate the reference answer in their own words (not just nod); design type must probe tradeoffs.
+- [ ] **Gating tutor-memory peer facts as knowledge points** — peer/ecosystem claims are facts in `.learning/positioning.md` (`[web]` / `[src]`), never gate-able `memory` points; a `[unv]` claim never sits behind a Feynman/quiz reference answer. Vs-peer answers come from the matrix (see `mastery-policy.md` §6).
+- [ ] **Skipping the overviews** — learning must open with the global overview (and each module with its module overview) before any per-node teaching; jumping straight into nodes loses the whole picture (learner field feedback). Engine-enforced: while `flow_phase` is `overview`/`module_overview`, `next-objective` refuses points.
+- [ ] **Resuming straight into a knowledge point** — a resume (`continue`, or the bare command that routes into it) always opens with the **Session Preamble** first: value replay (from `MISSION.md`) + current map + progress + due-review signpost, all display-only, no questions. Don't open a node before the preamble.
+- [ ] **Skipping `set-phase`** — after presenting an overview you must advance `flow_phase` (`set-phase module_overview --module m01`, then `set-phase learning`); otherwise `next-objective` keeps refusing new points and the session stalls.
+- [ ] **Blocking review on an unfinished overview** — scattered-time review is `/repo-mastery review` (`--mode review`), which bypasses the `flow_phase` gate and drains only due reviews. Don't let an unfinished overview stop the user's review moment.
+- [ ] **Per-point quiz grinding** — discussion and explanation come first; verification follows and stays lightweight. Don't turn every point into an interrogation.
 - [ ] **Cramming the whole repo into context** — read only the relevant files for the current point (locate via `code-map.json` in large repos).
 - [ ] **Substituting re-reading for retrieval** — rereading/summarizing creates an "illusion of learning" (recognition ≠ recall). Review must force recall (see `quiz-design.md`), never re-read.
 - [ ] **Consecutive same-type reviews** — interleave knowledge types in a review session; grinding one type trains discrimination poorly (`next_objective` prefers a different type from `last_review_type`).
+- [ ] **Forcing module 0 on a learner who cut it** — m00 is recommended but droppable; pushing it after the user declined stalls the Mission ("use it / hack internals" → cut; the global overview's differentiation teaser still covers the value).
+
+## Textbook-mode (chapter) phase
+
+- [ ] **`chapter_complete` without rebuilding the review queue / without writing `knowledge_types`** — `_rebuild_review_queue` reads `knowledge_types` and drops points whose type is missing (treated as `memory`); a covered module's unverified points then never enter review. Always write `knowledge_types[kp]` and call the rebuild.
+- [ ] **`chapter_start` while `flow_phase` is still `overview`/`module_overview`** — chapter-start validates `flow_phase == learning`; starting a chapter mid-overview leaves a dangling half-state (the chapter gate would fight the overview gate).
+- [ ] **Skipping `set-qualitative` after a passed concept/design check** — a passed Feynman judgment must be written via `set-qualitative` (writes `qualitative_mastery` **and** initialises the point's spaced review); flipping the boolean by hand leaves the point unscheduled for review.
+- [ ] **Entering a new module in interactive mode by default** — textbook-mode chapter is the default on entering each new module; after the module overview, auto-start it (`chapter-start`) with one line of notice, don't silently offer per-point nodes. Switch to per-point only when the learner asks for it, for that module.
+- [ ] **Dumping the textbook once and skipping the section walk** — `chapter` mode means the tutor teaches the material section by section (`chapter-advance`), not generating a document and moving on. A one-shot material dump has no teaching, no Q&A, no gate.
+- [ ] **Advancing to the next section without the user's confirmation** — after each section the tutor MUST stop and hand control back ("This section is done — any questions? If none, we move to the next section.") and wait for an explicit user reply before `chapter-advance --section N`. Chaining multiple sections in one turn is a violation even if every call is valid — the engine can't see the conversation, so the pause is the tutor's job. Same pause before teaching → `--status qna`.
+- [ ] **After-class checking that misses the module's key nodes** — the 1–2 deep questions must land on the module's critical knowledge points and go through the engine (`set-qualitative` / `record-attempt`), not trivia.
+- [ ] **Reading "chapter done" as "module mastered"** — `chapter-complete` covers the module but does not fake mastery; unchecked points are verified later via spaced review. Never write a mastery score for a point the learner never actually answered (fluency ≠ storage).
+- [ ] **Showing a covered module's points as unmastered** — in `status` / `COVERAGE.md`, a point whose module is in `chapter_covered_modules` is labelled "Covered · awaiting review verification", a third state between unmastered and mastered (real engine records). Listing it under the unmastered column misreads "studied, awaiting review verification" as "not studied".
 
 ## Hands-on phase
 
@@ -35,16 +72,26 @@
 - [ ] **Not updating a changed Mission** — when the learning goal shifts, update MISSION.md and write a learning record.
 - [ ] **Not writing a learning record when due** — when the user shows real understanding / states prior knowledge / a misconception gets corrected, write `records/NNNN-slug.md`; otherwise the ZPD baseline drifts.
 - [ ] **Not marking supersession after a correction** — mark the old record `Status: superseded by LR-NNNN` instead of deleting (the evolution history is useful).
+- [ ] **Applying saved global preferences to a new course** — a fresh `start` (or the bare command on a dir with no `.learning/`) must be **clean**: do not inherit `~/.repo-mastery/profile.md` style/depth/language preferences; the current input language and the new Mission drive it. Global memory is consulted only on explicit request.
+- [ ] **Routing `continue` by global memory instead of the current dir** — `continue` resumes the current directory's `.learning/`; if there is none, say so and guide to `start` on the current dir. Never jump to a project listed in `~/.repo-mastery/index.json` because it was "last learned".
 
 ## Notes & data phase
 
 - [ ] **Rewriting whole notes** — notes append incrementally, never full rewrites (token economy).
 - [ ] **Rewriting user note text** — `/note` content is kept verbatim; the tutor only registers blockers.
+- [ ] **Re-consolidating what auto already wrote** — `/repo-mastery note` consolidates the **interval since the last note** (`notes/.boundary.json`), deduplicated against the per-turn auto diary; re-summarizing already-written key points is wasted tokens (see `session-flow.md` §6.5).
+- [ ] **Inventing pre-compaction interval content** — when the note interval starts before a context compaction (cross-session resume), recover from `notes/<module>.md` + `records/` and mark unrecoverable detail "to revisit"; never fabricate take-aways the tutor can no longer see.
+- [ ] **Interval spanning modules consolidated into one note** — when the interval's discussion crosses modules, route each part to its own module's note; `notes/.boundary.json` records the last-consolidated module.
+- [ ] **Skipping the first note because there's no boundary** — no `.boundary.json` means the interval is from session/module start, not "nothing to consolidate"; write the boundary after the first note.
 - [ ] **Non-atomic `progress.json` writes** — temp file + rename, or the learning state can corrupt.
 - [ ] **Forgetting to update global memory** — update `~/.repo-mastery/index.json` (where you left off) each turn, or `continue` breaks.
+- [ ] **Full wrap-up on a mechanical turn** — a review drain, simple confirmation, or Q&A digesting with no new conclusion earns **slim wrap-up** (write-back + index.json + one-line report); auto-consolidate is skipped and deferred to the next substantive turn, so the "always fresh on substance" diary never becomes "always rewritten" (see `session-flow.md` §7).
+- [ ] **MASTERY.md going stale** — refresh the status dashboard (progress / mastery % / review due / next objective) on every substantive wrap-up and via `/repo-mastery status`; the Session Preamble reads it, so a stale MASTERY means a stale preamble (see `session-flow.md` §8).
+- [ ] **Full preamble on a same-session continue** — a session whose context already holds Mission / map / progress gets the **slim preamble** (one line: last position + next objective + due count, from `MASTERY.md`); re-replaying value/map the user just saw is wasted tokens (see `session-flow.md` §0).
 
 ## Phase 4 output phase
 
+- [ ] **Waiting until learning ends to build the course doc** — the course note (COVERAGE.md / HTML) is generated at Phase 2 confirmation as a first draft, then updated module-by-module as learning progresses (learner field feedback); don't synthesize only at the end.
 - [ ] **Regenerating the HTML shell** — `styles.css` / `main.js` / `_footer.html` / `build.sh` are only copied verbatim from `references/html-shell/`, never rewritten.
 - [ ] **HTML biased to UI step-strips** — this skill's HTML course centers on architecture diagrams / dependency graphs / call chains, not UI screenshots.
 - [ ] **COVERAGE.md missing source references** — the complete course doc must carry `file:line` references, or it loses its "traceable back to source" value.

--- a/skills/repo-mastery/references/html-shell/_base.html
+++ b/skills/repo-mastery/references/html-shell/_base.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>COURSE_TITLE</title>
+
+  <!-- Fonts: Sora (display) · DM Sans (body) · JetBrains Mono (code) -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="styles.css">
+
+  <!-- Per-course accent. Pick one palette; only these four lines change.
+         ember    #D9542E / #BF4322 / #FCEDE7 / #E68A6F   (default)
+         teal     #2C7C9C / #225F77 / #E6F1F5 / #5F9DB8
+         plum     #7C6BB0 / #5F5193 / #EEEAF6 / #A89AD0
+         pine     #2E8B57 / #226B41 / #E7F4EC / #6BB089
+         amber    #C9912F / #A8761F / #FBF1DC / #DFBE74     -->
+  <style>
+    :root {
+      --color-accent:       ACCENT_COLOR;
+      --color-accent-hover: ACCENT_HOVER;
+      --color-accent-light: ACCENT_LIGHT;
+      --color-accent-muted: ACCENT_MUTED;
+    }
+  </style>
+
+  <script src="main.js" defer></script>
+</head>
+<body>
+  <nav class="nav">
+    <div class="progress-bar" id="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100"></div>
+    <div class="nav-inner">
+      <span class="nav-title">COURSE_TITLE</span>
+      <div class="nav-dots" id="nav-dots" role="tablist">
+        NAV_DOTS
+      </div>
+    </div>
+  </nav>
+
+  <main id="main">

--- a/skills/repo-mastery/references/html-shell/_base.html
+++ b/skills/repo-mastery/references/html-shell/_base.html
@@ -10,6 +10,9 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Sora:wght@400;600;700;800&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 
+  <!-- Vendored highlighter first; styles.css links after so its `pre code.hljs`
+       override wins the specificity tie and the warm frame owns padding/scroll. -->
+  <link rel="stylesheet" href="vendor/highlight.min.css">
   <link rel="stylesheet" href="styles.css">
 
   <!-- Per-course accent. Pick one palette; only these four lines change.
@@ -27,6 +30,7 @@
     }
   </style>
 
+  <script src="vendor/highlight.min.js" defer></script>
   <script src="main.js" defer></script>
 </head>
 <body>

--- a/skills/repo-mastery/references/html-shell/_footer.html
+++ b/skills/repo-mastery/references/html-shell/_footer.html
@@ -1,0 +1,3 @@
+  </main>
+</body>
+</html>

--- a/skills/repo-mastery/references/html-shell/build.sh
+++ b/skills/repo-mastery/references/html-shell/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Assemble the course into a single index.html.
+# Usage: run from the course directory →  bash build.sh
+set -euo pipefail
+cat _base.html modules/*.html _footer.html > index.html
+echo "Built index.html ($(wc -c < index.html) bytes) — open it in a browser."

--- a/skills/repo-mastery/references/html-shell/design-system.md
+++ b/skills/repo-mastery/references/html-shell/design-system.md
@@ -1,0 +1,53 @@
+# Design System
+
+> **When to read this:** Phase 3, when writing module HTML. All tokens below are defined in `styles.css` (`:root`). Use the CSS variables — never hard-code colors, sizes, or spacing.
+
+The visual identity is a **warm field notebook**: aged-paper backgrounds, one confident accent, a geometric display face with personality, and generous whitespace. It should feel friendly and made-by-a-human, not like a generic AI gradient deck.
+
+## Color tokens
+
+Surfaces and ink (fixed):
+- `--color-bg` `#FBF8F3`, `--color-bg-warm` `#F4EEE4` (alternating module backgrounds), `--color-bg-code` `#21222C`
+- `--color-surface` `#FFFFFF`, `--color-surface-warm` `#FDFAF4`
+- `--color-border` `#E6DFD3`, `--color-border-light` `#EFEAE1`
+- `--color-text` `#2B2925`, `--color-text-secondary` `#6A645B`, `--color-text-muted`
+
+Semantic:
+- `--color-success` / `--color-success-light` — used by the recap card and correct quiz states.
+
+Accent (set per course in `_base.html`, five palettes provided): `--color-accent`, `--color-accent-hover`, `--color-accent-light`, `--color-accent-muted`. Pick the palette that fits the product's character.
+
+Category accents for actors and cards: `--color-actor-1..5` (ember, teal, plum, amber, pine). Use them to give chat avatars, flow actors, pattern cards, and icon circles distinct identities — assign by category, never as a rainbow.
+
+## Typography
+
+- Display (headings): `--font-display` = Sora.
+- Body: `--font-body` = DM Sans.
+- Code/commands: `--font-mono` = JetBrains Mono.
+- Scale: `--text-xs … --text-6xl`. Module title = `--text-4xl`, screen heading = `--text-2xl`, body = `--text-base`.
+
+## Layout
+
+- `--content-width` 760px, centered. `--nav-height` 56px (fixed top bar with progress + dots).
+- Spacing scale `--space-1 … --space-24`; radii `--radius-sm/md/lg/full`; shadows `--shadow-sm/md/lg`.
+- Modules are full-height (`100dvh` with `100vh` fallback) and alternate background tone via `:nth-child(even)`.
+- Motion: `--duration-fast/normal/slow`, `--ease-out`. All motion collapses under `prefers-reduced-motion`.
+
+## Module skeleton
+
+```html
+<section class="module" id="module-N">
+  <div class="module-content">
+    <div class="module-header">
+      <span class="module-number">0N</span>
+      <h2 class="module-title">…</h2>
+      <p class="module-subtitle">…</p>
+    </div>
+    <!-- objectives card here -->
+    <div class="screen"><h3 class="screen-heading">…</h3> … </div>
+    <!-- more screens; recap card screen; quiz screen -->
+  </div>
+</section>
+```
+
+Module files contain **only** the `<section>` — no `<html>`, `<head>`, `<style>`, or `<script>`. CSS and JS come from the copied `styles.css` / `main.js`.

--- a/skills/repo-mastery/references/html-shell/interactive-elements.md
+++ b/skills/repo-mastery/references/html-shell/interactive-elements.md
@@ -1,0 +1,125 @@
+# Interactive Elements
+
+> **When to read this:** Phase 3, when writing module HTML. Use only the HTML patterns below — all CSS lives in `styles.css` and all behavior in `main.js`, which auto-initialize by scanning class names and `data-*` attributes. Never inline `<style>`/`<script>` for these.
+
+Every course must include, somewhere: a **flow animation**, a **group chat**, **glossary tooltips**, a **quiz per module**, and a **command↔plain-English** block per module that has commands. Objectives + recap cards are required per module too.
+
+## Learning objectives (after the header, once per module)
+```html
+<div class="objectives animate-in">
+  <span class="objectives-eyebrow">🎯 学完本模块，你将能够</span>
+  <ul class="objectives-list">
+    <li>用动词开头、可检验的能力一</li>
+    <li>能力二</li>
+    <li>能力三</li>
+  </ul>
+</div>
+```
+3–4 items, each a concrete capability. Mirror the quiz.
+
+## Recap (its own screen, right before the quiz)
+```html
+<div class="screen">
+  <div class="recap animate-in">
+    <span class="recap-eyebrow">✅ 本模块小结</span>
+    <ul class="recap-list">
+      <li>要点一</li><li>要点二</li><li>要点三</li>
+    </ul>
+  </div>
+</div>
+```
+Each takeaway maps back to an objective. The card is green to signal "you've arrived".
+
+## Command ↔ plain-English translation
+Left = exact command/config from the docs; right = line-by-line plain English (the "why", not just the "what").
+```html
+<div class="translation-block animate-in">
+  <div class="translation-code"><span class="translation-label">命令</span>
+    <pre><code><span class="code-line">codex -m gpt-5.5</span></code></pre>
+  </div>
+  <div class="translation-english"><span class="translation-label">大白话</span>
+    <div class="translation-lines"><p class="tl">…</p></div>
+  </div>
+</div>
+```
+Use `white-space` wrapping (built in) — never horizontal scroll. Use commands verbatim.
+
+## Quiz (one per module, at the end)
+`main.js` exposes `selectOption(btn)`, `checkQuiz(id)`, `resetQuiz(id)`. Per-question answer + explanations live on `.quiz-question-block` via `data-correct`, `data-explanation-right`, `data-explanation-wrong`.
+```html
+<div class="quiz-container" id="quiz-mN">
+  <div class="scenario-block">
+    <div class="scenario-context"><span class="scenario-label">场景</span><p>…situation…</p></div>
+    <div class="quiz-question-block" data-correct="b"
+         data-explanation-right="对，因为…" data-explanation-wrong="再想想：…">
+      <div class="quiz-options">
+        <button class="quiz-option" data-value="a" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>选项 A</span></button>
+        <button class="quiz-option" data-value="b" onclick="selectOption(this)"><div class="quiz-option-radio"></div><span>选项 B</span></button>
+      </div>
+      <div class="quiz-feedback"></div>
+    </div>
+  </div>
+  <button class="quiz-check-btn" onclick="checkQuiz('quiz-mN')">提交答案</button>
+  <button class="quiz-reset-btn" onclick="resetQuiz('quiz-mN')">再试一次</button>
+</div>
+```
+Drop the `.scenario-block` wrapper for a plain multiple-choice question. Quiz application, not memory: scenarios, "which surface/command", troubleshooting — never definitions.
+
+## Group chat (≥1 per course)
+`main.js` auto-inits each `.chat-window`. Messages start hidden; buttons reveal them with a typing indicator.
+```html
+<div class="chat-window animate-in" id="chat-mN">
+  <div class="chat-messages">
+    <div class="chat-message" data-msg="0" data-sender="you" style="display:none">
+      <div class="chat-avatar" style="background: var(--color-actor-1)">你</div>
+      <div class="chat-bubble"><span class="chat-sender" style="color: var(--color-actor-1)">你</span><p>…</p></div>
+    </div>
+    <!-- more .chat-message, incrementing data-msg -->
+  </div>
+  <div class="chat-typing" id="chat-mN-typing" style="display:none">
+    <div class="chat-avatar">C</div>
+    <div class="chat-typing-dots"><span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></div>
+  </div>
+  <div class="chat-controls"><button class="btn chat-next-btn">下一条</button><button class="btn chat-all-btn">全部播放</button><button class="btn chat-reset-btn">重播</button><span class="chat-progress"></span></div>
+</div>
+```
+
+## Flow / data animation (≥1 per course)
+`main.js` auto-inits each `.flow-animation`. Steps are JSON in `data-steps`; actor element ids are `flow-actor-1`, `2`, … and `from`/`to` reference the numeric suffix.
+```html
+<div class="flow-animation" data-steps='[
+  {"highlight":"flow-actor-1","label":"第一步"},
+  {"highlight":"flow-actor-2","label":"传给下一个","packet":true,"from":"1","to":"2"}
+]'>
+  <div class="flow-actors">
+    <div class="flow-actor" id="flow-actor-1"><div class="flow-actor-icon">🧑</div><span>你</span></div>
+    <div class="flow-actor" id="flow-actor-2"><div class="flow-actor-icon">🧠</div><span>模型</span></div>
+  </div>
+  <div class="flow-packet" id="flow-packet"></div>
+  <div class="flow-step-label" id="flow-label">点“下一步”开始</div>
+  <div class="flow-controls"><button class="btn flow-next-btn">下一步</button><button class="btn flow-reset-btn">重来</button><span class="flow-progress"></span></div>
+</div>
+```
+⚠️ No apostrophes inside labels — the attribute is single-quote delimited and they break `JSON.parse`.
+
+## Glossary tooltips (every term, first use per module)
+```html
+<span class="term" data-definition="一句话、可带比喻的大白话定义。">沙箱</span>
+```
+`main.js` builds a fixed-position tooltip appended to `<body>` (never clipped). Be aggressive: acronyms and tool-specific nouns all get one.
+
+## Callouts (1–2 per module)
+```html
+<div class="callout callout-accent">
+  <div class="callout-icon">💡</div>
+  <div class="callout-content"><strong class="callout-title">标题</strong><p>…</p></div>
+</div>
+```
+Variants: `callout-accent` (insight), `callout-info` (good to know), `callout-warning` (common mistake).
+
+## Cards & lists (replace prose lists)
+- **Pattern cards** — `.pattern-cards > .pattern-card` with `.pattern-icon`, `.pattern-title`, `.pattern-desc`. For comparisons / "如果…就用…".
+- **Icon rows** — `.icon-rows > .icon-row` with `.icon-circle` + `<strong>` + `<p>`. For labeled lists.
+- **Step cards** — `.step-cards > .step-card` with `.step-num` + `.step-body`. For sequences and try-it checklists (put the expected result in the `<p>`).
+- **Badge list** — `.badge-list > .badge-item` with `.badge-code` + `.badge-desc`. For annotating config keys / modes.
+- **File tree** — `.file-tree` with `.ft-folder`/`.ft-file` (`.ft-name` + `.ft-desc`). For showing where files live.

--- a/skills/repo-mastery/references/html-shell/main.js
+++ b/skills/repo-mastery/references/html-shell/main.js
@@ -215,6 +215,18 @@
     window.addEventListener("scroll", hide, { passive: true });
   }
 
+  /* ---------- Syntax highlighting ---------- */
+  function initHighlight() {
+    // Vendored highlight.js; degrade silently if absent.
+    if (window.hljs) {
+      document.querySelectorAll("pre code").forEach(function (el) {
+        // Skip the dark command-translation component's code blocks.
+        if (el.closest(".translation-code")) return;
+        hljs.highlightElement(el);
+      });
+    }
+  }
+
   /* ---------- Nav: progress bar, dots, scroll reveal ---------- */
   function initNav() {
     var bar = document.getElementById("progress-bar");
@@ -266,5 +278,6 @@
     initTooltips();
     initNav();
     initReveal();
+    initHighlight();
   });
 })();

--- a/skills/repo-mastery/references/html-shell/main.js
+++ b/skills/repo-mastery/references/html-shell/main.js
@@ -1,0 +1,270 @@
+/* ============================================================
+   docs-to-course — interactive engine (original)
+   Author: CZ. Powers quizzes, group chat, flow animation,
+   glossary tooltips, scroll progress and reveal. No dependencies.
+   ============================================================ */
+(function () {
+  "use strict";
+  var ready = function (fn) {
+    if (document.readyState !== "loading") fn();
+    else document.addEventListener("DOMContentLoaded", fn);
+  };
+
+  /* ---------- Quizzes ---------- */
+  window.selectOption = function (btn) {
+    var block = btn.closest(".quiz-question-block");
+    if (!block || block.dataset.locked === "1") return;
+    block.querySelectorAll(".quiz-option").forEach(function (o) { o.classList.remove("selected"); });
+    btn.classList.add("selected");
+  };
+
+  window.checkQuiz = function (containerId) {
+    var c = document.getElementById(containerId);
+    if (!c) return;
+    c.querySelectorAll(".quiz-question-block").forEach(function (block) {
+      var picked = block.querySelector(".quiz-option.selected");
+      var fb = block.querySelector(".quiz-feedback");
+      if (!picked) {
+        if (fb) { fb.textContent = "先选一个答案 👆"; fb.className = "quiz-feedback show error"; }
+        return;
+      }
+      block.dataset.locked = "1";
+      var ok = picked.dataset.value === block.dataset.correct;
+      picked.classList.add(ok ? "correct" : "incorrect");
+      if (!ok) {
+        var right = block.querySelector('.quiz-option[data-value="' + block.dataset.correct + '"]');
+        if (right) right.classList.add("correct");
+      }
+      if (fb) {
+        fb.textContent = ok
+          ? (block.dataset.explanationRight || "答对了！")
+          : (block.dataset.explanationWrong || "再想想。");
+        fb.className = "quiz-feedback show " + (ok ? "success" : "error");
+      }
+    });
+    var reset = c.querySelector(".quiz-reset-btn");
+    if (reset) reset.classList.add("show");
+  };
+
+  window.resetQuiz = function (containerId) {
+    var c = document.getElementById(containerId);
+    if (!c) return;
+    c.querySelectorAll(".quiz-question-block").forEach(function (block) {
+      block.dataset.locked = "";
+      block.querySelectorAll(".quiz-option").forEach(function (o) {
+        o.classList.remove("selected", "correct", "incorrect");
+      });
+      var fb = block.querySelector(".quiz-feedback");
+      if (fb) fb.className = "quiz-feedback";
+    });
+    var reset = c.querySelector(".quiz-reset-btn");
+    if (reset) reset.classList.remove("show");
+  };
+
+  /* ---------- Group chat ---------- */
+  function initChat(win) {
+    var msgs = Array.prototype.slice.call(win.querySelectorAll(".chat-message"));
+    var typing = win.querySelector(".chat-typing");
+    var prog = win.querySelector(".chat-progress");
+    var nextBtn = win.querySelector(".chat-next-btn");
+    var allBtn = win.querySelector(".chat-all-btn");
+    var resetBtn = win.querySelector(".chat-reset-btn");
+    var i = 0, busy = false;
+    if (typing) typing.style.display = "none";
+
+    function updateProgress() { if (prog) prog.textContent = i + " / " + msgs.length; }
+    function done() { return i >= msgs.length; }
+
+    function reveal() {
+      if (busy || done()) return;
+      busy = true;
+      var m = msgs[i];
+      var sender = m.getAttribute("data-sender");
+      // show typing bubble briefly, mirroring the next sender's avatar colour
+      if (typing) {
+        var av = typing.querySelector(".chat-avatar");
+        var srcAv = m.querySelector(".chat-avatar");
+        if (av && srcAv) { av.textContent = srcAv.textContent; av.style.background = srcAv.style.background; }
+        typing.style.display = "flex";
+      }
+      setTimeout(function () {
+        if (typing) typing.style.display = "none";
+        m.style.display = "flex";
+        i++; updateProgress(); busy = false;
+        if (done() && nextBtn) nextBtn.disabled = true;
+      }, 520);
+    }
+
+    function playAll() {
+      if (done()) return;
+      reveal();
+      var t = setInterval(function () {
+        if (done()) { clearInterval(t); return; }
+        if (!busy) reveal();
+      }, 760);
+    }
+
+    function reset() {
+      msgs.forEach(function (m) { m.style.display = "none"; });
+      i = 0; busy = false; if (nextBtn) nextBtn.disabled = false; updateProgress();
+    }
+
+    msgs.forEach(function (m) { m.style.display = "none"; });
+    updateProgress();
+    if (nextBtn) nextBtn.addEventListener("click", reveal);
+    if (allBtn) allBtn.addEventListener("click", playAll);
+    if (resetBtn) resetBtn.addEventListener("click", reset);
+  }
+
+  /* ---------- Flow / data animation ---------- */
+  function initFlow(flow) {
+    var steps;
+    try { steps = JSON.parse(flow.getAttribute("data-steps") || "[]"); }
+    catch (e) { steps = []; }
+    var label = flow.querySelector(".flow-step-label");
+    var packet = flow.querySelector(".flow-packet");
+    var prog = flow.querySelector(".flow-progress");
+    var nextBtn = flow.querySelector(".flow-next-btn");
+    var resetBtn = flow.querySelector(".flow-reset-btn");
+    var i = 0;
+
+    function actor(idSuffix) { return flow.querySelector("#flow-actor-" + idSuffix.replace(/^actor-/, "").replace(/^flow-actor-/, "")); }
+    function clearActive() { flow.querySelectorAll(".flow-actor").forEach(function (a) { a.classList.remove("active"); }); }
+
+    function center(el) {
+      var cr = flow.getBoundingClientRect();
+      var r = el.getBoundingClientRect();
+      return { x: r.left - cr.left + r.width / 2, y: r.top - cr.top + r.height / 2 };
+    }
+
+    function movePacket(from, to) {
+      if (!packet || !from || !to) return;
+      var a = center(from.querySelector(".flow-actor-icon") || from);
+      var b = center(to.querySelector(".flow-actor-icon") || to);
+      packet.style.transition = "none";
+      packet.style.transform = "translate(" + (a.x - 7) + "px," + (a.y - 7) + "px)";
+      packet.classList.add("moving");
+      requestAnimationFrame(function () {
+        requestAnimationFrame(function () {
+          packet.style.transition = "";
+          packet.style.transform = "translate(" + (b.x - 7) + "px," + (b.y - 7) + "px)";
+        });
+      });
+      setTimeout(function () { packet.classList.remove("moving"); }, 650);
+    }
+
+    function render(step) {
+      clearActive();
+      if (step.highlight) { var h = flow.querySelector("#" + step.highlight); if (h) h.classList.add("active"); }
+      if (label) label.textContent = step.label || "";
+      if (step.packet && step.from && step.to) movePacket(actor(step.from), actor(step.to));
+    }
+
+    function next() {
+      if (i >= steps.length) return;
+      render(steps[i]); i++;
+      if (prog) prog.textContent = i + " / " + steps.length;
+      if (nextBtn && i >= steps.length) nextBtn.disabled = true;
+    }
+    function reset() {
+      i = 0; clearActive();
+      if (packet) packet.classList.remove("moving");
+      if (label) label.textContent = "点“下一步”开始 / Click Next to begin";
+      if (prog) prog.textContent = "0 / " + steps.length;
+      if (nextBtn) nextBtn.disabled = false;
+    }
+
+    if (prog) prog.textContent = "0 / " + steps.length;
+    if (nextBtn) nextBtn.addEventListener("click", next);
+    if (resetBtn) resetBtn.addEventListener("click", reset);
+  }
+
+  /* ---------- Glossary tooltips ---------- */
+  function initTooltips() {
+    var active = null;
+    function place(term, tip) {
+      document.body.appendChild(tip);
+      var r = term.getBoundingClientRect();
+      var w = tip.offsetWidth, h = tip.offsetHeight;
+      var left = Math.max(8, Math.min(r.left + r.width / 2 - w / 2, window.innerWidth - w - 8));
+      var top = r.top - h - 8;
+      if (top < 8) top = r.bottom + 8;
+      tip.style.left = left + "px";
+      tip.style.top = top + "px";
+    }
+    function hide() { if (active) { active.tip.classList.remove("visible"); active.tip.remove(); active.term.classList.remove("active"); active = null; } }
+    function show(term) {
+      hide();
+      var tip = document.createElement("span");
+      tip.className = "term-tip";
+      tip.textContent = term.getAttribute("data-definition");
+      term.classList.add("active");
+      place(term, tip);
+      requestAnimationFrame(function () { tip.classList.add("visible"); });
+      active = { term: term, tip: tip };
+    }
+    document.querySelectorAll(".term").forEach(function (term) {
+      term.addEventListener("mouseenter", function () { show(term); });
+      term.addEventListener("mouseleave", hide);
+      term.addEventListener("click", function (e) {
+        e.stopPropagation();
+        if (active && active.term === term) hide(); else show(term);
+      });
+    });
+    document.addEventListener("click", hide);
+    window.addEventListener("scroll", hide, { passive: true });
+  }
+
+  /* ---------- Nav: progress bar, dots, scroll reveal ---------- */
+  function initNav() {
+    var bar = document.getElementById("progress-bar");
+    var dots = Array.prototype.slice.call(document.querySelectorAll(".nav-dot"));
+    var modules = Array.prototype.slice.call(document.querySelectorAll(".module"));
+
+    function onScroll() {
+      var st = document.documentElement.scrollTop || document.body.scrollTop;
+      var h = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+      if (bar) bar.style.width = (h > 0 ? (st / h) * 100 : 0) + "%";
+    }
+    window.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+
+    dots.forEach(function (dot) {
+      dot.addEventListener("click", function () {
+        var t = document.getElementById(dot.getAttribute("data-target"));
+        if (t) window.scrollTo({ top: t.offsetTop - 40, behavior: "smooth" });
+      });
+    });
+
+    if ("IntersectionObserver" in window && modules.length) {
+      var obs = new IntersectionObserver(function (entries) {
+        entries.forEach(function (en) {
+          if (en.isIntersecting) {
+            var id = en.target.id;
+            dots.forEach(function (d) { d.classList.toggle("active", d.getAttribute("data-target") === id); });
+          }
+        });
+      }, { rootMargin: "-45% 0px -45% 0px" });
+      modules.forEach(function (m) { obs.observe(m); });
+    }
+  }
+
+  function initReveal() {
+    var els = Array.prototype.slice.call(document.querySelectorAll(".animate-in"));
+    if (!("IntersectionObserver" in window)) { els.forEach(function (e) { e.classList.add("visible"); }); return; }
+    var obs = new IntersectionObserver(function (entries) {
+      entries.forEach(function (en) {
+        if (en.isIntersecting) { en.target.classList.add("visible"); obs.unobserve(en.target); }
+      });
+    }, { rootMargin: "0px 0px -8% 0px", threshold: 0.05 });
+    els.forEach(function (e) { obs.observe(e); });
+  }
+
+  ready(function () {
+    document.querySelectorAll(".chat-window").forEach(initChat);
+    document.querySelectorAll(".flow-animation").forEach(initFlow);
+    initTooltips();
+    initNav();
+    initReveal();
+  });
+})();

--- a/skills/repo-mastery/references/html-shell/styles.css
+++ b/skills/repo-mastery/references/html-shell/styles.css
@@ -1,0 +1,314 @@
+/* ============================================================
+   docs-to-course — course stylesheet (original)
+   Author: CZ. Warm "field-notebook" aesthetic for learning courses.
+   Accent variables (--color-accent*) are injected per-course in _base.html.
+   ============================================================ */
+
+:root {
+  /* surfaces & ink */
+  --color-bg:            #FBF8F3;
+  --color-bg-warm:       #F4EEE4;
+  --color-bg-code:       #21222C;
+  --color-surface:       #FFFFFF;
+  --color-surface-warm:  #FDFAF4;
+  --color-border:        #E6DFD3;
+  --color-border-light:  #EFEAE1;
+  --color-text:          #2B2925;
+  --color-text-secondary:#6A645B;
+  --color-text-muted:    #9A938860;
+
+  /* semantic */
+  --color-success:       #2F8C57;
+  --color-success-light: #E7F4EC;
+
+  /* category accents for actors/cards */
+  --color-actor-1: #D9542E;
+  --color-actor-2: #2C7C9C;
+  --color-actor-3: #7C6BB0;
+  --color-actor-4: #D2A23C;
+  --color-actor-5: #2E8B57;
+
+  /* type */
+  --font-display: "Sora", system-ui, sans-serif;
+  --font-body:    "DM Sans", system-ui, sans-serif;
+  --font-mono:    "JetBrains Mono", ui-monospace, monospace;
+
+  --text-xs:  0.75rem;
+  --text-sm:  0.875rem;
+  --text-base:1rem;
+  --text-lg:  1.125rem;
+  --text-xl:  1.375rem;
+  --text-2xl: 1.75rem;
+  --text-4xl: 2.5rem;
+  --text-6xl: 4.5rem;
+
+  /* spacing scale */
+  --space-1:.25rem; --space-2:.5rem; --space-3:.75rem; --space-4:1rem;
+  --space-5:1.25rem; --space-6:1.5rem; --space-8:2rem; --space-10:2.5rem;
+  --space-12:3rem; --space-16:4rem; --space-20:5rem; --space-24:6rem;
+
+  --radius-sm:8px; --radius-md:12px; --radius-lg:18px; --radius-full:9999px;
+
+  --shadow-sm: 0 1px 2px rgba(43,41,37,.06);
+  --shadow-md: 0 6px 18px rgba(43,41,37,.09);
+  --shadow-lg: 0 14px 34px rgba(43,41,37,.12);
+
+  --leading-tight:1.12; --leading-snug:1.35; --leading-normal:1.65;
+
+  --nav-height: 56px;
+  --content-width: 760px;
+  --duration-fast:140ms; --duration-normal:300ms; --duration-slow:620ms;
+  --ease-out: cubic-bezier(.22,.8,.32,1);
+  --stagger-delay: 70ms;
+
+  /* fallback accents (overridden per-course in _base.html) */
+  --color-accent:#D9542E; --color-accent-hover:#BF4322;
+  --color-accent-light:#FCEDE7; --color-accent-muted:#E68A6F;
+}
+
+* { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--color-text);
+  background: var(--color-bg);
+  -webkit-font-smoothing: antialiased;
+}
+h1,h2,h3,h4 { font-family: var(--font-display); font-weight: 700; }
+p { margin: 0 0 var(--space-4); }
+p:last-child { margin-bottom: 0; }
+code { font-family: var(--font-mono); font-size: .9em; }
+:not(pre) > code {
+  background: var(--color-bg-warm);
+  color: var(--color-accent-hover);
+  padding: .1em .4em; border-radius: 6px;
+  font-size: .85em;
+}
+
+/* ── top nav + progress ─────────────────────────────────── */
+.nav {
+  position: fixed; top: 0; left: 0; right: 0; height: var(--nav-height);
+  z-index: 100; background: color-mix(in srgb, var(--color-bg) 88%, transparent);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--color-border-light);
+}
+.progress-bar {
+  position: absolute; top: 0; left: 0; height: 3px; width: 0%;
+  background: var(--color-accent); transition: width var(--duration-fast) linear;
+}
+.nav-inner {
+  max-width: var(--content-width); height: 100%; margin: 0 auto;
+  padding: 0 var(--space-6);
+  display: flex; align-items: center; justify-content: space-between; gap: var(--space-4);
+}
+.nav-title {
+  font-family: var(--font-display); font-weight: 700; font-size: var(--text-base);
+  color: var(--color-text); white-space: nowrap;
+}
+.nav-dots { display: flex; gap: var(--space-3); align-items: center; }
+.nav-dot {
+  position: relative; width: 11px; height: 11px; padding: 0;
+  border: 2px solid var(--color-accent-muted); border-radius: 50%;
+  background: transparent; cursor: pointer; transition: all var(--duration-fast);
+}
+.nav-dot:hover { border-color: var(--color-accent); transform: scale(1.15); }
+.nav-dot.active { background: var(--color-accent); border-color: var(--color-accent); }
+.nav-dot::after {
+  content: attr(data-tooltip);
+  position: absolute; top: 150%; right: 0; white-space: nowrap;
+  background: var(--color-bg-code); color: #F2EEE6;
+  font-family: var(--font-body); font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-3); border-radius: 6px;
+  opacity: 0; pointer-events: none; transform: translateY(-4px);
+  transition: opacity var(--duration-fast), transform var(--duration-fast);
+}
+.nav-dot:hover::after { opacity: 1; transform: translateY(0); }
+@media (max-width: 600px){ .nav-dots{ display:none; } }
+
+/* ── module + screen layout ─────────────────────────────── */
+.module {
+  min-height: 100vh; min-height: 100dvh;
+  padding: var(--space-16) var(--space-6) var(--space-20);
+  padding-top: calc(var(--nav-height) + var(--space-12));
+}
+.module:nth-child(even){ background: var(--color-bg-warm); }
+.module-content { max-width: var(--content-width); margin: 0 auto; }
+.module-header { margin-bottom: var(--space-10); }
+.module-number {
+  display: block; font-family: var(--font-display); font-weight: 700;
+  font-size: var(--text-6xl); line-height: 1; color: var(--color-accent); opacity: .14;
+}
+.module-title { font-size: var(--text-4xl); line-height: var(--leading-tight); margin: var(--space-2) 0 0; }
+.module-subtitle { margin-top: var(--space-3); font-size: var(--text-lg); color: var(--color-text-secondary); line-height: var(--leading-snug); }
+.screen { margin-bottom: var(--space-16); }
+.screen-heading { font-size: var(--text-2xl); margin: 0 0 var(--space-6); line-height: var(--leading-snug); }
+
+/* ── scroll reveal ──────────────────────────────────────── */
+.animate-in { opacity: 0; transform: translateY(18px); transition: opacity var(--duration-slow) var(--ease-out), transform var(--duration-slow) var(--ease-out); }
+.animate-in.visible { opacity: 1; transform: none; }
+
+/* ── learning objectives / recap ────────────────────────── */
+.objectives, .recap {
+  position: relative; margin: var(--space-8) 0 var(--space-12);
+  padding: var(--space-6) var(--space-6) var(--space-6) var(--space-8);
+  border: 1px solid var(--color-border-light); border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+.recap { margin: var(--space-8) 0; }
+.objectives { background: var(--color-accent-light); }
+.recap { background: var(--color-success-light); }
+.objectives::before, .recap::before {
+  content: ""; position: absolute; left: 0; top: var(--space-4); bottom: var(--space-4);
+  width: 4px; border-radius: var(--radius-full);
+}
+.objectives::before { background: var(--color-accent); }
+.recap::before { background: var(--color-success); }
+.objectives-eyebrow, .recap-eyebrow {
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  font-family: var(--font-display); font-size: var(--text-xs); font-weight: 700;
+  text-transform: uppercase; letter-spacing: .08em; margin-bottom: var(--space-4);
+}
+.objectives-eyebrow { color: var(--color-accent-hover); }
+.recap-eyebrow { color: var(--color-success); }
+.objectives-list, .recap-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: var(--space-3); }
+.objectives-list li, .recap-list li { display: flex; align-items: flex-start; gap: var(--space-3); font-size: var(--text-base); line-height: var(--leading-snug); }
+.objectives-list li::before {
+  content: "✓"; flex-shrink: 0; width: 22px; height: 22px; margin-top: 1px;
+  display: flex; align-items: center; justify-content: center;
+  background: var(--color-accent); color: #fff; border-radius: var(--radius-full);
+  font-size: 13px; font-weight: 700;
+}
+.recap-list li::before { content: "→"; flex-shrink: 0; color: var(--color-success); font-weight: 700; margin-top: 1px; }
+
+/* ── command / plain-english translation ────────────────── */
+.translation-block {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 0;
+  border-radius: var(--radius-md); overflow: hidden; box-shadow: var(--shadow-md);
+  margin: var(--space-8) 0;
+}
+.translation-code { position: relative; background: var(--color-bg-code); color: #E7E4DC; padding: var(--space-6); font-family: var(--font-mono); font-size: var(--text-sm); line-height: 1.7; overflow-x: hidden; }
+.translation-code pre, .translation-code code { white-space: pre-wrap; word-break: break-word; margin: 0; }
+.code-line { display: block; }
+.translation-english { background: var(--color-surface-warm); padding: var(--space-6); font-size: var(--text-sm); line-height: 1.7; border-left: 3px solid var(--color-accent); }
+.translation-label { position: absolute; top: var(--space-2); right: var(--space-3); font-size: var(--text-xs); text-transform: uppercase; letter-spacing: .1em; opacity: .5; }
+.translation-english .translation-label { position: static; display: block; margin-bottom: var(--space-3); color: var(--color-text-muted); }
+.translation-lines .tl { margin: 0 0 var(--space-3); }
+@media (max-width: 720px){ .translation-block{ grid-template-columns: 1fr; } .translation-english{ border-left: none; border-top: 3px solid var(--color-accent);} }
+
+/* ── quizzes ────────────────────────────────────────────── */
+.quiz-container { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--space-6); box-shadow: var(--shadow-sm); }
+.scenario-block { margin-bottom: var(--space-6); }
+.scenario-context { background: var(--color-bg-warm); border-radius: var(--radius-md); padding: var(--space-4) var(--space-5); margin-bottom: var(--space-4); }
+.scenario-label { display: inline-block; font-family: var(--font-display); font-size: var(--text-xs); font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: var(--color-accent-hover); margin-bottom: var(--space-2); }
+.scenario-context p { margin: 0; }
+.quiz-question { font-size: var(--text-lg); margin: 0 0 var(--space-4); }
+.quiz-options { display: flex; flex-direction: column; gap: var(--space-3); }
+.quiz-option { display: flex; align-items: center; gap: var(--space-3); width: 100%; text-align: left; padding: var(--space-3) var(--space-4); border: 2px solid var(--color-border); border-radius: var(--radius-md); background: var(--color-surface); cursor: pointer; font: inherit; color: inherit; transition: border-color var(--duration-fast), background var(--duration-fast); }
+.quiz-option:hover { border-color: var(--color-accent-muted); }
+.quiz-option.selected { border-color: var(--color-accent); background: var(--color-accent-light); }
+.quiz-option.correct { border-color: var(--color-success); background: var(--color-success-light); }
+.quiz-option.incorrect { border-color: #C0432F; background: #FBEAE6; }
+.quiz-option-radio { width: 18px; height: 18px; border-radius: 50%; border: 2px solid var(--color-border); flex-shrink: 0; transition: all var(--duration-fast); }
+.quiz-option.selected .quiz-option-radio { border-color: var(--color-accent); background: var(--color-accent); box-shadow: inset 0 0 0 3px #fff; }
+.quiz-option.correct .quiz-option-radio { border-color: var(--color-success); background: var(--color-success); box-shadow: inset 0 0 0 3px #fff; }
+.quiz-feedback { max-height: 0; overflow: hidden; opacity: 0; transition: max-height var(--duration-normal), opacity var(--duration-normal); font-size: var(--text-sm); }
+.quiz-feedback.show { max-height: 240px; opacity: 1; padding: var(--space-3) var(--space-4); margin-top: var(--space-3); border-radius: var(--radius-sm); }
+.quiz-feedback.success { background: var(--color-success-light); color: var(--color-success); }
+.quiz-feedback.error { background: #FBEAE6; color: #B23A28; }
+.quiz-check-btn, .quiz-reset-btn, .btn { font: inherit; font-family: var(--font-display); font-weight: 600; cursor: pointer; border-radius: var(--radius-full); padding: var(--space-2) var(--space-5); border: 1.5px solid var(--color-accent); transition: all var(--duration-fast); }
+.quiz-check-btn { background: var(--color-accent); color: #fff; margin-top: var(--space-5); }
+.quiz-check-btn:hover { background: var(--color-accent-hover); border-color: var(--color-accent-hover); }
+.quiz-reset-btn { background: transparent; color: var(--color-accent); margin: var(--space-5) 0 0 var(--space-3); display: none; }
+.quiz-reset-btn.show { display: inline-block; }
+
+/* ── callouts ───────────────────────────────────────────── */
+.callout { display: flex; gap: var(--space-4); padding: var(--space-5) var(--space-6); border-radius: var(--radius-md); margin: var(--space-6) 0; border-left: 4px solid var(--color-accent); background: var(--color-accent-light); }
+.callout-info { border-left-color: var(--color-actor-2); background: #E6F1F5; }
+.callout-warning { border-left-color: #C0432F; background: #FBEAE6; }
+.callout-icon { font-size: 1.4rem; line-height: 1; flex-shrink: 0; }
+.callout-title { display: block; font-family: var(--font-display); margin-bottom: var(--space-1); }
+.callout-content p { margin: 0; }
+
+/* ── pattern cards / icon rows / step cards / badges ────── */
+.pattern-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px,1fr)); gap: var(--space-4); margin: var(--space-6) 0; }
+.pattern-card { background: var(--color-surface); border-radius: var(--radius-md); padding: var(--space-6); box-shadow: var(--shadow-sm); transition: transform var(--duration-normal) var(--ease-out), box-shadow var(--duration-normal); }
+.pattern-card:hover { transform: translateY(-4px); box-shadow: var(--shadow-md); }
+.pattern-icon { width: 44px; height: 44px; border-radius: var(--radius-md); display: flex; align-items: center; justify-content: center; font-size: 1.3rem; color: #fff; margin-bottom: var(--space-3); }
+.pattern-title { font-size: var(--text-lg); margin: 0 0 var(--space-2); }
+.pattern-desc { margin: 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
+
+.icon-rows { display: flex; flex-direction: column; gap: var(--space-4); margin: var(--space-6) 0; }
+.icon-row { display: flex; align-items: center; gap: var(--space-4); padding: var(--space-4); background: var(--color-surface); border-radius: var(--radius-md); box-shadow: var(--shadow-sm); }
+.icon-row p { margin: var(--space-1) 0 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
+.icon-circle { width: 48px; height: 48px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 1.25rem; color: #fff; flex-shrink: 0; }
+
+.step-cards { display: flex; flex-direction: column; gap: var(--space-3); margin: var(--space-6) 0; }
+.step-card { display: flex; align-items: flex-start; gap: var(--space-4); padding: var(--space-4) var(--space-5); background: var(--color-surface); border-radius: var(--radius-md); border-left: 3px solid var(--color-accent); box-shadow: var(--shadow-sm); }
+.step-num { width: 32px; height: 32px; border-radius: 50%; background: var(--color-accent); color: #fff; font-family: var(--font-display); font-weight: 700; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.step-body p { margin: var(--space-1) 0 0; color: var(--color-text-secondary); font-size: var(--text-sm); }
+
+.badge-list { display: flex; flex-direction: column; gap: var(--space-2); margin: var(--space-6) 0; }
+.badge-item { display: flex; align-items: center; gap: var(--space-4); padding: var(--space-3) var(--space-4); border: 1px solid var(--color-border-light); border-radius: var(--radius-sm); transition: border-color var(--duration-fast); }
+.badge-item:hover { border-color: var(--color-accent-muted); }
+.badge-code { font-family: var(--font-mono); font-size: var(--text-sm); background: var(--color-bg-code); color: #D9C7F2; padding: var(--space-1) var(--space-3); border-radius: var(--radius-sm); white-space: nowrap; }
+.badge-desc { color: var(--color-text-secondary); font-size: var(--text-sm); }
+
+/* ── file tree ──────────────────────────────────────────── */
+.file-tree { font-family: var(--font-mono); font-size: var(--text-sm); margin: var(--space-6) 0; }
+.ft-folder, .ft-file { padding: var(--space-2) var(--space-3); border-left: 2px solid var(--color-border-light); margin-left: var(--space-4); }
+.ft-folder > .ft-name { color: var(--color-accent); font-weight: 600; }
+.ft-folder > .ft-name::before { content: "📁 "; }
+.ft-file > .ft-name::before { content: "📄 "; }
+.ft-desc { color: var(--color-text-secondary); font-family: var(--font-body); margin-left: var(--space-2); font-size: var(--text-xs); }
+.ft-children { margin-left: var(--space-4); }
+
+/* ── glossary tooltip terms ─────────────────────────────── */
+.term { border-bottom: 1.5px dashed var(--color-accent-muted); cursor: pointer; }
+.term:hover, .term.active { border-bottom-color: var(--color-accent); color: var(--color-accent-hover); }
+.term-tip {
+  position: fixed; z-index: 10000; max-width: min(320px, 80vw);
+  background: var(--color-bg-code); color: #EFEBE3;
+  padding: var(--space-3) var(--space-4); border-radius: var(--radius-sm);
+  font-family: var(--font-body); font-size: var(--text-sm); line-height: var(--leading-normal);
+  box-shadow: var(--shadow-lg); opacity: 0; pointer-events: none; transition: opacity var(--duration-fast);
+}
+.term-tip.visible { opacity: 1; }
+
+/* ── group chat ─────────────────────────────────────────── */
+.chat-window { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--space-5); margin: var(--space-6) 0; box-shadow: var(--shadow-sm); }
+.chat-messages { display: flex; flex-direction: column; gap: var(--space-4); min-height: 80px; }
+.chat-message { display: flex; gap: var(--space-3); align-items: flex-start; animation: chatIn var(--duration-normal) var(--ease-out); }
+@keyframes chatIn { from { opacity: 0; transform: translateY(8px);} to { opacity:1; transform:none; } }
+.chat-avatar { width: 36px; height: 36px; border-radius: 50%; flex-shrink: 0; color: #fff; font-family: var(--font-display); font-weight: 700; font-size: var(--text-sm); display: flex; align-items: center; justify-content: center; }
+.chat-bubble { background: var(--color-bg-warm); border-radius: var(--radius-md); padding: var(--space-3) var(--space-4); max-width: 80%; }
+.chat-sender { display: block; font-family: var(--font-display); font-weight: 600; font-size: var(--text-xs); margin-bottom: var(--space-1); }
+.chat-bubble p { margin: 0; font-size: var(--text-sm); line-height: var(--leading-snug); }
+.chat-typing { display: flex; gap: var(--space-3); align-items: center; }
+.chat-typing-dots { display: flex; gap: 5px; background: var(--color-bg-warm); padding: var(--space-3) var(--space-4); border-radius: var(--radius-md); }
+.typing-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--color-text-secondary); animation: typingBounce 1.4s infinite; }
+.typing-dot:nth-child(2){ animation-delay:.2s; } .typing-dot:nth-child(3){ animation-delay:.4s; }
+@keyframes typingBounce { 0%,60%,100%{ transform: translateY(0);} 30%{ transform: translateY(-6px);} }
+.chat-controls, .flow-controls { display: flex; align-items: center; gap: var(--space-3); margin-top: var(--space-5); flex-wrap: wrap; }
+.btn { background: transparent; color: var(--color-accent); font-size: var(--text-sm); padding: var(--space-2) var(--space-4); }
+.btn:hover { background: var(--color-accent-light); }
+.chat-progress, .flow-progress { font-size: var(--text-xs); color: var(--color-text-muted); margin-left: auto; }
+
+/* ── flow / data animation ──────────────────────────────── */
+.flow-animation { background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--space-6); margin: var(--space-6) 0; box-shadow: var(--shadow-sm); position: relative; }
+.flow-actors { display: flex; justify-content: space-between; gap: var(--space-3); position: relative; }
+.flow-actor { display: flex; flex-direction: column; align-items: center; gap: var(--space-2); flex: 1; text-align: center; font-size: var(--text-sm); color: var(--color-text-secondary); transition: all var(--duration-normal) var(--ease-out); }
+.flow-actor-icon { width: 56px; height: 56px; border-radius: var(--radius-md); background: var(--color-bg-warm); display: flex; align-items: center; justify-content: center; font-size: 1.5rem; transition: all var(--duration-normal) var(--ease-out); }
+.flow-actor.active { color: var(--color-text); }
+.flow-actor.active .flow-actor-icon { background: var(--color-accent-light); box-shadow: 0 0 0 3px var(--color-accent); transform: scale(1.08); }
+.flow-packet { position: absolute; width: 14px; height: 14px; border-radius: 50%; background: var(--color-accent); opacity: 0; top: 0; left: 0; transition: transform var(--duration-slow) var(--ease-out), opacity var(--duration-fast); pointer-events: none; }
+.flow-packet.moving { opacity: 1; }
+.flow-step-label { margin-top: var(--space-5); text-align: center; font-size: var(--text-sm); color: var(--color-text-secondary); min-height: 1.4em; }
+
+/* ── reduced motion ─────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+  .animate-in { opacity: 1; transform: none; }
+}

--- a/skills/repo-mastery/references/html-shell/styles.css
+++ b/skills/repo-mastery/references/html-shell/styles.css
@@ -312,3 +312,62 @@ code { font-family: var(--font-mono); font-size: .9em; }
   *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
   .animate-in { opacity: 1; transform: none; }
 }
+
+/* ── code blocks ────────────────────────────────────────── */
+:not(.translation-code) > pre {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
+  background: var(--color-bg-warm);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  overflow-x: auto;
+  margin: var(--space-6) 0;
+}
+/* Neutralize the vendored hljs inner frame so the warm `pre` owns the padding,
+   background and horizontal scroll (no white inner block / double scrollbar).
+   styles.css is linked AFTER vendor/highlight.min.css, so this wins the
+   specificity tie on `pre code.hljs`. */
+pre code.hljs { background: transparent; padding: 0; overflow: visible; }
+pre code { font-size: inherit; }
+/* Token colors for highlighted code come from vendor/highlight.min.css
+   (GitHub light theme); this only frames the block and must not override it. */
+
+/* ── collapsible source blocks ──────────────────────────── */
+details {
+  margin: var(--space-6) 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+details summary {
+  list-style: none;
+  cursor: pointer;
+  padding: var(--space-3) var(--space-4);
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  user-select: none;
+}
+details summary::-webkit-details-marker { display: none; }
+details summary:hover { color: var(--color-text); }
+details[open] summary { border-bottom: 1px solid var(--color-border-light); }
+details summary::after {
+  content: "▸";
+  float: right;
+  margin-left: var(--space-3);
+  color: var(--color-accent-muted);
+  transition: transform var(--duration-fast) var(--ease-out);
+}
+details[open] summary::after { transform: rotate(90deg); }
+/* `details` is never .translation-code; the :not() only matches the scoped
+   base `pre` selector's class specificity so this override still wins. */
+details:not(.translation-code) > pre {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+}

--- a/skills/repo-mastery/references/html-shell/vendor/README.md
+++ b/skills/repo-mastery/references/html-shell/vendor/README.md
@@ -1,0 +1,8 @@
+# Vendored third-party assets (no runtime CDN)
+
+## highlight.js — v11.11.1 (common build, 36 languages)
+- `highlight.min.js` — browser UMD build, BSD-3-Clause, from cdnjs
+  (https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js), fetched 2026-08-12.
+- `highlight.min.css` — GitHub light theme, BSD-3-Clause, from cdnjs (same version), fetched 2026-08-12.
+- Used by the HTML course shell for syntax highlighting; wired in `_base.html`; initialized in `main.js`.
+- Re-vendor by replacing both files with a newer version and updating this note.

--- a/skills/repo-mastery/references/html-shell/vendor/highlight.min.css
+++ b/skills/repo-mastery/references/html-shell/vendor/highlight.min.css
@@ -1,0 +1,10 @@
+pre code.hljs{display:block;overflow-x:auto;padding:1em}code.hljs{padding:3px 5px}/*!
+  Theme: GitHub
+  Description: Light theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-light
+  Current colors taken from GitHub's CSS
+*/.hljs{color:#24292e;background:#fff}.hljs-doctag,.hljs-keyword,.hljs-meta .hljs-keyword,.hljs-template-tag,.hljs-template-variable,.hljs-type,.hljs-variable.language_{color:#d73a49}.hljs-title,.hljs-title.class_,.hljs-title.class_.inherited__,.hljs-title.function_{color:#6f42c1}.hljs-attr,.hljs-attribute,.hljs-literal,.hljs-meta,.hljs-number,.hljs-operator,.hljs-selector-attr,.hljs-selector-class,.hljs-selector-id,.hljs-variable{color:#005cc5}.hljs-meta .hljs-string,.hljs-regexp,.hljs-string{color:#032f62}.hljs-built_in,.hljs-symbol{color:#e36209}.hljs-code,.hljs-comment,.hljs-formula{color:#6a737d}.hljs-name,.hljs-quote,.hljs-selector-pseudo,.hljs-selector-tag{color:#22863a}.hljs-subst{color:#24292e}.hljs-section{color:#005cc5;font-weight:700}.hljs-bullet{color:#735c0f}.hljs-emphasis{color:#24292e;font-style:italic}.hljs-strong{color:#24292e;font-weight:700}.hljs-addition{color:#22863a;background-color:#f0fff4}.hljs-deletion{color:#b31d28;background-color:#ffeef0}

--- a/skills/repo-mastery/references/html-shell/vendor/highlight.min.js
+++ b/skills/repo-mastery/references/html-shell/vendor/highlight.min.js
@@ -1,0 +1,1244 @@
+/*!
+  Highlight.js v11.11.1 (git: 08cb242e7d)
+  (c) 2006-2024 Josh Goebel <hello@joshgoebel.com> and other contributors
+  License: BSD-3-Clause
+ */
+var hljs=function(){"use strict";function e(n){
+return n instanceof Map?n.clear=n.delete=n.set=()=>{
+throw Error("map is read-only")}:n instanceof Set&&(n.add=n.clear=n.delete=()=>{
+throw Error("set is read-only")
+}),Object.freeze(n),Object.getOwnPropertyNames(n).forEach((t=>{
+const a=n[t],i=typeof a;"object"!==i&&"function"!==i||Object.isFrozen(a)||e(a)
+})),n}class n{constructor(e){
+void 0===e.data&&(e.data={}),this.data=e.data,this.isMatchIgnored=!1}
+ignoreMatch(){this.isMatchIgnored=!0}}function t(e){
+return e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;").replace(/'/g,"&#x27;")
+}function a(e,...n){const t=Object.create(null);for(const n in e)t[n]=e[n]
+;return n.forEach((e=>{for(const n in e)t[n]=e[n]})),t}const i=e=>!!e.scope
+;class r{constructor(e,n){
+this.buffer="",this.classPrefix=n.classPrefix,e.walk(this)}addText(e){
+this.buffer+=t(e)}openNode(e){if(!i(e))return;const n=((e,{prefix:n})=>{
+if(e.startsWith("language:"))return e.replace("language:","language-")
+;if(e.includes(".")){const t=e.split(".")
+;return[`${n}${t.shift()}`,...t.map(((e,n)=>`${e}${"_".repeat(n+1)}`))].join(" ")
+}return`${n}${e}`})(e.scope,{prefix:this.classPrefix});this.span(n)}
+closeNode(e){i(e)&&(this.buffer+="</span>")}value(){return this.buffer}span(e){
+this.buffer+=`<span class="${e}">`}}const s=(e={})=>{const n={children:[]}
+;return Object.assign(n,e),n};class o{constructor(){
+this.rootNode=s(),this.stack=[this.rootNode]}get top(){
+return this.stack[this.stack.length-1]}get root(){return this.rootNode}add(e){
+this.top.children.push(e)}openNode(e){const n=s({scope:e})
+;this.add(n),this.stack.push(n)}closeNode(){
+if(this.stack.length>1)return this.stack.pop()}closeAllNodes(){
+for(;this.closeNode(););}toJSON(){return JSON.stringify(this.rootNode,null,4)}
+walk(e){return this.constructor._walk(e,this.rootNode)}static _walk(e,n){
+return"string"==typeof n?e.addText(n):n.children&&(e.openNode(n),
+n.children.forEach((n=>this._walk(e,n))),e.closeNode(n)),e}static _collapse(e){
+"string"!=typeof e&&e.children&&(e.children.every((e=>"string"==typeof e))?e.children=[e.children.join("")]:e.children.forEach((e=>{
+o._collapse(e)})))}}class l extends o{constructor(e){super(),this.options=e}
+addText(e){""!==e&&this.add(e)}startScope(e){this.openNode(e)}endScope(){
+this.closeNode()}__addSublanguage(e,n){const t=e.root
+;n&&(t.scope="language:"+n),this.add(t)}toHTML(){
+return new r(this,this.options).value()}finalize(){
+return this.closeAllNodes(),!0}}function c(e){
+return e?"string"==typeof e?e:e.source:null}function d(e){return b("(?=",e,")")}
+function g(e){return b("(?:",e,")*")}function u(e){return b("(?:",e,")?")}
+function b(...e){return e.map((e=>c(e))).join("")}function m(...e){const n=(e=>{
+const n=e[e.length-1]
+;return"object"==typeof n&&n.constructor===Object?(e.splice(e.length-1,1),n):{}
+})(e);return"("+(n.capture?"":"?:")+e.map((e=>c(e))).join("|")+")"}
+function p(e){return RegExp(e.toString()+"|").exec("").length-1}
+const _=/\[(?:[^\\\]]|\\.)*\]|\(\??|\\([1-9][0-9]*)|\\./
+;function h(e,{joinWith:n}){let t=0;return e.map((e=>{t+=1;const n=t
+;let a=c(e),i="";for(;a.length>0;){const e=_.exec(a);if(!e){i+=a;break}
+i+=a.substring(0,e.index),
+a=a.substring(e.index+e[0].length),"\\"===e[0][0]&&e[1]?i+="\\"+(Number(e[1])+n):(i+=e[0],
+"("===e[0]&&t++)}return i})).map((e=>`(${e})`)).join(n)}
+const f="[a-zA-Z]\\w*",E="[a-zA-Z_]\\w*",y="\\b\\d+(\\.\\d+)?",w="(-?)(\\b0[xX][a-fA-F0-9]+|(\\b\\d+(\\.\\d*)?|\\.\\d+)([eE][-+]?\\d+)?)",v="\\b(0b[01]+)",N={
+begin:"\\\\[\\s\\S]",relevance:0},k={scope:"string",begin:"'",end:"'",
+illegal:"\\n",contains:[N]},x={scope:"string",begin:'"',end:'"',illegal:"\\n",
+contains:[N]},O=(e,n,t={})=>{const i=a({scope:"comment",begin:e,end:n,
+contains:[]},t);i.contains.push({scope:"doctag",
+begin:"[ ]*(?=(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):)",
+end:/(TODO|FIXME|NOTE|BUG|OPTIMIZE|HACK|XXX):/,excludeBegin:!0,relevance:0})
+;const r=m("I","a","is","so","us","to","at","if","in","it","on",/[A-Za-z]+['](d|ve|re|ll|t|s|n)/,/[A-Za-z]+[-][a-z]+/,/[A-Za-z][a-z]{2,}/)
+;return i.contains.push({begin:b(/[ ]+/,"(",r,/[.]?[:]?([.][ ]|[ ])/,"){3}")}),i
+},M=O("//","$"),A=O("/\\*","\\*/"),S=O("#","$");var C=Object.freeze({
+__proto__:null,APOS_STRING_MODE:k,BACKSLASH_ESCAPE:N,BINARY_NUMBER_MODE:{
+scope:"number",begin:v,relevance:0},BINARY_NUMBER_RE:v,COMMENT:O,
+C_BLOCK_COMMENT_MODE:A,C_LINE_COMMENT_MODE:M,C_NUMBER_MODE:{scope:"number",
+begin:w,relevance:0},C_NUMBER_RE:w,END_SAME_AS_BEGIN:e=>Object.assign(e,{
+"on:begin":(e,n)=>{n.data._beginMatch=e[1]},"on:end":(e,n)=>{
+n.data._beginMatch!==e[1]&&n.ignoreMatch()}}),HASH_COMMENT_MODE:S,IDENT_RE:f,
+MATCH_NOTHING_RE:/\b\B/,METHOD_GUARD:{begin:"\\.\\s*"+E,relevance:0},
+NUMBER_MODE:{scope:"number",begin:y,relevance:0},NUMBER_RE:y,
+PHRASAL_WORDS_MODE:{
+begin:/\b(a|an|the|are|I'm|isn't|don't|doesn't|won't|but|just|should|pretty|simply|enough|gonna|going|wtf|so|such|will|you|your|they|like|more)\b/
+},QUOTE_STRING_MODE:x,REGEXP_MODE:{scope:"regexp",begin:/\/(?=[^/\n]*\/)/,
+end:/\/[gimuy]*/,contains:[N,{begin:/\[/,end:/\]/,relevance:0,contains:[N]}]},
+RE_STARTERS_RE:"!|!=|!==|%|%=|&|&&|&=|\\*|\\*=|\\+|\\+=|,|-|-=|/=|/|:|;|<<|<<=|<=|<|===|==|=|>>>=|>>=|>=|>>>|>>|>|\\?|\\[|\\{|\\(|\\^|\\^=|\\||\\|=|\\|\\||~",
+SHEBANG:(e={})=>{const n=/^#![ ]*\//
+;return e.binary&&(e.begin=b(n,/.*\b/,e.binary,/\b.*/)),a({scope:"meta",begin:n,
+end:/$/,relevance:0,"on:begin":(e,n)=>{0!==e.index&&n.ignoreMatch()}},e)},
+TITLE_MODE:{scope:"title",begin:f,relevance:0},UNDERSCORE_IDENT_RE:E,
+UNDERSCORE_TITLE_MODE:{scope:"title",begin:E,relevance:0}});function T(e,n){
+"."===e.input[e.index-1]&&n.ignoreMatch()}function R(e,n){
+void 0!==e.className&&(e.scope=e.className,delete e.className)}function D(e,n){
+n&&e.beginKeywords&&(e.begin="\\b("+e.beginKeywords.split(" ").join("|")+")(?!\\.)(?=\\b|\\s)",
+e.__beforeBegin=T,e.keywords=e.keywords||e.beginKeywords,delete e.beginKeywords,
+void 0===e.relevance&&(e.relevance=0))}function I(e,n){
+Array.isArray(e.illegal)&&(e.illegal=m(...e.illegal))}function L(e,n){
+if(e.match){
+if(e.begin||e.end)throw Error("begin & end are not supported with match")
+;e.begin=e.match,delete e.match}}function B(e,n){
+void 0===e.relevance&&(e.relevance=1)}const $=(e,n)=>{if(!e.beforeMatch)return
+;if(e.starts)throw Error("beforeMatch cannot be used with starts")
+;const t=Object.assign({},e);Object.keys(e).forEach((n=>{delete e[n]
+})),e.keywords=t.keywords,e.begin=b(t.beforeMatch,d(t.begin)),e.starts={
+relevance:0,contains:[Object.assign(t,{endsParent:!0})]
+},e.relevance=0,delete t.beforeMatch
+},F=["of","and","for","in","not","or","if","then","parent","list","value"]
+;function z(e,n,t="keyword"){const a=Object.create(null)
+;return"string"==typeof e?i(t,e.split(" ")):Array.isArray(e)?i(t,e):Object.keys(e).forEach((t=>{
+Object.assign(a,z(e[t],n,t))})),a;function i(e,t){
+n&&(t=t.map((e=>e.toLowerCase()))),t.forEach((n=>{const t=n.split("|")
+;a[t[0]]=[e,j(t[0],t[1])]}))}}function j(e,n){
+return n?Number(n):(e=>F.includes(e.toLowerCase()))(e)?0:1}const U={},P=e=>{
+console.error(e)},K=(e,...n)=>{console.log("WARN: "+e,...n)},q=(e,n)=>{
+U[`${e}/${n}`]||(console.log(`Deprecated as of ${e}. ${n}`),U[`${e}/${n}`]=!0)
+},H=Error();function G(e,n,{key:t}){let a=0;const i=e[t],r={},s={}
+;for(let e=1;e<=n.length;e++)s[e+a]=i[e],r[e+a]=!0,a+=p(n[e-1])
+;e[t]=s,e[t]._emit=r,e[t]._multi=!0}function Z(e){(e=>{
+e.scope&&"object"==typeof e.scope&&null!==e.scope&&(e.beginScope=e.scope,
+delete e.scope)})(e),"string"==typeof e.beginScope&&(e.beginScope={
+_wrap:e.beginScope}),"string"==typeof e.endScope&&(e.endScope={_wrap:e.endScope
+}),(e=>{if(Array.isArray(e.begin)){
+if(e.skip||e.excludeBegin||e.returnBegin)throw P("skip, excludeBegin, returnBegin not compatible with beginScope: {}"),
+H
+;if("object"!=typeof e.beginScope||null===e.beginScope)throw P("beginScope must be object"),
+H;G(e,e.begin,{key:"beginScope"}),e.begin=h(e.begin,{joinWith:""})}})(e),(e=>{
+if(Array.isArray(e.end)){
+if(e.skip||e.excludeEnd||e.returnEnd)throw P("skip, excludeEnd, returnEnd not compatible with endScope: {}"),
+H
+;if("object"!=typeof e.endScope||null===e.endScope)throw P("endScope must be object"),
+H;G(e,e.end,{key:"endScope"}),e.end=h(e.end,{joinWith:""})}})(e)}function W(e){
+function n(n,t){
+return RegExp(c(n),"m"+(e.case_insensitive?"i":"")+(e.unicodeRegex?"u":"")+(t?"g":""))
+}class t{constructor(){
+this.matchIndexes={},this.regexes=[],this.matchAt=1,this.position=0}
+addRule(e,n){
+n.position=this.position++,this.matchIndexes[this.matchAt]=n,this.regexes.push([n,e]),
+this.matchAt+=p(e)+1}compile(){0===this.regexes.length&&(this.exec=()=>null)
+;const e=this.regexes.map((e=>e[1]));this.matcherRe=n(h(e,{joinWith:"|"
+}),!0),this.lastIndex=0}exec(e){this.matcherRe.lastIndex=this.lastIndex
+;const n=this.matcherRe.exec(e);if(!n)return null
+;const t=n.findIndex(((e,n)=>n>0&&void 0!==e)),a=this.matchIndexes[t]
+;return n.splice(0,t),Object.assign(n,a)}}class i{constructor(){
+this.rules=[],this.multiRegexes=[],
+this.count=0,this.lastIndex=0,this.regexIndex=0}getMatcher(e){
+if(this.multiRegexes[e])return this.multiRegexes[e];const n=new t
+;return this.rules.slice(e).forEach((([e,t])=>n.addRule(e,t))),
+n.compile(),this.multiRegexes[e]=n,n}resumingScanAtSamePosition(){
+return 0!==this.regexIndex}considerAll(){this.regexIndex=0}addRule(e,n){
+this.rules.push([e,n]),"begin"===n.type&&this.count++}exec(e){
+const n=this.getMatcher(this.regexIndex);n.lastIndex=this.lastIndex
+;let t=n.exec(e)
+;if(this.resumingScanAtSamePosition())if(t&&t.index===this.lastIndex);else{
+const n=this.getMatcher(0);n.lastIndex=this.lastIndex+1,t=n.exec(e)}
+return t&&(this.regexIndex+=t.position+1,
+this.regexIndex===this.count&&this.considerAll()),t}}
+if(e.compilerExtensions||(e.compilerExtensions=[]),
+e.contains&&e.contains.includes("self"))throw Error("ERR: contains `self` is not supported at the top-level of a language.  See documentation.")
+;return e.classNameAliases=a(e.classNameAliases||{}),function t(r,s){const o=r
+;if(r.isCompiled)return o
+;[R,L,Z,$].forEach((e=>e(r,s))),e.compilerExtensions.forEach((e=>e(r,s))),
+r.__beforeBegin=null,[D,I,B].forEach((e=>e(r,s))),r.isCompiled=!0;let l=null
+;return"object"==typeof r.keywords&&r.keywords.$pattern&&(r.keywords=Object.assign({},r.keywords),
+l=r.keywords.$pattern,
+delete r.keywords.$pattern),l=l||/\w+/,r.keywords&&(r.keywords=z(r.keywords,e.case_insensitive)),
+o.keywordPatternRe=n(l,!0),
+s&&(r.begin||(r.begin=/\B|\b/),o.beginRe=n(o.begin),r.end||r.endsWithParent||(r.end=/\B|\b/),
+r.end&&(o.endRe=n(o.end)),
+o.terminatorEnd=c(o.end)||"",r.endsWithParent&&s.terminatorEnd&&(o.terminatorEnd+=(r.end?"|":"")+s.terminatorEnd)),
+r.illegal&&(o.illegalRe=n(r.illegal)),
+r.contains||(r.contains=[]),r.contains=[].concat(...r.contains.map((e=>(e=>(e.variants&&!e.cachedVariants&&(e.cachedVariants=e.variants.map((n=>a(e,{
+variants:null},n)))),e.cachedVariants?e.cachedVariants:Q(e)?a(e,{
+starts:e.starts?a(e.starts):null
+}):Object.isFrozen(e)?a(e):e))("self"===e?r:e)))),r.contains.forEach((e=>{t(e,o)
+})),r.starts&&t(r.starts,s),o.matcher=(e=>{const n=new i
+;return e.contains.forEach((e=>n.addRule(e.begin,{rule:e,type:"begin"
+}))),e.terminatorEnd&&n.addRule(e.terminatorEnd,{type:"end"
+}),e.illegal&&n.addRule(e.illegal,{type:"illegal"}),n})(o),o}(e)}function Q(e){
+return!!e&&(e.endsWithParent||Q(e.starts))}class X extends Error{
+constructor(e,n){super(e),this.name="HTMLInjectionError",this.html=n}}
+const V=t,J=a,Y=Symbol("nomatch"),ee=t=>{
+const a=Object.create(null),i=Object.create(null),r=[];let s=!0
+;const o="Could not find the language '{}', did you forget to load/include a language module?",c={
+disableAutodetect:!0,name:"Plain text",contains:[]};let p={
+ignoreUnescapedHTML:!1,throwUnescapedHTML:!1,noHighlightRe:/^(no-?highlight)$/i,
+languageDetectRe:/\blang(?:uage)?-([\w-]+)\b/i,classPrefix:"hljs-",
+cssSelector:"pre code",languages:null,__emitter:l};function _(e){
+return p.noHighlightRe.test(e)}function h(e,n,t){let a="",i=""
+;"object"==typeof n?(a=e,
+t=n.ignoreIllegals,i=n.language):(q("10.7.0","highlight(lang, code, ...args) has been deprecated."),
+q("10.7.0","Please use highlight(code, options) instead.\nhttps://github.com/highlightjs/highlight.js/issues/2277"),
+i=e,a=n),void 0===t&&(t=!0);const r={code:a,language:i};O("before:highlight",r)
+;const s=r.result?r.result:f(r.language,r.code,t)
+;return s.code=r.code,O("after:highlight",s),s}function f(e,t,i,r){
+const l=Object.create(null);function c(){if(!O.keywords)return void A.addText(S)
+;let e=0;O.keywordPatternRe.lastIndex=0;let n=O.keywordPatternRe.exec(S),t=""
+;for(;n;){t+=S.substring(e,n.index)
+;const i=v.case_insensitive?n[0].toLowerCase():n[0],r=(a=i,O.keywords[a]);if(r){
+const[e,a]=r
+;if(A.addText(t),t="",l[i]=(l[i]||0)+1,l[i]<=7&&(C+=a),e.startsWith("_"))t+=n[0];else{
+const t=v.classNameAliases[e]||e;g(n[0],t)}}else t+=n[0]
+;e=O.keywordPatternRe.lastIndex,n=O.keywordPatternRe.exec(S)}var a
+;t+=S.substring(e),A.addText(t)}function d(){null!=O.subLanguage?(()=>{
+if(""===S)return;let e=null;if("string"==typeof O.subLanguage){
+if(!a[O.subLanguage])return void A.addText(S)
+;e=f(O.subLanguage,S,!0,M[O.subLanguage]),M[O.subLanguage]=e._top
+}else e=E(S,O.subLanguage.length?O.subLanguage:null)
+;O.relevance>0&&(C+=e.relevance),A.__addSublanguage(e._emitter,e.language)
+})():c(),S=""}function g(e,n){
+""!==e&&(A.startScope(n),A.addText(e),A.endScope())}function u(e,n){let t=1
+;const a=n.length-1;for(;t<=a;){if(!e._emit[t]){t++;continue}
+const a=v.classNameAliases[e[t]]||e[t],i=n[t];a?g(i,a):(S=i,c(),S=""),t++}}
+function b(e,n){
+return e.scope&&"string"==typeof e.scope&&A.openNode(v.classNameAliases[e.scope]||e.scope),
+e.beginScope&&(e.beginScope._wrap?(g(S,v.classNameAliases[e.beginScope._wrap]||e.beginScope._wrap),
+S=""):e.beginScope._multi&&(u(e.beginScope,n),S="")),O=Object.create(e,{parent:{
+value:O}}),O}function m(e,t,a){let i=((e,n)=>{const t=e&&e.exec(n)
+;return t&&0===t.index})(e.endRe,a);if(i){if(e["on:end"]){const a=new n(e)
+;e["on:end"](t,a),a.isMatchIgnored&&(i=!1)}if(i){
+for(;e.endsParent&&e.parent;)e=e.parent;return e}}
+if(e.endsWithParent)return m(e.parent,t,a)}function _(e){
+return 0===O.matcher.regexIndex?(S+=e[0],1):(D=!0,0)}function h(e){
+const n=e[0],a=t.substring(e.index),i=m(O,e,a);if(!i)return Y;const r=O
+;O.endScope&&O.endScope._wrap?(d(),
+g(n,O.endScope._wrap)):O.endScope&&O.endScope._multi?(d(),
+u(O.endScope,e)):r.skip?S+=n:(r.returnEnd||r.excludeEnd||(S+=n),
+d(),r.excludeEnd&&(S=n));do{
+O.scope&&A.closeNode(),O.skip||O.subLanguage||(C+=O.relevance),O=O.parent
+}while(O!==i.parent);return i.starts&&b(i.starts,e),r.returnEnd?0:n.length}
+let y={};function w(a,r){const o=r&&r[0];if(S+=a,null==o)return d(),0
+;if("begin"===y.type&&"end"===r.type&&y.index===r.index&&""===o){
+if(S+=t.slice(r.index,r.index+1),!s){const n=Error(`0 width match regex (${e})`)
+;throw n.languageName=e,n.badRule=y.rule,n}return 1}
+if(y=r,"begin"===r.type)return(e=>{
+const t=e[0],a=e.rule,i=new n(a),r=[a.__beforeBegin,a["on:begin"]]
+;for(const n of r)if(n&&(n(e,i),i.isMatchIgnored))return _(t)
+;return a.skip?S+=t:(a.excludeBegin&&(S+=t),
+d(),a.returnBegin||a.excludeBegin||(S=t)),b(a,e),a.returnBegin?0:t.length})(r)
+;if("illegal"===r.type&&!i){
+const e=Error('Illegal lexeme "'+o+'" for mode "'+(O.scope||"<unnamed>")+'"')
+;throw e.mode=O,e}if("end"===r.type){const e=h(r);if(e!==Y)return e}
+if("illegal"===r.type&&""===o)return S+="\n",1
+;if(R>1e5&&R>3*r.index)throw Error("potential infinite loop, way more iterations than matches")
+;return S+=o,o.length}const v=N(e)
+;if(!v)throw P(o.replace("{}",e)),Error('Unknown language: "'+e+'"')
+;const k=W(v);let x="",O=r||k;const M={},A=new p.__emitter(p);(()=>{const e=[]
+;for(let n=O;n!==v;n=n.parent)n.scope&&e.unshift(n.scope)
+;e.forEach((e=>A.openNode(e)))})();let S="",C=0,T=0,R=0,D=!1;try{
+if(v.__emitTokens)v.__emitTokens(t,A);else{for(O.matcher.considerAll();;){
+R++,D?D=!1:O.matcher.considerAll(),O.matcher.lastIndex=T
+;const e=O.matcher.exec(t);if(!e)break;const n=w(t.substring(T,e.index),e)
+;T=e.index+n}w(t.substring(T))}return A.finalize(),x=A.toHTML(),{language:e,
+value:x,relevance:C,illegal:!1,_emitter:A,_top:O}}catch(n){
+if(n.message&&n.message.includes("Illegal"))return{language:e,value:V(t),
+illegal:!0,relevance:0,_illegalBy:{message:n.message,index:T,
+context:t.slice(T-100,T+100),mode:n.mode,resultSoFar:x},_emitter:A};if(s)return{
+language:e,value:V(t),illegal:!1,relevance:0,errorRaised:n,_emitter:A,_top:O}
+;throw n}}function E(e,n){n=n||p.languages||Object.keys(a);const t=(e=>{
+const n={value:V(e),illegal:!1,relevance:0,_top:c,_emitter:new p.__emitter(p)}
+;return n._emitter.addText(e),n})(e),i=n.filter(N).filter(x).map((n=>f(n,e,!1)))
+;i.unshift(t);const r=i.sort(((e,n)=>{
+if(e.relevance!==n.relevance)return n.relevance-e.relevance
+;if(e.language&&n.language){if(N(e.language).supersetOf===n.language)return 1
+;if(N(n.language).supersetOf===e.language)return-1}return 0})),[s,o]=r,l=s
+;return l.secondBest=o,l}function y(e){let n=null;const t=(e=>{
+let n=e.className+" ";n+=e.parentNode?e.parentNode.className:""
+;const t=p.languageDetectRe.exec(n);if(t){const n=N(t[1])
+;return n||(K(o.replace("{}",t[1])),
+K("Falling back to no-highlight mode for this block.",e)),n?t[1]:"no-highlight"}
+return n.split(/\s+/).find((e=>_(e)||N(e)))})(e);if(_(t))return
+;if(O("before:highlightElement",{el:e,language:t
+}),e.dataset.highlighted)return void console.log("Element previously highlighted. To highlight again, first unset `dataset.highlighted`.",e)
+;if(e.children.length>0&&(p.ignoreUnescapedHTML||(console.warn("One of your code blocks includes unescaped HTML. This is a potentially serious security risk."),
+console.warn("https://github.com/highlightjs/highlight.js/wiki/security"),
+console.warn("The element with unescaped HTML:"),
+console.warn(e)),p.throwUnescapedHTML))throw new X("One of your code blocks includes unescaped HTML.",e.innerHTML)
+;n=e;const a=n.textContent,r=t?h(a,{language:t,ignoreIllegals:!0}):E(a)
+;e.innerHTML=r.value,e.dataset.highlighted="yes",((e,n,t)=>{const a=n&&i[n]||t
+;e.classList.add("hljs"),e.classList.add("language-"+a)
+})(e,t,r.language),e.result={language:r.language,re:r.relevance,
+relevance:r.relevance},r.secondBest&&(e.secondBest={
+language:r.secondBest.language,relevance:r.secondBest.relevance
+}),O("after:highlightElement",{el:e,result:r,text:a})}let w=!1;function v(){
+if("loading"===document.readyState)return w||window.addEventListener("DOMContentLoaded",(()=>{
+v()}),!1),void(w=!0);document.querySelectorAll(p.cssSelector).forEach(y)}
+function N(e){return e=(e||"").toLowerCase(),a[e]||a[i[e]]}
+function k(e,{languageName:n}){"string"==typeof e&&(e=[e]),e.forEach((e=>{
+i[e.toLowerCase()]=n}))}function x(e){const n=N(e)
+;return n&&!n.disableAutodetect}function O(e,n){const t=e;r.forEach((e=>{
+e[t]&&e[t](n)}))}Object.assign(t,{highlight:h,highlightAuto:E,highlightAll:v,
+highlightElement:y,
+highlightBlock:e=>(q("10.7.0","highlightBlock will be removed entirely in v12.0"),
+q("10.7.0","Please use highlightElement now."),y(e)),configure:e=>{p=J(p,e)},
+initHighlighting:()=>{
+v(),q("10.6.0","initHighlighting() deprecated.  Use highlightAll() now.")},
+initHighlightingOnLoad:()=>{
+v(),q("10.6.0","initHighlightingOnLoad() deprecated.  Use highlightAll() now.")
+},registerLanguage:(e,n)=>{let i=null;try{i=n(t)}catch(n){
+if(P("Language definition for '{}' could not be registered.".replace("{}",e)),
+!s)throw n;P(n),i=c}
+i.name||(i.name=e),a[e]=i,i.rawDefinition=n.bind(null,t),i.aliases&&k(i.aliases,{
+languageName:e})},unregisterLanguage:e=>{delete a[e]
+;for(const n of Object.keys(i))i[n]===e&&delete i[n]},
+listLanguages:()=>Object.keys(a),getLanguage:N,registerAliases:k,
+autoDetection:x,inherit:J,addPlugin:e=>{(e=>{
+e["before:highlightBlock"]&&!e["before:highlightElement"]&&(e["before:highlightElement"]=n=>{
+e["before:highlightBlock"](Object.assign({block:n.el},n))
+}),e["after:highlightBlock"]&&!e["after:highlightElement"]&&(e["after:highlightElement"]=n=>{
+e["after:highlightBlock"](Object.assign({block:n.el},n))})})(e),r.push(e)},
+removePlugin:e=>{const n=r.indexOf(e);-1!==n&&r.splice(n,1)}}),t.debugMode=()=>{
+s=!1},t.safeMode=()=>{s=!0},t.versionString="11.11.1",t.regex={concat:b,
+lookahead:d,either:m,optional:u,anyNumberOfTimes:g}
+;for(const n in C)"object"==typeof C[n]&&e(C[n]);return Object.assign(t,C),t
+},ne=ee({});ne.newInstance=()=>ee({});const te=e=>({IMPORTANT:{scope:"meta",
+begin:"!important"},BLOCK_COMMENT:e.C_BLOCK_COMMENT_MODE,HEXCOLOR:{
+scope:"number",begin:/#(([0-9a-fA-F]{3,4})|(([0-9a-fA-F]{2}){3,4}))\b/},
+FUNCTION_DISPATCH:{className:"built_in",begin:/[\w-]+(?=\()/},
+ATTRIBUTE_SELECTOR_MODE:{scope:"selector-attr",begin:/\[/,end:/\]/,illegal:"$",
+contains:[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]},CSS_NUMBER_MODE:{
+scope:"number",
+begin:e.NUMBER_RE+"(%|em|ex|ch|rem|vw|vh|vmin|vmax|cm|mm|in|pt|pc|px|deg|grad|rad|turn|s|ms|Hz|kHz|dpi|dpcm|dppx)?",
+relevance:0},CSS_VARIABLE:{className:"attr",begin:/--[A-Za-z_][A-Za-z0-9_-]*/}
+}),ae=["a","abbr","address","article","aside","audio","b","blockquote","body","button","canvas","caption","cite","code","dd","del","details","dfn","div","dl","dt","em","fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","header","hgroup","html","i","iframe","img","input","ins","kbd","label","legend","li","main","mark","menu","nav","object","ol","optgroup","option","p","picture","q","quote","samp","section","select","source","span","strong","summary","sup","table","tbody","td","textarea","tfoot","th","thead","time","tr","ul","var","video","defs","g","marker","mask","pattern","svg","switch","symbol","feBlend","feColorMatrix","feComponentTransfer","feComposite","feConvolveMatrix","feDiffuseLighting","feDisplacementMap","feFlood","feGaussianBlur","feImage","feMerge","feMorphology","feOffset","feSpecularLighting","feTile","feTurbulence","linearGradient","radialGradient","stop","circle","ellipse","image","line","path","polygon","polyline","rect","text","use","textPath","tspan","foreignObject","clipPath"],ie=["any-hover","any-pointer","aspect-ratio","color","color-gamut","color-index","device-aspect-ratio","device-height","device-width","display-mode","forced-colors","grid","height","hover","inverted-colors","monochrome","orientation","overflow-block","overflow-inline","pointer","prefers-color-scheme","prefers-contrast","prefers-reduced-motion","prefers-reduced-transparency","resolution","scan","scripting","update","width","min-width","max-width","min-height","max-height"].sort().reverse(),re=["active","any-link","blank","checked","current","default","defined","dir","disabled","drop","empty","enabled","first","first-child","first-of-type","fullscreen","future","focus","focus-visible","focus-within","has","host","host-context","hover","indeterminate","in-range","invalid","is","lang","last-child","last-of-type","left","link","local-link","not","nth-child","nth-col","nth-last-child","nth-last-col","nth-last-of-type","nth-of-type","only-child","only-of-type","optional","out-of-range","past","placeholder-shown","read-only","read-write","required","right","root","scope","target","target-within","user-invalid","valid","visited","where"].sort().reverse(),se=["after","backdrop","before","cue","cue-region","first-letter","first-line","grammar-error","marker","part","placeholder","selection","slotted","spelling-error"].sort().reverse(),oe=["accent-color","align-content","align-items","align-self","alignment-baseline","all","anchor-name","animation","animation-composition","animation-delay","animation-direction","animation-duration","animation-fill-mode","animation-iteration-count","animation-name","animation-play-state","animation-range","animation-range-end","animation-range-start","animation-timeline","animation-timing-function","appearance","aspect-ratio","backdrop-filter","backface-visibility","background","background-attachment","background-blend-mode","background-clip","background-color","background-image","background-origin","background-position","background-position-x","background-position-y","background-repeat","background-size","baseline-shift","block-size","border","border-block","border-block-color","border-block-end","border-block-end-color","border-block-end-style","border-block-end-width","border-block-start","border-block-start-color","border-block-start-style","border-block-start-width","border-block-style","border-block-width","border-bottom","border-bottom-color","border-bottom-left-radius","border-bottom-right-radius","border-bottom-style","border-bottom-width","border-collapse","border-color","border-end-end-radius","border-end-start-radius","border-image","border-image-outset","border-image-repeat","border-image-slice","border-image-source","border-image-width","border-inline","border-inline-color","border-inline-end","border-inline-end-color","border-inline-end-style","border-inline-end-width","border-inline-start","border-inline-start-color","border-inline-start-style","border-inline-start-width","border-inline-style","border-inline-width","border-left","border-left-color","border-left-style","border-left-width","border-radius","border-right","border-right-color","border-right-style","border-right-width","border-spacing","border-start-end-radius","border-start-start-radius","border-style","border-top","border-top-color","border-top-left-radius","border-top-right-radius","border-top-style","border-top-width","border-width","bottom","box-align","box-decoration-break","box-direction","box-flex","box-flex-group","box-lines","box-ordinal-group","box-orient","box-pack","box-shadow","box-sizing","break-after","break-before","break-inside","caption-side","caret-color","clear","clip","clip-path","clip-rule","color","color-interpolation","color-interpolation-filters","color-profile","color-rendering","color-scheme","column-count","column-fill","column-gap","column-rule","column-rule-color","column-rule-style","column-rule-width","column-span","column-width","columns","contain","contain-intrinsic-block-size","contain-intrinsic-height","contain-intrinsic-inline-size","contain-intrinsic-size","contain-intrinsic-width","container","container-name","container-type","content","content-visibility","counter-increment","counter-reset","counter-set","cue","cue-after","cue-before","cursor","cx","cy","direction","display","dominant-baseline","empty-cells","enable-background","field-sizing","fill","fill-opacity","fill-rule","filter","flex","flex-basis","flex-direction","flex-flow","flex-grow","flex-shrink","flex-wrap","float","flood-color","flood-opacity","flow","font","font-display","font-family","font-feature-settings","font-kerning","font-language-override","font-optical-sizing","font-palette","font-size","font-size-adjust","font-smooth","font-smoothing","font-stretch","font-style","font-synthesis","font-synthesis-position","font-synthesis-small-caps","font-synthesis-style","font-synthesis-weight","font-variant","font-variant-alternates","font-variant-caps","font-variant-east-asian","font-variant-emoji","font-variant-ligatures","font-variant-numeric","font-variant-position","font-variation-settings","font-weight","forced-color-adjust","gap","glyph-orientation-horizontal","glyph-orientation-vertical","grid","grid-area","grid-auto-columns","grid-auto-flow","grid-auto-rows","grid-column","grid-column-end","grid-column-start","grid-gap","grid-row","grid-row-end","grid-row-start","grid-template","grid-template-areas","grid-template-columns","grid-template-rows","hanging-punctuation","height","hyphenate-character","hyphenate-limit-chars","hyphens","icon","image-orientation","image-rendering","image-resolution","ime-mode","initial-letter","initial-letter-align","inline-size","inset","inset-area","inset-block","inset-block-end","inset-block-start","inset-inline","inset-inline-end","inset-inline-start","isolation","justify-content","justify-items","justify-self","kerning","left","letter-spacing","lighting-color","line-break","line-height","line-height-step","list-style","list-style-image","list-style-position","list-style-type","margin","margin-block","margin-block-end","margin-block-start","margin-bottom","margin-inline","margin-inline-end","margin-inline-start","margin-left","margin-right","margin-top","margin-trim","marker","marker-end","marker-mid","marker-start","marks","mask","mask-border","mask-border-mode","mask-border-outset","mask-border-repeat","mask-border-slice","mask-border-source","mask-border-width","mask-clip","mask-composite","mask-image","mask-mode","mask-origin","mask-position","mask-repeat","mask-size","mask-type","masonry-auto-flow","math-depth","math-shift","math-style","max-block-size","max-height","max-inline-size","max-width","min-block-size","min-height","min-inline-size","min-width","mix-blend-mode","nav-down","nav-index","nav-left","nav-right","nav-up","none","normal","object-fit","object-position","offset","offset-anchor","offset-distance","offset-path","offset-position","offset-rotate","opacity","order","orphans","outline","outline-color","outline-offset","outline-style","outline-width","overflow","overflow-anchor","overflow-block","overflow-clip-margin","overflow-inline","overflow-wrap","overflow-x","overflow-y","overlay","overscroll-behavior","overscroll-behavior-block","overscroll-behavior-inline","overscroll-behavior-x","overscroll-behavior-y","padding","padding-block","padding-block-end","padding-block-start","padding-bottom","padding-inline","padding-inline-end","padding-inline-start","padding-left","padding-right","padding-top","page","page-break-after","page-break-before","page-break-inside","paint-order","pause","pause-after","pause-before","perspective","perspective-origin","place-content","place-items","place-self","pointer-events","position","position-anchor","position-visibility","print-color-adjust","quotes","r","resize","rest","rest-after","rest-before","right","rotate","row-gap","ruby-align","ruby-position","scale","scroll-behavior","scroll-margin","scroll-margin-block","scroll-margin-block-end","scroll-margin-block-start","scroll-margin-bottom","scroll-margin-inline","scroll-margin-inline-end","scroll-margin-inline-start","scroll-margin-left","scroll-margin-right","scroll-margin-top","scroll-padding","scroll-padding-block","scroll-padding-block-end","scroll-padding-block-start","scroll-padding-bottom","scroll-padding-inline","scroll-padding-inline-end","scroll-padding-inline-start","scroll-padding-left","scroll-padding-right","scroll-padding-top","scroll-snap-align","scroll-snap-stop","scroll-snap-type","scroll-timeline","scroll-timeline-axis","scroll-timeline-name","scrollbar-color","scrollbar-gutter","scrollbar-width","shape-image-threshold","shape-margin","shape-outside","shape-rendering","speak","speak-as","src","stop-color","stop-opacity","stroke","stroke-dasharray","stroke-dashoffset","stroke-linecap","stroke-linejoin","stroke-miterlimit","stroke-opacity","stroke-width","tab-size","table-layout","text-align","text-align-all","text-align-last","text-anchor","text-combine-upright","text-decoration","text-decoration-color","text-decoration-line","text-decoration-skip","text-decoration-skip-ink","text-decoration-style","text-decoration-thickness","text-emphasis","text-emphasis-color","text-emphasis-position","text-emphasis-style","text-indent","text-justify","text-orientation","text-overflow","text-rendering","text-shadow","text-size-adjust","text-transform","text-underline-offset","text-underline-position","text-wrap","text-wrap-mode","text-wrap-style","timeline-scope","top","touch-action","transform","transform-box","transform-origin","transform-style","transition","transition-behavior","transition-delay","transition-duration","transition-property","transition-timing-function","translate","unicode-bidi","user-modify","user-select","vector-effect","vertical-align","view-timeline","view-timeline-axis","view-timeline-inset","view-timeline-name","view-transition-name","visibility","voice-balance","voice-duration","voice-family","voice-pitch","voice-range","voice-rate","voice-stress","voice-volume","white-space","white-space-collapse","widows","width","will-change","word-break","word-spacing","word-wrap","writing-mode","x","y","z-index","zoom"].sort().reverse(),le=re.concat(se).sort().reverse()
+;var ce="[0-9](_*[0-9])*",de=`\\.(${ce})`,ge="[0-9a-fA-F](_*[0-9a-fA-F])*",ue={
+className:"number",variants:[{
+begin:`(\\b(${ce})((${de})|\\.)?|(${de}))[eE][+-]?(${ce})[fFdD]?\\b`},{
+begin:`\\b(${ce})((${de})[fFdD]?\\b|\\.([fFdD]\\b)?)`},{
+begin:`(${de})[fFdD]?\\b`},{begin:`\\b(${ce})[fFdD]\\b`},{
+begin:`\\b0[xX]((${ge})\\.?|(${ge})?\\.(${ge}))[pP][+-]?(${ce})[fFdD]?\\b`},{
+begin:"\\b(0|[1-9](_*[0-9])*)[lL]?\\b"},{begin:`\\b0[xX](${ge})[lL]?\\b`},{
+begin:"\\b0(_*[0-7])*[lL]?\\b"},{begin:"\\b0[bB][01](_*[01])*[lL]?\\b"}],
+relevance:0};function be(e,n,t){return-1===t?"":e.replace(n,(a=>be(e,n,t-1)))}
+const me="[A-Za-z$_][0-9A-Za-z$_]*",pe=["as","in","of","if","for","while","finally","var","new","function","do","return","void","else","break","catch","instanceof","with","throw","case","default","try","switch","continue","typeof","delete","let","yield","const","class","debugger","async","await","static","import","from","export","extends","using"],_e=["true","false","null","undefined","NaN","Infinity"],he=["Object","Function","Boolean","Symbol","Math","Date","Number","BigInt","String","RegExp","Array","Float32Array","Float64Array","Int8Array","Uint8Array","Uint8ClampedArray","Int16Array","Int32Array","Uint16Array","Uint32Array","BigInt64Array","BigUint64Array","Set","Map","WeakSet","WeakMap","ArrayBuffer","SharedArrayBuffer","Atomics","DataView","JSON","Promise","Generator","GeneratorFunction","AsyncFunction","Reflect","Proxy","Intl","WebAssembly"],fe=["Error","EvalError","InternalError","RangeError","ReferenceError","SyntaxError","TypeError","URIError"],Ee=["setInterval","setTimeout","clearInterval","clearTimeout","require","exports","eval","isFinite","isNaN","parseFloat","parseInt","decodeURI","decodeURIComponent","encodeURI","encodeURIComponent","escape","unescape"],ye=["arguments","this","super","console","window","document","localStorage","sessionStorage","module","global"],we=[].concat(Ee,he,fe)
+;function ve(e){const n=e.regex,t=me,a={begin:/<[A-Za-z0-9\\._:-]+/,
+end:/\/[A-Za-z0-9\\._:-]+>|\/>/,isTrulyOpeningTag:(e,n)=>{
+const t=e[0].length+e.index,a=e.input[t]
+;if("<"===a||","===a)return void n.ignoreMatch();let i
+;">"===a&&(((e,{after:n})=>{const t="</"+e[0].slice(1)
+;return-1!==e.input.indexOf(t,n)})(e,{after:t})||n.ignoreMatch())
+;const r=e.input.substring(t)
+;((i=r.match(/^\s*=/))||(i=r.match(/^\s+extends\s+/))&&0===i.index)&&n.ignoreMatch()
+}},i={$pattern:me,keyword:pe,literal:_e,built_in:we,"variable.language":ye
+},r="[0-9](_?[0-9])*",s=`\\.(${r})`,o="0|[1-9](_?[0-9])*|0[0-7]*[89][0-9]*",l={
+className:"number",variants:[{
+begin:`(\\b(${o})((${s})|\\.)?|(${s}))[eE][+-]?(${r})\\b`},{
+begin:`\\b(${o})\\b((${s})\\b|\\.)?|(${s})\\b`},{
+begin:"\\b(0|[1-9](_?[0-9])*)n\\b"},{
+begin:"\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*n?\\b"},{
+begin:"\\b0[bB][0-1](_?[0-1])*n?\\b"},{begin:"\\b0[oO][0-7](_?[0-7])*n?\\b"},{
+begin:"\\b0[0-7]+n?\\b"}],relevance:0},c={className:"subst",begin:"\\$\\{",
+end:"\\}",keywords:i,contains:[]},d={begin:".?html`",end:"",starts:{end:"`",
+returnEnd:!1,contains:[e.BACKSLASH_ESCAPE,c],subLanguage:"xml"}},g={
+begin:".?css`",end:"",starts:{end:"`",returnEnd:!1,
+contains:[e.BACKSLASH_ESCAPE,c],subLanguage:"css"}},u={begin:".?gql`",end:"",
+starts:{end:"`",returnEnd:!1,contains:[e.BACKSLASH_ESCAPE,c],
+subLanguage:"graphql"}},b={className:"string",begin:"`",end:"`",
+contains:[e.BACKSLASH_ESCAPE,c]},m={className:"comment",
+variants:[e.COMMENT(/\/\*\*(?!\/)/,"\\*/",{relevance:0,contains:[{
+begin:"(?=@[A-Za-z]+)",relevance:0,contains:[{className:"doctag",
+begin:"@[A-Za-z]+"},{className:"type",begin:"\\{",end:"\\}",excludeEnd:!0,
+excludeBegin:!0,relevance:0},{className:"variable",begin:t+"(?=\\s*(-)|$)",
+endsParent:!0,relevance:0},{begin:/(?=[^\n])\s/,relevance:0}]}]
+}),e.C_BLOCK_COMMENT_MODE,e.C_LINE_COMMENT_MODE]
+},p=[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,d,g,u,b,{match:/\$\d+/},l]
+;c.contains=p.concat({begin:/\{/,end:/\}/,keywords:i,contains:["self"].concat(p)
+});const _=[].concat(m,c.contains),h=_.concat([{begin:/(\s*)\(/,end:/\)/,
+keywords:i,contains:["self"].concat(_)}]),f={className:"params",begin:/(\s*)\(/,
+end:/\)/,excludeBegin:!0,excludeEnd:!0,keywords:i,contains:h},E={variants:[{
+match:[/class/,/\s+/,t,/\s+/,/extends/,/\s+/,n.concat(t,"(",n.concat(/\./,t),")*")],
+scope:{1:"keyword",3:"title.class",5:"keyword",7:"title.class.inherited"}},{
+match:[/class/,/\s+/,t],scope:{1:"keyword",3:"title.class"}}]},y={relevance:0,
+match:n.either(/\bJSON/,/\b[A-Z][a-z]+([A-Z][a-z]*|\d)*/,/\b[A-Z]{2,}([A-Z][a-z]+|\d)+([A-Z][a-z]*)*/,/\b[A-Z]{2,}[a-z]+([A-Z][a-z]+|\d)*([A-Z][a-z]*)*/),
+className:"title.class",keywords:{_:[...he,...fe]}},w={variants:[{
+match:[/function/,/\s+/,t,/(?=\s*\()/]},{match:[/function/,/\s*(?=\()/]}],
+className:{1:"keyword",3:"title.function"},label:"func.def",contains:[f],
+illegal:/%/},v={
+match:n.concat(/\b/,(N=[...Ee,"super","import"].map((e=>e+"\\s*\\(")),
+n.concat("(?!",N.join("|"),")")),t,n.lookahead(/\s*\(/)),
+className:"title.function",relevance:0};var N;const k={
+begin:n.concat(/\./,n.lookahead(n.concat(t,/(?![0-9A-Za-z$_(])/))),end:t,
+excludeBegin:!0,keywords:"prototype",className:"property",relevance:0},x={
+match:[/get|set/,/\s+/,t,/(?=\()/],className:{1:"keyword",3:"title.function"},
+contains:[{begin:/\(\)/},f]
+},O="(\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)|"+e.UNDERSCORE_IDENT_RE+")\\s*=>",M={
+match:[/const|var|let/,/\s+/,t,/\s*/,/=\s*/,/(async\s*)?/,n.lookahead(O)],
+keywords:"async",className:{1:"keyword",3:"title.function"},contains:[f]}
+;return{name:"JavaScript",aliases:["js","jsx","mjs","cjs"],keywords:i,exports:{
+PARAMS_CONTAINS:h,CLASS_REFERENCE:y},illegal:/#(?![$_A-z])/,
+contains:[e.SHEBANG({label:"shebang",binary:"node",relevance:5}),{
+label:"use_strict",className:"meta",relevance:10,
+begin:/^\s*['"]use (strict|asm)['"]/
+},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,d,g,u,b,m,{match:/\$\d+/},l,y,{
+scope:"attr",match:t+n.lookahead(":"),relevance:0},M,{
+begin:"("+e.RE_STARTERS_RE+"|\\b(case|return|throw)\\b)\\s*",
+keywords:"return throw case",relevance:0,contains:[m,e.REGEXP_MODE,{
+className:"function",begin:O,returnBegin:!0,end:"\\s*=>",contains:[{
+className:"params",variants:[{begin:e.UNDERSCORE_IDENT_RE,relevance:0},{
+className:null,begin:/\(\s*\)/,skip:!0},{begin:/(\s*)\(/,end:/\)/,
+excludeBegin:!0,excludeEnd:!0,keywords:i,contains:h}]}]},{begin:/,/,relevance:0
+},{match:/\s+/,relevance:0},{variants:[{begin:"<>",end:"</>"},{
+match:/<[A-Za-z0-9\\._:-]+\s*\/>/},{begin:a.begin,
+"on:begin":a.isTrulyOpeningTag,end:a.end}],subLanguage:"xml",contains:[{
+begin:a.begin,end:a.end,skip:!0,contains:["self"]}]}]},w,{
+beginKeywords:"while if switch catch for"},{
+begin:"\\b(?!function)"+e.UNDERSCORE_IDENT_RE+"\\([^()]*(\\([^()]*(\\([^()]*\\)[^()]*)*\\)[^()]*)*\\)\\s*\\{",
+returnBegin:!0,label:"func.def",contains:[f,e.inherit(e.TITLE_MODE,{begin:t,
+className:"title.function"})]},{match:/\.\.\./,relevance:0},k,{match:"\\$"+t,
+relevance:0},{match:[/\bconstructor(?=\s*\()/],className:{1:"title.function"},
+contains:[f]},v,{relevance:0,match:/\b[A-Z][A-Z_0-9]+\b/,
+className:"variable.constant"},E,x,{match:/\$[(.]/}]}}
+const Ne=e=>b(/\b/,e,/\w$/.test(e)?/\b/:/\B/),ke=["Protocol","Type"].map(Ne),xe=["init","self"].map(Ne),Oe=["Any","Self"],Me=["actor","any","associatedtype","async","await",/as\?/,/as!/,"as","borrowing","break","case","catch","class","consume","consuming","continue","convenience","copy","default","defer","deinit","didSet","distributed","do","dynamic","each","else","enum","extension","fallthrough",/fileprivate\(set\)/,"fileprivate","final","for","func","get","guard","if","import","indirect","infix",/init\?/,/init!/,"inout",/internal\(set\)/,"internal","in","is","isolated","nonisolated","lazy","let","macro","mutating","nonmutating",/open\(set\)/,"open","operator","optional","override","package","postfix","precedencegroup","prefix",/private\(set\)/,"private","protocol",/public\(set\)/,"public","repeat","required","rethrows","return","set","some","static","struct","subscript","super","switch","throws","throw",/try\?/,/try!/,"try","typealias",/unowned\(safe\)/,/unowned\(unsafe\)/,"unowned","var","weak","where","while","willSet"],Ae=["false","nil","true"],Se=["assignment","associativity","higherThan","left","lowerThan","none","right"],Ce=["#colorLiteral","#column","#dsohandle","#else","#elseif","#endif","#error","#file","#fileID","#fileLiteral","#filePath","#function","#if","#imageLiteral","#keyPath","#line","#selector","#sourceLocation","#warning"],Te=["abs","all","any","assert","assertionFailure","debugPrint","dump","fatalError","getVaList","isKnownUniquelyReferenced","max","min","numericCast","pointwiseMax","pointwiseMin","precondition","preconditionFailure","print","readLine","repeatElement","sequence","stride","swap","swift_unboxFromSwiftValueWithType","transcode","type","unsafeBitCast","unsafeDowncast","withExtendedLifetime","withUnsafeMutablePointer","withUnsafePointer","withVaList","withoutActuallyEscaping","zip"],Re=m(/[/=\-+!*%<>&|^~?]/,/[\u00A1-\u00A7]/,/[\u00A9\u00AB]/,/[\u00AC\u00AE]/,/[\u00B0\u00B1]/,/[\u00B6\u00BB\u00BF\u00D7\u00F7]/,/[\u2016-\u2017]/,/[\u2020-\u2027]/,/[\u2030-\u203E]/,/[\u2041-\u2053]/,/[\u2055-\u205E]/,/[\u2190-\u23FF]/,/[\u2500-\u2775]/,/[\u2794-\u2BFF]/,/[\u2E00-\u2E7F]/,/[\u3001-\u3003]/,/[\u3008-\u3020]/,/[\u3030]/),De=m(Re,/[\u0300-\u036F]/,/[\u1DC0-\u1DFF]/,/[\u20D0-\u20FF]/,/[\uFE00-\uFE0F]/,/[\uFE20-\uFE2F]/),Ie=b(Re,De,"*"),Le=m(/[a-zA-Z_]/,/[\u00A8\u00AA\u00AD\u00AF\u00B2-\u00B5\u00B7-\u00BA]/,/[\u00BC-\u00BE\u00C0-\u00D6\u00D8-\u00F6\u00F8-\u00FF]/,/[\u0100-\u02FF\u0370-\u167F\u1681-\u180D\u180F-\u1DBF]/,/[\u1E00-\u1FFF]/,/[\u200B-\u200D\u202A-\u202E\u203F-\u2040\u2054\u2060-\u206F]/,/[\u2070-\u20CF\u2100-\u218F\u2460-\u24FF\u2776-\u2793]/,/[\u2C00-\u2DFF\u2E80-\u2FFF]/,/[\u3004-\u3007\u3021-\u302F\u3031-\u303F\u3040-\uD7FF]/,/[\uF900-\uFD3D\uFD40-\uFDCF\uFDF0-\uFE1F\uFE30-\uFE44]/,/[\uFE47-\uFEFE\uFF00-\uFFFD]/),Be=m(Le,/\d/,/[\u0300-\u036F\u1DC0-\u1DFF\u20D0-\u20FF\uFE20-\uFE2F]/),$e=b(Le,Be,"*"),Fe=b(/[A-Z]/,Be,"*"),ze=["attached","autoclosure",b(/convention\(/,m("swift","block","c"),/\)/),"discardableResult","dynamicCallable","dynamicMemberLookup","escaping","freestanding","frozen","GKInspectable","IBAction","IBDesignable","IBInspectable","IBOutlet","IBSegueAction","inlinable","main","nonobjc","NSApplicationMain","NSCopying","NSManaged",b(/objc\(/,$e,/\)/),"objc","objcMembers","propertyWrapper","requires_stored_property_inits","resultBuilder","Sendable","testable","UIApplicationMain","unchecked","unknown","usableFromInline","warn_unqualified_access"],je=["iOS","iOSApplicationExtension","macOS","macOSApplicationExtension","macCatalyst","macCatalystApplicationExtension","watchOS","watchOSApplicationExtension","tvOS","tvOSApplicationExtension","swift"]
+;var Ue=Object.freeze({__proto__:null,grmr_bash:e=>{const n=e.regex,t={},a={
+begin:/\$\{/,end:/\}/,contains:["self",{begin:/:-/,contains:[t]}]}
+;Object.assign(t,{className:"variable",variants:[{
+begin:n.concat(/\$[\w\d#@][\w\d_]*/,"(?![\\w\\d])(?![$])")},a]});const i={
+className:"subst",begin:/\$\(/,end:/\)/,contains:[e.BACKSLASH_ESCAPE]
+},r=e.inherit(e.COMMENT(),{match:[/(^|\s)/,/#.*$/],scope:{2:"comment"}}),s={
+begin:/<<-?\s*(?=\w+)/,starts:{contains:[e.END_SAME_AS_BEGIN({begin:/(\w+)/,
+end:/(\w+)/,className:"string"})]}},o={className:"string",begin:/"/,end:/"/,
+contains:[e.BACKSLASH_ESCAPE,t,i]};i.contains.push(o);const l={begin:/\$?\(\(/,
+end:/\)\)/,contains:[{begin:/\d+#[0-9a-f]+/,className:"number"},e.NUMBER_MODE,t]
+},c=e.SHEBANG({binary:"(fish|bash|zsh|sh|csh|ksh|tcsh|dash|scsh)",relevance:10
+}),d={className:"function",begin:/\w[\w\d_]*\s*\(\s*\)\s*\{/,returnBegin:!0,
+contains:[e.inherit(e.TITLE_MODE,{begin:/\w[\w\d_]*/})],relevance:0};return{
+name:"Bash",aliases:["sh","zsh"],keywords:{$pattern:/\b[a-z][a-z0-9._-]+\b/,
+keyword:["if","then","else","elif","fi","time","for","while","until","in","do","done","case","esac","coproc","function","select"],
+literal:["true","false"],
+built_in:["break","cd","continue","eval","exec","exit","export","getopts","hash","pwd","readonly","return","shift","test","times","trap","umask","unset","alias","bind","builtin","caller","command","declare","echo","enable","help","let","local","logout","mapfile","printf","read","readarray","source","sudo","type","typeset","ulimit","unalias","set","shopt","autoload","bg","bindkey","bye","cap","chdir","clone","comparguments","compcall","compctl","compdescribe","compfiles","compgroups","compquote","comptags","comptry","compvalues","dirs","disable","disown","echotc","echoti","emulate","fc","fg","float","functions","getcap","getln","history","integer","jobs","kill","limit","log","noglob","popd","print","pushd","pushln","rehash","sched","setcap","setopt","stat","suspend","ttyctl","unfunction","unhash","unlimit","unsetopt","vared","wait","whence","where","which","zcompile","zformat","zftp","zle","zmodload","zparseopts","zprof","zpty","zregexparse","zsocket","zstyle","ztcp","chcon","chgrp","chown","chmod","cp","dd","df","dir","dircolors","ln","ls","mkdir","mkfifo","mknod","mktemp","mv","realpath","rm","rmdir","shred","sync","touch","truncate","vdir","b2sum","base32","base64","cat","cksum","comm","csplit","cut","expand","fmt","fold","head","join","md5sum","nl","numfmt","od","paste","ptx","pr","sha1sum","sha224sum","sha256sum","sha384sum","sha512sum","shuf","sort","split","sum","tac","tail","tr","tsort","unexpand","uniq","wc","arch","basename","chroot","date","dirname","du","echo","env","expr","factor","groups","hostid","id","link","logname","nice","nohup","nproc","pathchk","pinky","printenv","printf","pwd","readlink","runcon","seq","sleep","stat","stdbuf","stty","tee","test","timeout","tty","uname","unlink","uptime","users","who","whoami","yes"]
+},contains:[c,e.SHEBANG(),d,l,r,s,{match:/(\/[a-z._-]+)+/},o,{match:/\\"/},{
+className:"string",begin:/'/,end:/'/},{match:/\\'/},t]}},grmr_c:e=>{
+const n=e.regex,t=e.COMMENT("//","$",{contains:[{begin:/\\\n/}]
+}),a="decltype\\(auto\\)",i="[a-zA-Z_]\\w*::",r="("+a+"|"+n.optional(i)+"[a-zA-Z_]\\w*"+n.optional("<[^<>]+>")+")",s={
+className:"type",variants:[{begin:"\\b[a-z\\d_]*_t\\b"},{
+match:/\batomic_[a-z]{3,6}\b/}]},o={className:"string",variants:[{
+begin:'(u8?|U|L)?"',end:'"',illegal:"\\n",contains:[e.BACKSLASH_ESCAPE]},{
+begin:"(u8?|U|L)?'(\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4,8}|[0-7]{3}|\\S)|.)",
+end:"'",illegal:"."},e.END_SAME_AS_BEGIN({
+begin:/(?:u8?|U|L)?R"([^()\\ ]{0,16})\(/,end:/\)([^()\\ ]{0,16})"/})]},l={
+className:"number",variants:[{match:/\b(0b[01']+)/},{
+match:/(-?)\b([\d']+(\.[\d']*)?|\.[\d']+)((ll|LL|l|L)(u|U)?|(u|U)(ll|LL|l|L)?|f|F|b|B)/
+},{
+match:/(-?)\b(0[xX][a-fA-F0-9]+(?:'[a-fA-F0-9]+)*(?:\.[a-fA-F0-9]*(?:'[a-fA-F0-9]*)*)?(?:[pP][-+]?[0-9]+)?(l|L)?(u|U)?)/
+},{match:/(-?)\b\d+(?:'\d+)*(?:\.\d*(?:'\d*)*)?(?:[eE][-+]?\d+)?/}],relevance:0
+},c={className:"meta",begin:/#\s*[a-z]+\b/,end:/$/,keywords:{
+keyword:"if else elif endif define undef warning error line pragma _Pragma ifdef ifndef elifdef elifndef include"
+},contains:[{begin:/\\\n/,relevance:0},e.inherit(o,{className:"string"}),{
+className:"string",begin:/<.*?>/},t,e.C_BLOCK_COMMENT_MODE]},d={
+className:"title",begin:n.optional(i)+e.IDENT_RE,relevance:0
+},g=n.optional(i)+e.IDENT_RE+"\\s*\\(",u={
+keyword:["asm","auto","break","case","continue","default","do","else","enum","extern","for","fortran","goto","if","inline","register","restrict","return","sizeof","typeof","typeof_unqual","struct","switch","typedef","union","volatile","while","_Alignas","_Alignof","_Atomic","_Generic","_Noreturn","_Static_assert","_Thread_local","alignas","alignof","noreturn","static_assert","thread_local","_Pragma"],
+type:["float","double","signed","unsigned","int","short","long","char","void","_Bool","_BitInt","_Complex","_Imaginary","_Decimal32","_Decimal64","_Decimal96","_Decimal128","_Decimal64x","_Decimal128x","_Float16","_Float32","_Float64","_Float128","_Float32x","_Float64x","_Float128x","const","static","constexpr","complex","bool","imaginary"],
+literal:"true false NULL",
+built_in:"std string wstring cin cout cerr clog stdin stdout stderr stringstream istringstream ostringstream auto_ptr deque list queue stack vector map set pair bitset multiset multimap unordered_set unordered_map unordered_multiset unordered_multimap priority_queue make_pair array shared_ptr abort terminate abs acos asin atan2 atan calloc ceil cosh cos exit exp fabs floor fmod fprintf fputs free frexp fscanf future isalnum isalpha iscntrl isdigit isgraph islower isprint ispunct isspace isupper isxdigit tolower toupper labs ldexp log10 log malloc realloc memchr memcmp memcpy memset modf pow printf putchar puts scanf sinh sin snprintf sprintf sqrt sscanf strcat strchr strcmp strcpy strcspn strlen strncat strncmp strncpy strpbrk strrchr strspn strstr tanh tan vfprintf vprintf vsprintf endl initializer_list unique_ptr"
+},b=[c,s,t,e.C_BLOCK_COMMENT_MODE,l,o],m={variants:[{begin:/=/,end:/;/},{
+begin:/\(/,end:/\)/},{beginKeywords:"new throw return else",end:/;/}],
+keywords:u,contains:b.concat([{begin:/\(/,end:/\)/,keywords:u,
+contains:b.concat(["self"]),relevance:0}]),relevance:0},p={
+begin:"("+r+"[\\*&\\s]+)+"+g,returnBegin:!0,end:/[{;=]/,excludeEnd:!0,
+keywords:u,illegal:/[^\w\s\*&:<>.]/,contains:[{begin:a,keywords:u,relevance:0},{
+begin:g,returnBegin:!0,contains:[e.inherit(d,{className:"title.function"})],
+relevance:0},{relevance:0,match:/,/},{className:"params",begin:/\(/,end:/\)/,
+keywords:u,relevance:0,contains:[t,e.C_BLOCK_COMMENT_MODE,o,l,s,{begin:/\(/,
+end:/\)/,keywords:u,relevance:0,contains:["self",t,e.C_BLOCK_COMMENT_MODE,o,l,s]
+}]},s,t,e.C_BLOCK_COMMENT_MODE,c]};return{name:"C",aliases:["h"],keywords:u,
+disableAutodetect:!0,illegal:"</",contains:[].concat(m,p,b,[c,{
+begin:e.IDENT_RE+"::",keywords:u},{className:"class",
+beginKeywords:"enum class struct union",end:/[{;:<>=]/,contains:[{
+beginKeywords:"final class struct"},e.TITLE_MODE]}]),exports:{preprocessor:c,
+strings:o,keywords:u}}},grmr_cpp:e=>{const n=e.regex,t=e.COMMENT("//","$",{
+contains:[{begin:/\\\n/}]
+}),a="decltype\\(auto\\)",i="[a-zA-Z_]\\w*::",r="(?!struct)("+a+"|"+n.optional(i)+"[a-zA-Z_]\\w*"+n.optional("<[^<>]+>")+")",s={
+className:"type",begin:"\\b[a-z\\d_]*_t\\b"},o={className:"string",variants:[{
+begin:'(u8?|U|L)?"',end:'"',illegal:"\\n",contains:[e.BACKSLASH_ESCAPE]},{
+begin:"(u8?|U|L)?'(\\\\(x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4,8}|[0-7]{3}|\\S)|.)",
+end:"'",illegal:"."},e.END_SAME_AS_BEGIN({
+begin:/(?:u8?|U|L)?R"([^()\\ ]{0,16})\(/,end:/\)([^()\\ ]{0,16})"/})]},l={
+className:"number",variants:[{
+begin:"[+-]?(?:(?:[0-9](?:'?[0-9])*\\.(?:[0-9](?:'?[0-9])*)?|\\.[0-9](?:'?[0-9])*)(?:[Ee][+-]?[0-9](?:'?[0-9])*)?|[0-9](?:'?[0-9])*[Ee][+-]?[0-9](?:'?[0-9])*|0[Xx](?:[0-9A-Fa-f](?:'?[0-9A-Fa-f])*(?:\\.(?:[0-9A-Fa-f](?:'?[0-9A-Fa-f])*)?)?|\\.[0-9A-Fa-f](?:'?[0-9A-Fa-f])*)[Pp][+-]?[0-9](?:'?[0-9])*)(?:[Ff](?:16|32|64|128)?|(BF|bf)16|[Ll]|)"
+},{
+begin:"[+-]?\\b(?:0[Bb][01](?:'?[01])*|0[Xx][0-9A-Fa-f](?:'?[0-9A-Fa-f])*|0(?:'?[0-7])*|[1-9](?:'?[0-9])*)(?:[Uu](?:LL?|ll?)|[Uu][Zz]?|(?:LL?|ll?)[Uu]?|[Zz][Uu]|)"
+}],relevance:0},c={className:"meta",begin:/#\s*[a-z]+\b/,end:/$/,keywords:{
+keyword:"if else elif endif define undef warning error line pragma _Pragma ifdef ifndef include"
+},contains:[{begin:/\\\n/,relevance:0},e.inherit(o,{className:"string"}),{
+className:"string",begin:/<.*?>/},t,e.C_BLOCK_COMMENT_MODE]},d={
+className:"title",begin:n.optional(i)+e.IDENT_RE,relevance:0
+},g=n.optional(i)+e.IDENT_RE+"\\s*\\(",u={
+type:["bool","char","char16_t","char32_t","char8_t","double","float","int","long","short","void","wchar_t","unsigned","signed","const","static"],
+keyword:["alignas","alignof","and","and_eq","asm","atomic_cancel","atomic_commit","atomic_noexcept","auto","bitand","bitor","break","case","catch","class","co_await","co_return","co_yield","compl","concept","const_cast|10","consteval","constexpr","constinit","continue","decltype","default","delete","do","dynamic_cast|10","else","enum","explicit","export","extern","false","final","for","friend","goto","if","import","inline","module","mutable","namespace","new","noexcept","not","not_eq","nullptr","operator","or","or_eq","override","private","protected","public","reflexpr","register","reinterpret_cast|10","requires","return","sizeof","static_assert","static_cast|10","struct","switch","synchronized","template","this","thread_local","throw","transaction_safe","transaction_safe_dynamic","true","try","typedef","typeid","typename","union","using","virtual","volatile","while","xor","xor_eq"],
+literal:["NULL","false","nullopt","nullptr","true"],built_in:["_Pragma"],
+_type_hints:["any","auto_ptr","barrier","binary_semaphore","bitset","complex","condition_variable","condition_variable_any","counting_semaphore","deque","false_type","flat_map","flat_set","future","imaginary","initializer_list","istringstream","jthread","latch","lock_guard","multimap","multiset","mutex","optional","ostringstream","packaged_task","pair","promise","priority_queue","queue","recursive_mutex","recursive_timed_mutex","scoped_lock","set","shared_future","shared_lock","shared_mutex","shared_timed_mutex","shared_ptr","stack","string_view","stringstream","timed_mutex","thread","true_type","tuple","unique_lock","unique_ptr","unordered_map","unordered_multimap","unordered_multiset","unordered_set","variant","vector","weak_ptr","wstring","wstring_view"]
+},b={className:"function.dispatch",relevance:0,keywords:{
+_hint:["abort","abs","acos","apply","as_const","asin","atan","atan2","calloc","ceil","cerr","cin","clog","cos","cosh","cout","declval","endl","exchange","exit","exp","fabs","floor","fmod","forward","fprintf","fputs","free","frexp","fscanf","future","invoke","isalnum","isalpha","iscntrl","isdigit","isgraph","islower","isprint","ispunct","isspace","isupper","isxdigit","labs","launder","ldexp","log","log10","make_pair","make_shared","make_shared_for_overwrite","make_tuple","make_unique","malloc","memchr","memcmp","memcpy","memset","modf","move","pow","printf","putchar","puts","realloc","scanf","sin","sinh","snprintf","sprintf","sqrt","sscanf","std","stderr","stdin","stdout","strcat","strchr","strcmp","strcpy","strcspn","strlen","strncat","strncmp","strncpy","strpbrk","strrchr","strspn","strstr","swap","tan","tanh","terminate","to_underlying","tolower","toupper","vfprintf","visit","vprintf","vsprintf"]
+},
+begin:n.concat(/\b/,/(?!decltype)/,/(?!if)/,/(?!for)/,/(?!switch)/,/(?!while)/,e.IDENT_RE,n.lookahead(/(<[^<>]+>|)\s*\(/))
+},m=[b,c,s,t,e.C_BLOCK_COMMENT_MODE,l,o],p={variants:[{begin:/=/,end:/;/},{
+begin:/\(/,end:/\)/},{beginKeywords:"new throw return else",end:/;/}],
+keywords:u,contains:m.concat([{begin:/\(/,end:/\)/,keywords:u,
+contains:m.concat(["self"]),relevance:0}]),relevance:0},_={className:"function",
+begin:"("+r+"[\\*&\\s]+)+"+g,returnBegin:!0,end:/[{;=]/,excludeEnd:!0,
+keywords:u,illegal:/[^\w\s\*&:<>.]/,contains:[{begin:a,keywords:u,relevance:0},{
+begin:g,returnBegin:!0,contains:[d],relevance:0},{begin:/::/,relevance:0},{
+begin:/:/,endsWithParent:!0,contains:[o,l]},{relevance:0,match:/,/},{
+className:"params",begin:/\(/,end:/\)/,keywords:u,relevance:0,
+contains:[t,e.C_BLOCK_COMMENT_MODE,o,l,s,{begin:/\(/,end:/\)/,keywords:u,
+relevance:0,contains:["self",t,e.C_BLOCK_COMMENT_MODE,o,l,s]}]
+},s,t,e.C_BLOCK_COMMENT_MODE,c]};return{name:"C++",
+aliases:["cc","c++","h++","hpp","hh","hxx","cxx"],keywords:u,illegal:"</",
+classNameAliases:{"function.dispatch":"built_in"},
+contains:[].concat(p,_,b,m,[c,{
+begin:"\\b(deque|list|queue|priority_queue|pair|stack|vector|map|set|bitset|multiset|multimap|unordered_map|unordered_set|unordered_multiset|unordered_multimap|array|tuple|optional|variant|function|flat_map|flat_set)\\s*<(?!<)",
+end:">",keywords:u,contains:["self",s]},{begin:e.IDENT_RE+"::",keywords:u},{
+match:[/\b(?:enum(?:\s+(?:class|struct))?|class|struct|union)/,/\s+/,/\w+/],
+className:{1:"keyword",3:"title.class"}}])}},grmr_csharp:e=>{const n={
+keyword:["abstract","as","base","break","case","catch","class","const","continue","do","else","event","explicit","extern","finally","fixed","for","foreach","goto","if","implicit","in","interface","internal","is","lock","namespace","new","operator","out","override","params","private","protected","public","readonly","record","ref","return","scoped","sealed","sizeof","stackalloc","static","struct","switch","this","throw","try","typeof","unchecked","unsafe","using","virtual","void","volatile","while"].concat(["add","alias","and","ascending","args","async","await","by","descending","dynamic","equals","file","from","get","global","group","init","into","join","let","nameof","not","notnull","on","or","orderby","partial","record","remove","required","scoped","select","set","unmanaged","value|0","var","when","where","with","yield"]),
+built_in:["bool","byte","char","decimal","delegate","double","dynamic","enum","float","int","long","nint","nuint","object","sbyte","short","string","ulong","uint","ushort"],
+literal:["default","false","null","true"]},t=e.inherit(e.TITLE_MODE,{
+begin:"[a-zA-Z](\\.?\\w)*"}),a={className:"number",variants:[{
+begin:"\\b(0b[01']+)"},{
+begin:"(-?)\\b([\\d']+(\\.[\\d']*)?|\\.[\\d']+)(u|U|l|L|ul|UL|f|F|b|B)"},{
+begin:"(-?)(\\b0[xX][a-fA-F0-9']+|(\\b[\\d']+(\\.[\\d']*)?|\\.[\\d']+)([eE][-+]?[\\d']+)?)"
+}],relevance:0},i={className:"string",begin:'@"',end:'"',contains:[{begin:'""'}]
+},r=e.inherit(i,{illegal:/\n/}),s={className:"subst",begin:/\{/,end:/\}/,
+keywords:n},o=e.inherit(s,{illegal:/\n/}),l={className:"string",begin:/\$"/,
+end:'"',illegal:/\n/,contains:[{begin:/\{\{/},{begin:/\}\}/
+},e.BACKSLASH_ESCAPE,o]},c={className:"string",begin:/\$@"/,end:'"',contains:[{
+begin:/\{\{/},{begin:/\}\}/},{begin:'""'},s]},d=e.inherit(c,{illegal:/\n/,
+contains:[{begin:/\{\{/},{begin:/\}\}/},{begin:'""'},o]})
+;s.contains=[c,l,i,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,a,e.C_BLOCK_COMMENT_MODE],
+o.contains=[d,l,r,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,a,e.inherit(e.C_BLOCK_COMMENT_MODE,{
+illegal:/\n/})];const g={variants:[{className:"string",
+begin:/"""("*)(?!")(.|\n)*?"""\1/,relevance:1
+},c,l,i,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]},u={begin:"<",end:">",
+contains:[{beginKeywords:"in out"},t]
+},b=e.IDENT_RE+"(<"+e.IDENT_RE+"(\\s*,\\s*"+e.IDENT_RE+")*>)?(\\[\\])?",m={
+begin:"@"+e.IDENT_RE,relevance:0};return{name:"C#",aliases:["cs","c#"],
+keywords:n,illegal:/::/,contains:[e.COMMENT("///","$",{returnBegin:!0,
+contains:[{className:"doctag",variants:[{begin:"///",relevance:0},{
+begin:"\x3c!--|--\x3e"},{begin:"</?",end:">"}]}]
+}),e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{className:"meta",begin:"#",
+end:"$",keywords:{
+keyword:"if else elif endif define undef warning error line region endregion pragma checksum"
+}},g,a,{beginKeywords:"class interface",relevance:0,end:/[{;=]/,
+illegal:/[^\s:,]/,contains:[{beginKeywords:"where class"
+},t,u,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{beginKeywords:"namespace",
+relevance:0,end:/[{;=]/,illegal:/[^\s:]/,
+contains:[t,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{
+beginKeywords:"record",relevance:0,end:/[{;=]/,illegal:/[^\s:]/,
+contains:[t,u,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{className:"meta",
+begin:"^\\s*\\[(?=[\\w])",excludeBegin:!0,end:"\\]",excludeEnd:!0,contains:[{
+className:"string",begin:/"/,end:/"/}]},{
+beginKeywords:"new return throw await else",relevance:0},{className:"function",
+begin:"("+b+"\\s+)+"+e.IDENT_RE+"\\s*(<[^=]+>\\s*)?\\(",returnBegin:!0,
+end:/\s*[{;=]/,excludeEnd:!0,keywords:n,contains:[{
+beginKeywords:"public private protected static internal protected abstract async extern override unsafe virtual new sealed partial",
+relevance:0},{begin:e.IDENT_RE+"\\s*(<[^=]+>\\s*)?\\(",returnBegin:!0,
+contains:[e.TITLE_MODE,u],relevance:0},{match:/\(\)/},{className:"params",
+begin:/\(/,end:/\)/,excludeBegin:!0,excludeEnd:!0,keywords:n,relevance:0,
+contains:[g,a,e.C_BLOCK_COMMENT_MODE]
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},m]}},grmr_css:e=>{
+const n=e.regex,t=te(e),a=[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE];return{
+name:"CSS",case_insensitive:!0,illegal:/[=|'\$]/,keywords:{
+keyframePosition:"from to"},classNameAliases:{keyframePosition:"selector-tag"},
+contains:[t.BLOCK_COMMENT,{begin:/-(webkit|moz|ms|o)-(?=[a-z])/
+},t.CSS_NUMBER_MODE,{className:"selector-id",begin:/#[A-Za-z0-9_-]+/,relevance:0
+},{className:"selector-class",begin:"\\.[a-zA-Z-][a-zA-Z0-9_-]*",relevance:0
+},t.ATTRIBUTE_SELECTOR_MODE,{className:"selector-pseudo",variants:[{
+begin:":("+re.join("|")+")"},{begin:":(:)?("+se.join("|")+")"}]
+},t.CSS_VARIABLE,{className:"attribute",begin:"\\b("+oe.join("|")+")\\b"},{
+begin:/:/,end:/[;}{]/,
+contains:[t.BLOCK_COMMENT,t.HEXCOLOR,t.IMPORTANT,t.CSS_NUMBER_MODE,...a,{
+begin:/(url|data-uri)\(/,end:/\)/,relevance:0,keywords:{built_in:"url data-uri"
+},contains:[...a,{className:"string",begin:/[^)]/,endsWithParent:!0,
+excludeEnd:!0}]},t.FUNCTION_DISPATCH]},{begin:n.lookahead(/@/),end:"[{;]",
+relevance:0,illegal:/:/,contains:[{className:"keyword",begin:/@-?\w[\w]*(-\w+)*/
+},{begin:/\s/,endsWithParent:!0,excludeEnd:!0,relevance:0,keywords:{
+$pattern:/[a-z-]+/,keyword:"and or not only",attribute:ie.join(" ")},contains:[{
+begin:/[a-z-]+(?=:)/,className:"attribute"},...a,t.CSS_NUMBER_MODE]}]},{
+className:"selector-tag",begin:"\\b("+ae.join("|")+")\\b"}]}},grmr_diff:e=>{
+const n=e.regex;return{name:"Diff",aliases:["patch"],contains:[{
+className:"meta",relevance:10,
+match:n.either(/^@@ +-\d+,\d+ +\+\d+,\d+ +@@/,/^\*\*\* +\d+,\d+ +\*\*\*\*$/,/^--- +\d+,\d+ +----$/)
+},{className:"comment",variants:[{
+begin:n.either(/Index: /,/^index/,/={3,}/,/^-{3}/,/^\*{3} /,/^\+{3}/,/^diff --git/),
+end:/$/},{match:/^\*{15}$/}]},{className:"addition",begin:/^\+/,end:/$/},{
+className:"deletion",begin:/^-/,end:/$/},{className:"addition",begin:/^!/,
+end:/$/}]}},grmr_go:e=>{const n={
+keyword:["break","case","chan","const","continue","default","defer","else","fallthrough","for","func","go","goto","if","import","interface","map","package","range","return","select","struct","switch","type","var"],
+type:["bool","byte","complex64","complex128","error","float32","float64","int8","int16","int32","int64","string","uint8","uint16","uint32","uint64","int","uint","uintptr","rune"],
+literal:["true","false","iota","nil"],
+built_in:["append","cap","close","complex","copy","imag","len","make","new","panic","print","println","real","recover","delete"]
+};return{name:"Go",aliases:["golang"],keywords:n,illegal:"</",
+contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{className:"string",
+variants:[e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,{begin:"`",end:"`"}]},{
+className:"number",variants:[{
+match:/-?\b0[xX]\.[a-fA-F0-9](_?[a-fA-F0-9])*[pP][+-]?\d(_?\d)*i?/,relevance:0
+},{
+match:/-?\b0[xX](_?[a-fA-F0-9])+((\.([a-fA-F0-9](_?[a-fA-F0-9])*)?)?[pP][+-]?\d(_?\d)*)?i?/,
+relevance:0},{match:/-?\b0[oO](_?[0-7])*i?/,relevance:0},{
+match:/-?\.\d(_?\d)*([eE][+-]?\d(_?\d)*)?i?/,relevance:0},{
+match:/-?\b\d(_?\d)*(\.(\d(_?\d)*)?)?([eE][+-]?\d(_?\d)*)?i?/,relevance:0}]},{
+begin:/:=/},{className:"function",beginKeywords:"func",end:"\\s*(\\{|$)",
+excludeEnd:!0,contains:[e.TITLE_MODE,{className:"params",begin:/\(/,end:/\)/,
+endsParent:!0,keywords:n,illegal:/["']/}]}]}},grmr_graphql:e=>{const n=e.regex
+;return{name:"GraphQL",aliases:["gql"],case_insensitive:!0,disableAutodetect:!1,
+keywords:{
+keyword:["query","mutation","subscription","type","input","schema","directive","interface","union","scalar","fragment","enum","on"],
+literal:["true","false","null"]},
+contains:[e.HASH_COMMENT_MODE,e.QUOTE_STRING_MODE,e.NUMBER_MODE,{
+scope:"punctuation",match:/[.]{3}/,relevance:0},{scope:"punctuation",
+begin:/[\!\(\)\:\=\[\]\{\|\}]{1}/,relevance:0},{scope:"variable",begin:/\$/,
+end:/\W/,excludeEnd:!0,relevance:0},{scope:"meta",match:/@\w+/,excludeEnd:!0},{
+scope:"symbol",begin:n.concat(/[_A-Za-z][_0-9A-Za-z]*/,n.lookahead(/\s*:/)),
+relevance:0}],illegal:[/[;<']/,/BEGIN/]}},grmr_ini:e=>{const n=e.regex,t={
+className:"number",relevance:0,variants:[{begin:/([+-]+)?[\d]+_[\d_]+/},{
+begin:e.NUMBER_RE}]},a=e.COMMENT();a.variants=[{begin:/;/,end:/$/},{begin:/#/,
+end:/$/}];const i={className:"variable",variants:[{begin:/\$[\w\d"][\w\d_]*/},{
+begin:/\$\{(.*?)\}/}]},r={className:"literal",
+begin:/\bon|off|true|false|yes|no\b/},s={className:"string",
+contains:[e.BACKSLASH_ESCAPE],variants:[{begin:"'''",end:"'''",relevance:10},{
+begin:'"""',end:'"""',relevance:10},{begin:'"',end:'"'},{begin:"'",end:"'"}]
+},o={begin:/\[/,end:/\]/,contains:[a,r,i,s,t,"self"],relevance:0
+},l=n.either(/[A-Za-z0-9_-]+/,/"(\\"|[^"])*"/,/'[^']*'/);return{
+name:"TOML, also INI",aliases:["toml"],case_insensitive:!0,illegal:/\S/,
+contains:[a,{className:"section",begin:/\[+/,end:/\]+/},{
+begin:n.concat(l,"(\\s*\\.\\s*",l,")*",n.lookahead(/\s*=\s*[^#\s]/)),
+className:"attr",starts:{end:/$/,contains:[a,o,r,i,s,t]}}]}},grmr_java:e=>{
+const n=e.regex,t="[\xc0-\u02b8a-zA-Z_$][\xc0-\u02b8a-zA-Z_$0-9]*",a=t+be("(?:<"+t+"~~~(?:\\s*,\\s*"+t+"~~~)*>)?",/~~~/g,2),i={
+keyword:["synchronized","abstract","private","var","static","if","const ","for","while","strictfp","finally","protected","import","native","final","void","enum","else","break","transient","catch","instanceof","volatile","case","assert","package","default","public","try","switch","continue","throws","protected","public","private","module","requires","exports","do","sealed","yield","permits","goto","when"],
+literal:["false","true","null"],
+type:["char","boolean","long","float","int","byte","short","double"],
+built_in:["super","this"]},r={className:"meta",begin:"@"+t,contains:[{
+begin:/\(/,end:/\)/,contains:["self"]}]},s={className:"params",begin:/\(/,
+end:/\)/,keywords:i,relevance:0,contains:[e.C_BLOCK_COMMENT_MODE],endsParent:!0}
+;return{name:"Java",aliases:["jsp"],keywords:i,illegal:/<\/|#/,
+contains:[e.COMMENT("/\\*\\*","\\*/",{relevance:0,contains:[{begin:/\w+@/,
+relevance:0},{className:"doctag",begin:"@[A-Za-z]+"}]}),{
+begin:/import java\.[a-z]+\./,keywords:"import",relevance:2
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,{begin:/"""/,end:/"""/,
+className:"string",contains:[e.BACKSLASH_ESCAPE]
+},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,{
+match:[/\b(?:class|interface|enum|extends|implements|new)/,/\s+/,t],className:{
+1:"keyword",3:"title.class"}},{match:/non-sealed/,scope:"keyword"},{
+begin:[n.concat(/(?!else)/,t),/\s+/,t,/\s+/,/=(?!=)/],className:{1:"type",
+3:"variable",5:"operator"}},{begin:[/record/,/\s+/,t],className:{1:"keyword",
+3:"title.class"},contains:[s,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{
+beginKeywords:"new throw return else",relevance:0},{
+begin:["(?:"+a+"\\s+)",e.UNDERSCORE_IDENT_RE,/\s*(?=\()/],className:{
+2:"title.function"},keywords:i,contains:[{className:"params",begin:/\(/,
+end:/\)/,keywords:i,relevance:0,
+contains:[r,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,ue,e.C_BLOCK_COMMENT_MODE]
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},ue,r]}},grmr_javascript:ve,
+grmr_json:e=>{const n=["true","false","null"],t={scope:"literal",
+beginKeywords:n.join(" ")};return{name:"JSON",aliases:["jsonc"],keywords:{
+literal:n},contains:[{className:"attr",begin:/"(\\.|[^\\"\r\n])*"(?=\s*:)/,
+relevance:1.01},{match:/[{}[\],:]/,className:"punctuation",relevance:0
+},e.QUOTE_STRING_MODE,t,e.C_NUMBER_MODE,e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE],
+illegal:"\\S"}},grmr_kotlin:e=>{const n={
+keyword:"abstract as val var vararg get set class object open private protected public noinline crossinline dynamic final enum if else do while for when throw try catch finally import package is in fun override companion reified inline lateinit init interface annotation data sealed internal infix operator out by constructor super tailrec where const inner suspend typealias external expect actual",
+built_in:"Byte Short Char Int Long Boolean Float Double Void Unit Nothing",
+literal:"true false null"},t={className:"symbol",begin:e.UNDERSCORE_IDENT_RE+"@"
+},a={className:"subst",begin:/\$\{/,end:/\}/,contains:[e.C_NUMBER_MODE]},i={
+className:"variable",begin:"\\$"+e.UNDERSCORE_IDENT_RE},r={className:"string",
+variants:[{begin:'"""',end:'"""(?=[^"])',contains:[i,a]},{begin:"'",end:"'",
+illegal:/\n/,contains:[e.BACKSLASH_ESCAPE]},{begin:'"',end:'"',illegal:/\n/,
+contains:[e.BACKSLASH_ESCAPE,i,a]}]};a.contains.push(r);const s={
+className:"meta",
+begin:"@(?:file|property|field|get|set|receiver|param|setparam|delegate)\\s*:(?:\\s*"+e.UNDERSCORE_IDENT_RE+")?"
+},o={className:"meta",begin:"@"+e.UNDERSCORE_IDENT_RE,contains:[{begin:/\(/,
+end:/\)/,contains:[e.inherit(r,{className:"string"}),"self"]}]
+},l=ue,c=e.COMMENT("/\\*","\\*/",{contains:[e.C_BLOCK_COMMENT_MODE]}),d={
+variants:[{className:"type",begin:e.UNDERSCORE_IDENT_RE},{begin:/\(/,end:/\)/,
+contains:[]}]},g=d;return g.variants[1].contains=[d],d.variants[1].contains=[g],
+{name:"Kotlin",aliases:["kt","kts"],keywords:n,
+contains:[e.COMMENT("/\\*\\*","\\*/",{relevance:0,contains:[{className:"doctag",
+begin:"@[A-Za-z]+"}]}),e.C_LINE_COMMENT_MODE,c,{className:"keyword",
+begin:/\b(break|continue|return|this)\b/,starts:{contains:[{className:"symbol",
+begin:/@\w+/}]}},t,s,o,{className:"function",beginKeywords:"fun",end:"[(]|$",
+returnBegin:!0,excludeEnd:!0,keywords:n,relevance:5,contains:[{
+begin:e.UNDERSCORE_IDENT_RE+"\\s*\\(",returnBegin:!0,relevance:0,
+contains:[e.UNDERSCORE_TITLE_MODE]},{className:"type",begin:/</,end:/>/,
+keywords:"reified",relevance:0},{className:"params",begin:/\(/,end:/\)/,
+endsParent:!0,keywords:n,relevance:0,contains:[{begin:/:/,end:/[=,\/]/,
+endsWithParent:!0,contains:[d,e.C_LINE_COMMENT_MODE,c],relevance:0
+},e.C_LINE_COMMENT_MODE,c,s,o,r,e.C_NUMBER_MODE]},c]},{
+begin:[/class|interface|trait/,/\s+/,e.UNDERSCORE_IDENT_RE],beginScope:{
+3:"title.class"},keywords:"class interface trait",end:/[:\{(]|$/,excludeEnd:!0,
+illegal:"extends implements",contains:[{
+beginKeywords:"public protected internal private constructor"
+},e.UNDERSCORE_TITLE_MODE,{className:"type",begin:/</,end:/>/,excludeBegin:!0,
+excludeEnd:!0,relevance:0},{className:"type",begin:/[,:]\s*/,end:/[<\(,){\s]|$/,
+excludeBegin:!0,returnEnd:!0},s,o]},r,{className:"meta",begin:"^#!/usr/bin/env",
+end:"$",illegal:"\n"},l]}},grmr_less:e=>{
+const n=te(e),t=le,a="[\\w-]+",i="("+a+"|@\\{"+a+"\\})",r=[],s=[],o=e=>({
+className:"string",begin:"~?"+e+".*?"+e}),l=(e,n,t)=>({className:e,begin:n,
+relevance:t}),c={$pattern:/[a-z-]+/,keyword:"and or not only",
+attribute:ie.join(" ")},d={begin:"\\(",end:"\\)",contains:s,keywords:c,
+relevance:0}
+;s.push(e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,o("'"),o('"'),n.CSS_NUMBER_MODE,{
+begin:"(url|data-uri)\\(",starts:{className:"string",end:"[\\)\\n]",
+excludeEnd:!0}
+},n.HEXCOLOR,d,l("variable","@@?"+a,10),l("variable","@\\{"+a+"\\}"),l("built_in","~?`[^`]*?`"),{
+className:"attribute",begin:a+"\\s*:",end:":",returnBegin:!0,excludeEnd:!0
+},n.IMPORTANT,{beginKeywords:"and not"},n.FUNCTION_DISPATCH);const g=s.concat({
+begin:/\{/,end:/\}/,contains:r}),u={beginKeywords:"when",endsWithParent:!0,
+contains:[{beginKeywords:"and not"}].concat(s)},b={begin:i+"\\s*:",
+returnBegin:!0,end:/[;}]/,relevance:0,contains:[{begin:/-(webkit|moz|ms|o)-/
+},n.CSS_VARIABLE,{className:"attribute",begin:"\\b("+oe.join("|")+")\\b",
+end:/(?=:)/,starts:{endsWithParent:!0,illegal:"[<=$]",relevance:0,contains:s}}]
+},m={className:"keyword",
+begin:"@(import|media|charset|font-face|(-[a-z]+-)?keyframes|supports|document|namespace|page|viewport|host)\\b",
+starts:{end:"[;{}]",keywords:c,returnEnd:!0,contains:s,relevance:0}},p={
+className:"variable",variants:[{begin:"@"+a+"\\s*:",relevance:15},{begin:"@"+a
+}],starts:{end:"[;}]",returnEnd:!0,contains:g}},_={variants:[{
+begin:"[\\.#:&\\[>]",end:"[;{}]"},{begin:i,end:/\{/}],returnBegin:!0,
+returnEnd:!0,illegal:"[<='$\"]",relevance:0,
+contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,u,l("keyword","all\\b"),l("variable","@\\{"+a+"\\}"),{
+begin:"\\b("+ae.join("|")+")\\b",className:"selector-tag"
+},n.CSS_NUMBER_MODE,l("selector-tag",i,0),l("selector-id","#"+i),l("selector-class","\\."+i,0),l("selector-tag","&",0),n.ATTRIBUTE_SELECTOR_MODE,{
+className:"selector-pseudo",begin:":("+re.join("|")+")"},{
+className:"selector-pseudo",begin:":(:)?("+se.join("|")+")"},{begin:/\(/,
+end:/\)/,relevance:0,contains:g},{begin:"!important"},n.FUNCTION_DISPATCH]},h={
+begin:a+":(:)?"+`(${t.join("|")})`,returnBegin:!0,contains:[_]}
+;return r.push(e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,m,p,h,b,_,u,n.FUNCTION_DISPATCH),
+{name:"Less",case_insensitive:!0,illegal:"[=>'/<($\"]",contains:r}},
+grmr_lua:e=>{const n="\\[=*\\[",t="\\]=*\\]",a={begin:n,end:t,contains:["self"]
+},i=[e.COMMENT("--(?!"+n+")","$"),e.COMMENT("--"+n,t,{contains:[a],relevance:10
+})];return{name:"Lua",aliases:["pluto"],keywords:{
+$pattern:e.UNDERSCORE_IDENT_RE,literal:"true false nil",
+keyword:"and break do else elseif end for goto if in local not or repeat return then until while",
+built_in:"_G _ENV _VERSION __index __newindex __mode __call __metatable __tostring __len __gc __add __sub __mul __div __mod __pow __concat __unm __eq __lt __le assert collectgarbage dofile error getfenv getmetatable ipairs load loadfile loadstring module next pairs pcall print rawequal rawget rawset require select setfenv setmetatable tonumber tostring type unpack xpcall arg self coroutine resume yield status wrap create running debug getupvalue debug sethook getmetatable gethook setmetatable setlocal traceback setfenv getinfo setupvalue getlocal getregistry getfenv io lines write close flush open output type read stderr stdin input stdout popen tmpfile math log max acos huge ldexp pi cos tanh pow deg tan cosh sinh random randomseed frexp ceil floor rad abs sqrt modf asin min mod fmod log10 atan2 exp sin atan os exit setlocale date getenv difftime remove time clock tmpname rename execute package preload loadlib loaded loaders cpath config path seeall string sub upper len gfind rep find match char dump gmatch reverse byte format gsub lower table setn insert getn foreachi maxn foreach concat sort remove"
+},contains:i.concat([{className:"function",beginKeywords:"function",end:"\\)",
+contains:[e.inherit(e.TITLE_MODE,{
+begin:"([_a-zA-Z]\\w*\\.)*([_a-zA-Z]\\w*:)?[_a-zA-Z]\\w*"}),{className:"params",
+begin:"\\(",endsWithParent:!0,contains:i}].concat(i)
+},e.C_NUMBER_MODE,e.APOS_STRING_MODE,e.QUOTE_STRING_MODE,{className:"string",
+begin:n,end:t,contains:[a],relevance:5}])}},grmr_makefile:e=>{const n={
+className:"variable",variants:[{begin:"\\$\\("+e.UNDERSCORE_IDENT_RE+"\\)",
+contains:[e.BACKSLASH_ESCAPE]},{begin:/\$[@%<?\^\+\*]/}]},t={className:"string",
+begin:/"/,end:/"/,contains:[e.BACKSLASH_ESCAPE,n]},a={className:"variable",
+begin:/\$\([\w-]+\s/,end:/\)/,keywords:{
+built_in:"subst patsubst strip findstring filter filter-out sort word wordlist firstword lastword dir notdir suffix basename addsuffix addprefix join wildcard realpath abspath error warning shell origin flavor foreach if or and call eval file value"
+},contains:[n,t]},i={begin:"^"+e.UNDERSCORE_IDENT_RE+"\\s*(?=[:+?]?=)"},r={
+className:"section",begin:/^[^\s]+:/,end:/$/,contains:[n]};return{
+name:"Makefile",aliases:["mk","mak","make"],keywords:{$pattern:/[\w-]+/,
+keyword:"define endef undefine ifdef ifndef ifeq ifneq else endif include -include sinclude override export unexport private vpath"
+},contains:[e.HASH_COMMENT_MODE,n,t,a,i,{className:"meta",begin:/^\.PHONY:/,
+end:/$/,keywords:{$pattern:/[\.\w]+/,keyword:".PHONY"}},r]}},grmr_markdown:e=>{
+const n={begin:/<\/?[A-Za-z_]/,end:">",subLanguage:"xml",relevance:0},t={
+variants:[{begin:/\[.+?\]\[.*?\]/,relevance:0},{
+begin:/\[.+?\]\(((data|javascript|mailto):|(?:http|ftp)s?:\/\/).*?\)/,
+relevance:2},{
+begin:e.regex.concat(/\[.+?\]\(/,/[A-Za-z][A-Za-z0-9+.-]*/,/:\/\/.*?\)/),
+relevance:2},{begin:/\[.+?\]\([./?&#].*?\)/,relevance:1},{
+begin:/\[.*?\]\(.*?\)/,relevance:0}],returnBegin:!0,contains:[{match:/\[(?=\])/
+},{className:"string",relevance:0,begin:"\\[",end:"\\]",excludeBegin:!0,
+returnEnd:!0},{className:"link",relevance:0,begin:"\\]\\(",end:"\\)",
+excludeBegin:!0,excludeEnd:!0},{className:"symbol",relevance:0,begin:"\\]\\[",
+end:"\\]",excludeBegin:!0,excludeEnd:!0}]},a={className:"strong",contains:[],
+variants:[{begin:/_{2}(?!\s)/,end:/_{2}/},{begin:/\*{2}(?!\s)/,end:/\*{2}/}]
+},i={className:"emphasis",contains:[],variants:[{begin:/\*(?![*\s])/,end:/\*/},{
+begin:/_(?![_\s])/,end:/_/,relevance:0}]},r=e.inherit(a,{contains:[]
+}),s=e.inherit(i,{contains:[]});a.contains.push(s),i.contains.push(r)
+;let o=[n,t];return[a,i,r,s].forEach((e=>{e.contains=e.contains.concat(o)
+})),o=o.concat(a,i),{name:"Markdown",aliases:["md","mkdown","mkd"],contains:[{
+className:"section",variants:[{begin:"^#{1,6}",end:"$",contains:o},{
+begin:"(?=^.+?\\n[=-]{2,}$)",contains:[{begin:"^[=-]*$"},{begin:"^",end:"\\n",
+contains:o}]}]},n,{className:"bullet",begin:"^[ \t]*([*+-]|(\\d+\\.))(?=\\s+)",
+end:"\\s+",excludeEnd:!0},a,i,{className:"quote",begin:"^>\\s+",contains:o,
+end:"$"},{className:"code",variants:[{begin:"(`{3,})[^`](.|\\n)*?\\1`*[ ]*"},{
+begin:"(~{3,})[^~](.|\\n)*?\\1~*[ ]*"},{begin:"```",end:"```+[ ]*$"},{
+begin:"~~~",end:"~~~+[ ]*$"},{begin:"`.+?`"},{begin:"(?=^( {4}|\\t))",
+contains:[{begin:"^( {4}|\\t)",end:"(\\n)$"}],relevance:0}]},{
+begin:"^[-\\*]{3,}",end:"$"},t,{begin:/^\[[^\n]+\]:/,returnBegin:!0,contains:[{
+className:"symbol",begin:/\[/,end:/\]/,excludeBegin:!0,excludeEnd:!0},{
+className:"link",begin:/:\s*/,end:/$/,excludeBegin:!0}]},{scope:"literal",
+match:/&([a-zA-Z0-9]+|#[0-9]{1,7}|#[Xx][0-9a-fA-F]{1,6});/}]}},
+grmr_objectivec:e=>{const n=/[a-zA-Z@][a-zA-Z0-9_]*/,t={$pattern:n,
+keyword:["@interface","@class","@protocol","@implementation"]};return{
+name:"Objective-C",aliases:["mm","objc","obj-c","obj-c++","objective-c++"],
+keywords:{"variable.language":["this","super"],$pattern:n,
+keyword:["while","export","sizeof","typedef","const","struct","for","union","volatile","static","mutable","if","do","return","goto","enum","else","break","extern","asm","case","default","register","explicit","typename","switch","continue","inline","readonly","assign","readwrite","self","@synchronized","id","typeof","nonatomic","IBOutlet","IBAction","strong","weak","copy","in","out","inout","bycopy","byref","oneway","__strong","__weak","__block","__autoreleasing","@private","@protected","@public","@try","@property","@end","@throw","@catch","@finally","@autoreleasepool","@synthesize","@dynamic","@selector","@optional","@required","@encode","@package","@import","@defs","@compatibility_alias","__bridge","__bridge_transfer","__bridge_retained","__bridge_retain","__covariant","__contravariant","__kindof","_Nonnull","_Nullable","_Null_unspecified","__FUNCTION__","__PRETTY_FUNCTION__","__attribute__","getter","setter","retain","unsafe_unretained","nonnull","nullable","null_unspecified","null_resettable","class","instancetype","NS_DESIGNATED_INITIALIZER","NS_UNAVAILABLE","NS_REQUIRES_SUPER","NS_RETURNS_INNER_POINTER","NS_INLINE","NS_AVAILABLE","NS_DEPRECATED","NS_ENUM","NS_OPTIONS","NS_SWIFT_UNAVAILABLE","NS_ASSUME_NONNULL_BEGIN","NS_ASSUME_NONNULL_END","NS_REFINED_FOR_SWIFT","NS_SWIFT_NAME","NS_SWIFT_NOTHROW","NS_DURING","NS_HANDLER","NS_ENDHANDLER","NS_VALUERETURN","NS_VOIDRETURN"],
+literal:["false","true","FALSE","TRUE","nil","YES","NO","NULL"],
+built_in:["dispatch_once_t","dispatch_queue_t","dispatch_sync","dispatch_async","dispatch_once"],
+type:["int","float","char","unsigned","signed","short","long","double","wchar_t","unichar","void","bool","BOOL","id|0","_Bool"]
+},illegal:"</",contains:[{className:"built_in",
+begin:"\\b(AV|CA|CF|CG|CI|CL|CM|CN|CT|MK|MP|MTK|MTL|NS|SCN|SK|UI|WK|XC)\\w+"
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,e.C_NUMBER_MODE,e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,{
+className:"string",variants:[{begin:'@"',end:'"',illegal:"\\n",
+contains:[e.BACKSLASH_ESCAPE]}]},{className:"meta",begin:/#\s*[a-z]+\b/,end:/$/,
+keywords:{
+keyword:"if else elif endif define undef warning error line pragma ifdef ifndef include"
+},contains:[{begin:/\\\n/,relevance:0},e.inherit(e.QUOTE_STRING_MODE,{
+className:"string"}),{className:"string",begin:/<.*?>/,end:/$/,illegal:"\\n"
+},e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE]},{className:"class",
+begin:"("+t.keyword.join("|")+")\\b",end:/(\{|$)/,excludeEnd:!0,keywords:t,
+contains:[e.UNDERSCORE_TITLE_MODE]},{begin:"\\."+e.UNDERSCORE_IDENT_RE,
+relevance:0}]}},grmr_perl:e=>{const n=e.regex,t=/[dualxmsipngr]{0,12}/,a={
+$pattern:/[\w.]+/,
+keyword:"abs accept alarm and atan2 bind binmode bless break caller chdir chmod chomp chop chown chr chroot class close closedir connect continue cos crypt dbmclose dbmopen defined delete die do dump each else elsif endgrent endhostent endnetent endprotoent endpwent endservent eof eval exec exists exit exp fcntl field fileno flock for foreach fork format formline getc getgrent getgrgid getgrnam gethostbyaddr gethostbyname gethostent getlogin getnetbyaddr getnetbyname getnetent getpeername getpgrp getpriority getprotobyname getprotobynumber getprotoent getpwent getpwnam getpwuid getservbyname getservbyport getservent getsockname getsockopt given glob gmtime goto grep gt hex if index int ioctl join keys kill last lc lcfirst length link listen local localtime log lstat lt ma map method mkdir msgctl msgget msgrcv msgsnd my ne next no not oct open opendir or ord our pack package pipe pop pos print printf prototype push q|0 qq quotemeta qw qx rand read readdir readline readlink readpipe recv redo ref rename require reset return reverse rewinddir rindex rmdir say scalar seek seekdir select semctl semget semop send setgrent sethostent setnetent setpgrp setpriority setprotoent setpwent setservent setsockopt shift shmctl shmget shmread shmwrite shutdown sin sleep socket socketpair sort splice split sprintf sqrt srand stat state study sub substr symlink syscall sysopen sysread sysseek system syswrite tell telldir tie tied time times tr truncate uc ucfirst umask undef unless unlink unpack unshift untie until use utime values vec wait waitpid wantarray warn when while write x|0 xor y|0"
+},i={className:"subst",begin:"[$@]\\{",end:"\\}",keywords:a},r={begin:/->\{/,
+end:/\}/},s={scope:"attr",match:/\s+:\s*\w+(\s*\(.*?\))?/},o={scope:"variable",
+variants:[{begin:/\$\d/},{
+begin:n.concat(/[$%@](?!")(\^\w\b|#\w+(::\w+)*|\{\w+\}|\w+(::\w*)*)/,"(?![A-Za-z])(?![@$%])")
+},{begin:/[$%@](?!")[^\s\w{=]|\$=/,relevance:0}],contains:[s]},l={
+className:"number",variants:[{match:/0?\.[0-9][0-9_]+\b/},{
+match:/\bv?(0|[1-9][0-9_]*(\.[0-9_]+)?|[1-9][0-9_]*)\b/},{
+match:/\b0[0-7][0-7_]*\b/},{match:/\b0x[0-9a-fA-F][0-9a-fA-F_]*\b/},{
+match:/\b0b[0-1][0-1_]*\b/}],relevance:0
+},c=[e.BACKSLASH_ESCAPE,i,o],d=[/!/,/\//,/\|/,/\?/,/'/,/"/,/#/],g=(e,a,i="\\1")=>{
+const r="\\1"===i?i:n.concat(i,a)
+;return n.concat(n.concat("(?:",e,")"),a,/(?:\\.|[^\\\/])*?/,r,/(?:\\.|[^\\\/])*?/,i,t)
+},u=(e,a,i)=>n.concat(n.concat("(?:",e,")"),a,/(?:\\.|[^\\\/])*?/,i,t),b=[o,e.HASH_COMMENT_MODE,e.COMMENT(/^=\w/,/=cut/,{
+endsWithParent:!0}),r,{className:"string",contains:c,variants:[{
+begin:"q[qwxr]?\\s*\\(",end:"\\)",relevance:5},{begin:"q[qwxr]?\\s*\\[",
+end:"\\]",relevance:5},{begin:"q[qwxr]?\\s*\\{",end:"\\}",relevance:5},{
+begin:"q[qwxr]?\\s*\\|",end:"\\|",relevance:5},{begin:"q[qwxr]?\\s*<",end:">",
+relevance:5},{begin:"qw\\s+q",end:"q",relevance:5},{begin:"'",end:"'",
+contains:[e.BACKSLASH_ESCAPE]},{begin:'"',end:'"'},{begin:"`",end:"`",
+contains:[e.BACKSLASH_ESCAPE]},{begin:/\{\w+\}/,relevance:0},{
+begin:"-?\\w+\\s*=>",relevance:0}]},l,{
+begin:"(\\/\\/|"+e.RE_STARTERS_RE+"|\\b(split|return|print|reverse|grep)\\b)\\s*",
+keywords:"split return print reverse grep",relevance:0,
+contains:[e.HASH_COMMENT_MODE,{className:"regexp",variants:[{
+begin:g("s|tr|y",n.either(...d,{capture:!0}))},{begin:g("s|tr|y","\\(","\\)")},{
+begin:g("s|tr|y","\\[","\\]")},{begin:g("s|tr|y","\\{","\\}")}],relevance:2},{
+className:"regexp",variants:[{begin:/(m|qr)\/\//,relevance:0},{
+begin:u("(?:m|qr)?",/\//,/\//)},{begin:u("m|qr",n.either(...d,{capture:!0
+}),/\1/)},{begin:u("m|qr",/\(/,/\)/)},{begin:u("m|qr",/\[/,/\]/)},{
+begin:u("m|qr",/\{/,/\}/)}]}]},{className:"function",beginKeywords:"sub method",
+end:"(\\s*\\(.*?\\))?[;{]",excludeEnd:!0,relevance:5,contains:[e.TITLE_MODE,s]
+},{className:"class",beginKeywords:"class",end:"[;{]",excludeEnd:!0,relevance:5,
+contains:[e.TITLE_MODE,s,l]},{begin:"-\\w\\b",relevance:0},{begin:"^__DATA__$",
+end:"^__END__$",subLanguage:"mojolicious",contains:[{begin:"^@@.*",end:"$",
+className:"comment"}]}];return i.contains=b,r.contains=b,{name:"Perl",
+aliases:["pl","pm"],keywords:a,contains:b}},grmr_php:e=>{
+const n=e.regex,t=/(?![A-Za-z0-9])(?![$])/,a=n.concat(/[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/,t),i=n.concat(/(\\?[A-Z][a-z0-9_\x7f-\xff]+|\\?[A-Z]+(?=[A-Z][a-z0-9_\x7f-\xff])){1,}/,t),r=n.concat(/[A-Z]+/,t),s={
+scope:"variable",match:"\\$+"+a},o={scope:"subst",variants:[{begin:/\$\w+/},{
+begin:/\{\$/,end:/\}/}]},l=e.inherit(e.APOS_STRING_MODE,{illegal:null
+}),c="[ \t\n]",d={scope:"string",variants:[e.inherit(e.QUOTE_STRING_MODE,{
+illegal:null,contains:e.QUOTE_STRING_MODE.contains.concat(o)}),l,{
+begin:/<<<[ \t]*(?:(\w+)|"(\w+)")\n/,end:/[ \t]*(\w+)\b/,
+contains:e.QUOTE_STRING_MODE.contains.concat(o),"on:begin":(e,n)=>{
+n.data._beginMatch=e[1]||e[2]},"on:end":(e,n)=>{
+n.data._beginMatch!==e[1]&&n.ignoreMatch()}},e.END_SAME_AS_BEGIN({
+begin:/<<<[ \t]*'(\w+)'\n/,end:/[ \t]*(\w+)\b/})]},g={scope:"number",variants:[{
+begin:"\\b0[bB][01]+(?:_[01]+)*\\b"},{begin:"\\b0[oO][0-7]+(?:_[0-7]+)*\\b"},{
+begin:"\\b0[xX][\\da-fA-F]+(?:_[\\da-fA-F]+)*\\b"},{
+begin:"(?:\\b\\d+(?:_\\d+)*(\\.(?:\\d+(?:_\\d+)*))?|\\B\\.\\d+)(?:[eE][+-]?\\d+)?"
+}],relevance:0
+},u=["false","null","true"],b=["__CLASS__","__DIR__","__FILE__","__FUNCTION__","__COMPILER_HALT_OFFSET__","__LINE__","__METHOD__","__NAMESPACE__","__TRAIT__","die","echo","exit","include","include_once","print","require","require_once","array","abstract","and","as","binary","bool","boolean","break","callable","case","catch","class","clone","const","continue","declare","default","do","double","else","elseif","empty","enddeclare","endfor","endforeach","endif","endswitch","endwhile","enum","eval","extends","final","finally","float","for","foreach","from","global","goto","if","implements","instanceof","insteadof","int","integer","interface","isset","iterable","list","match|0","mixed","new","never","object","or","private","protected","public","readonly","real","return","string","switch","throw","trait","try","unset","use","var","void","while","xor","yield"],m=["Error|0","AppendIterator","ArgumentCountError","ArithmeticError","ArrayIterator","ArrayObject","AssertionError","BadFunctionCallException","BadMethodCallException","CachingIterator","CallbackFilterIterator","CompileError","Countable","DirectoryIterator","DivisionByZeroError","DomainException","EmptyIterator","ErrorException","Exception","FilesystemIterator","FilterIterator","GlobIterator","InfiniteIterator","InvalidArgumentException","IteratorIterator","LengthException","LimitIterator","LogicException","MultipleIterator","NoRewindIterator","OutOfBoundsException","OutOfRangeException","OuterIterator","OverflowException","ParentIterator","ParseError","RangeException","RecursiveArrayIterator","RecursiveCachingIterator","RecursiveCallbackFilterIterator","RecursiveDirectoryIterator","RecursiveFilterIterator","RecursiveIterator","RecursiveIteratorIterator","RecursiveRegexIterator","RecursiveTreeIterator","RegexIterator","RuntimeException","SeekableIterator","SplDoublyLinkedList","SplFileInfo","SplFileObject","SplFixedArray","SplHeap","SplMaxHeap","SplMinHeap","SplObjectStorage","SplObserver","SplPriorityQueue","SplQueue","SplStack","SplSubject","SplTempFileObject","TypeError","UnderflowException","UnexpectedValueException","UnhandledMatchError","ArrayAccess","BackedEnum","Closure","Fiber","Generator","Iterator","IteratorAggregate","Serializable","Stringable","Throwable","Traversable","UnitEnum","WeakReference","WeakMap","Directory","__PHP_Incomplete_Class","parent","php_user_filter","self","static","stdClass"],p={
+keyword:b,literal:(e=>{const n=[];return e.forEach((e=>{
+n.push(e),e.toLowerCase()===e?n.push(e.toUpperCase()):n.push(e.toLowerCase())
+})),n})(u),built_in:m},_=e=>e.map((e=>e.replace(/\|\d+$/,""))),h={variants:[{
+match:[/new/,n.concat(c,"+"),n.concat("(?!",_(m).join("\\b|"),"\\b)"),i],scope:{
+1:"keyword",4:"title.class"}}]},f=n.concat(a,"\\b(?!\\()"),E={variants:[{
+match:[n.concat(/::/,n.lookahead(/(?!class\b)/)),f],scope:{2:"variable.constant"
+}},{match:[/::/,/class/],scope:{2:"variable.language"}},{
+match:[i,n.concat(/::/,n.lookahead(/(?!class\b)/)),f],scope:{1:"title.class",
+3:"variable.constant"}},{match:[i,n.concat("::",n.lookahead(/(?!class\b)/))],
+scope:{1:"title.class"}},{match:[i,/::/,/class/],scope:{1:"title.class",
+3:"variable.language"}}]},y={scope:"attr",
+match:n.concat(a,n.lookahead(":"),n.lookahead(/(?!::)/))},w={relevance:0,
+begin:/\(/,end:/\)/,keywords:p,contains:[y,s,E,e.C_BLOCK_COMMENT_MODE,d,g,h]
+},v={relevance:0,
+match:[/\b/,n.concat("(?!fn\\b|function\\b|",_(b).join("\\b|"),"|",_(m).join("\\b|"),"\\b)"),a,n.concat(c,"*"),n.lookahead(/(?=\()/)],
+scope:{3:"title.function.invoke"},contains:[w]};w.contains.push(v)
+;const N=[y,E,e.C_BLOCK_COMMENT_MODE,d,g,h],k={
+begin:n.concat(/#\[\s*\\?/,n.either(i,r)),beginScope:"meta",end:/]/,
+endScope:"meta",keywords:{literal:u,keyword:["new","array"]},contains:[{
+begin:/\[/,end:/]/,keywords:{literal:u,keyword:["new","array"]},
+contains:["self",...N]},...N,{scope:"meta",variants:[{match:i},{match:r}]}]}
+;return{case_insensitive:!1,keywords:p,
+contains:[k,e.HASH_COMMENT_MODE,e.COMMENT("//","$"),e.COMMENT("/\\*","\\*/",{
+contains:[{scope:"doctag",match:"@[A-Za-z]+"}]}),{match:/__halt_compiler\(\);/,
+keywords:"__halt_compiler",starts:{scope:"comment",end:e.MATCH_NOTHING_RE,
+contains:[{match:/\?>/,scope:"meta",endsParent:!0}]}},{scope:"meta",variants:[{
+begin:/<\?php/,relevance:10},{begin:/<\?=/},{begin:/<\?/,relevance:.1},{
+begin:/\?>/}]},{scope:"variable.language",match:/\$this\b/},s,v,E,{
+match:[/const/,/\s/,a],scope:{1:"keyword",3:"variable.constant"}},h,{
+scope:"function",relevance:0,beginKeywords:"fn function",end:/[;{]/,
+excludeEnd:!0,illegal:"[$%\\[]",contains:[{beginKeywords:"use"
+},e.UNDERSCORE_TITLE_MODE,{begin:"=>",endsParent:!0},{scope:"params",
+begin:"\\(",end:"\\)",excludeBegin:!0,excludeEnd:!0,keywords:p,
+contains:["self",k,s,E,e.C_BLOCK_COMMENT_MODE,d,g]}]},{scope:"class",variants:[{
+beginKeywords:"enum",illegal:/[($"]/},{beginKeywords:"class interface trait",
+illegal:/[:($"]/}],relevance:0,end:/\{/,excludeEnd:!0,contains:[{
+beginKeywords:"extends implements"},e.UNDERSCORE_TITLE_MODE]},{
+beginKeywords:"namespace",relevance:0,end:";",illegal:/[.']/,
+contains:[e.inherit(e.UNDERSCORE_TITLE_MODE,{scope:"title.class"})]},{
+beginKeywords:"use",relevance:0,end:";",contains:[{
+match:/\b(as|const|function)\b/,scope:"keyword"},e.UNDERSCORE_TITLE_MODE]},d,g]}
+},grmr_php_template:e=>({name:"PHP template",subLanguage:"xml",contains:[{
+begin:/<\?(php|=)?/,end:/\?>/,subLanguage:"php",contains:[{begin:"/\\*",
+end:"\\*/",skip:!0},{begin:'b"',end:'"',skip:!0},{begin:"b'",end:"'",skip:!0
+},e.inherit(e.APOS_STRING_MODE,{illegal:null,className:null,contains:null,
+skip:!0}),e.inherit(e.QUOTE_STRING_MODE,{illegal:null,className:null,
+contains:null,skip:!0})]}]}),grmr_plaintext:e=>({name:"Plain text",
+aliases:["text","txt"],disableAutodetect:!0}),grmr_python:e=>{
+const n=e.regex,t=/[\p{XID_Start}_]\p{XID_Continue}*/u,a=["and","as","assert","async","await","break","case","class","continue","def","del","elif","else","except","finally","for","from","global","if","import","in","is","lambda","match","nonlocal|10","not","or","pass","raise","return","try","while","with","yield"],i={
+$pattern:/[A-Za-z]\w+|__\w+__/,keyword:a,
+built_in:["__import__","abs","all","any","ascii","bin","bool","breakpoint","bytearray","bytes","callable","chr","classmethod","compile","complex","delattr","dict","dir","divmod","enumerate","eval","exec","filter","float","format","frozenset","getattr","globals","hasattr","hash","help","hex","id","input","int","isinstance","issubclass","iter","len","list","locals","map","max","memoryview","min","next","object","oct","open","ord","pow","print","property","range","repr","reversed","round","set","setattr","slice","sorted","staticmethod","str","sum","super","tuple","type","vars","zip"],
+literal:["__debug__","Ellipsis","False","None","NotImplemented","True"],
+type:["Any","Callable","Coroutine","Dict","List","Literal","Generic","Optional","Sequence","Set","Tuple","Type","Union"]
+},r={className:"meta",begin:/^(>>>|\.\.\.) /},s={className:"subst",begin:/\{/,
+end:/\}/,keywords:i,illegal:/#/},o={begin:/\{\{/,relevance:0},l={
+className:"string",contains:[e.BACKSLASH_ESCAPE],variants:[{
+begin:/([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?'''/,end:/'''/,
+contains:[e.BACKSLASH_ESCAPE,r],relevance:10},{
+begin:/([uU]|[bB]|[rR]|[bB][rR]|[rR][bB])?"""/,end:/"""/,
+contains:[e.BACKSLASH_ESCAPE,r],relevance:10},{
+begin:/([fF][rR]|[rR][fF]|[fF])'''/,end:/'''/,
+contains:[e.BACKSLASH_ESCAPE,r,o,s]},{begin:/([fF][rR]|[rR][fF]|[fF])"""/,
+end:/"""/,contains:[e.BACKSLASH_ESCAPE,r,o,s]},{begin:/([uU]|[rR])'/,end:/'/,
+relevance:10},{begin:/([uU]|[rR])"/,end:/"/,relevance:10},{
+begin:/([bB]|[bB][rR]|[rR][bB])'/,end:/'/},{begin:/([bB]|[bB][rR]|[rR][bB])"/,
+end:/"/},{begin:/([fF][rR]|[rR][fF]|[fF])'/,end:/'/,
+contains:[e.BACKSLASH_ESCAPE,o,s]},{begin:/([fF][rR]|[rR][fF]|[fF])"/,end:/"/,
+contains:[e.BACKSLASH_ESCAPE,o,s]},e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]
+},c="[0-9](_?[0-9])*",d=`(\\b(${c}))?\\.(${c})|\\b(${c})\\.`,g="\\b|"+a.join("|"),u={
+className:"number",relevance:0,variants:[{
+begin:`(\\b(${c})|(${d}))[eE][+-]?(${c})[jJ]?(?=${g})`},{begin:`(${d})[jJ]?`},{
+begin:`\\b([1-9](_?[0-9])*|0+(_?0)*)[lLjJ]?(?=${g})`},{
+begin:`\\b0[bB](_?[01])+[lL]?(?=${g})`},{begin:`\\b0[oO](_?[0-7])+[lL]?(?=${g})`
+},{begin:`\\b0[xX](_?[0-9a-fA-F])+[lL]?(?=${g})`},{begin:`\\b(${c})[jJ](?=${g})`
+}]},b={className:"comment",begin:n.lookahead(/# type:/),end:/$/,keywords:i,
+contains:[{begin:/# type:/},{begin:/#/,end:/\b\B/,endsWithParent:!0}]},m={
+className:"params",variants:[{className:"",begin:/\(\s*\)/,skip:!0},{begin:/\(/,
+end:/\)/,excludeBegin:!0,excludeEnd:!0,keywords:i,
+contains:["self",r,u,l,e.HASH_COMMENT_MODE]}]};return s.contains=[l,u,r],{
+name:"Python",aliases:["py","gyp","ipython"],unicodeRegex:!0,keywords:i,
+illegal:/(<\/|\?)|=>/,contains:[r,u,{scope:"variable.language",match:/\bself\b/
+},{beginKeywords:"if",relevance:0},{match:/\bor\b/,scope:"keyword"
+},l,b,e.HASH_COMMENT_MODE,{match:[/\bdef/,/\s+/,t],scope:{1:"keyword",
+3:"title.function"},contains:[m]},{variants:[{
+match:[/\bclass/,/\s+/,t,/\s*/,/\(\s*/,t,/\s*\)/]},{match:[/\bclass/,/\s+/,t]}],
+scope:{1:"keyword",3:"title.class",6:"title.class.inherited"}},{
+className:"meta",begin:/^[\t ]*@/,end:/(?=#)|$/,contains:[u,m,l]}]}},
+grmr_python_repl:e=>({aliases:["pycon"],contains:[{className:"meta.prompt",
+starts:{end:/ |$/,starts:{end:"$",subLanguage:"python"}},variants:[{
+begin:/^>>>(?=[ ]|$)/},{begin:/^\.\.\.(?=[ ]|$)/}]}]}),grmr_r:e=>{
+const n=e.regex,t=/(?:(?:[a-zA-Z]|\.[._a-zA-Z])[._a-zA-Z0-9]*)|\.(?!\d)/,a=n.either(/0[xX][0-9a-fA-F]+\.[0-9a-fA-F]*[pP][+-]?\d+i?/,/0[xX][0-9a-fA-F]+(?:[pP][+-]?\d+)?[Li]?/,/(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?[Li]?/),i=/[=!<>:]=|\|\||&&|:::?|<-|<<-|->>|->|\|>|[-+*\/?!$&|:<=>@^~]|\*\*/,r=n.either(/[()]/,/[{}]/,/\[\[/,/[[\]]/,/\\/,/,/)
+;return{name:"R",keywords:{$pattern:t,
+keyword:"function if in break next repeat else for while",
+literal:"NULL NA TRUE FALSE Inf NaN NA_integer_|10 NA_real_|10 NA_character_|10 NA_complex_|10",
+built_in:"LETTERS letters month.abb month.name pi T F abs acos acosh all any anyNA Arg as.call as.character as.complex as.double as.environment as.integer as.logical as.null.default as.numeric as.raw asin asinh atan atanh attr attributes baseenv browser c call ceiling class Conj cos cosh cospi cummax cummin cumprod cumsum digamma dim dimnames emptyenv exp expression floor forceAndCall gamma gc.time globalenv Im interactive invisible is.array is.atomic is.call is.character is.complex is.double is.environment is.expression is.finite is.function is.infinite is.integer is.language is.list is.logical is.matrix is.na is.name is.nan is.null is.numeric is.object is.pairlist is.raw is.recursive is.single is.symbol lazyLoadDBfetch length lgamma list log max min missing Mod names nargs nzchar oldClass on.exit pos.to.env proc.time prod quote range Re rep retracemem return round seq_along seq_len seq.int sign signif sin sinh sinpi sqrt standardGeneric substitute sum switch tan tanh tanpi tracemem trigamma trunc unclass untracemem UseMethod xtfrm"
+},contains:[e.COMMENT(/#'/,/$/,{contains:[{scope:"doctag",match:/@examples/,
+starts:{end:n.lookahead(n.either(/\n^#'\s*(?=@[a-zA-Z]+)/,/\n^(?!#')/)),
+endsParent:!0}},{scope:"doctag",begin:"@param",end:/$/,contains:[{
+scope:"variable",variants:[{match:t},{match:/`(?:\\.|[^`\\])+`/}],endsParent:!0
+}]},{scope:"doctag",match:/@[a-zA-Z]+/},{scope:"keyword",match:/\\[a-zA-Z]+/}]
+}),e.HASH_COMMENT_MODE,{scope:"string",contains:[e.BACKSLASH_ESCAPE],
+variants:[e.END_SAME_AS_BEGIN({begin:/[rR]"(-*)\(/,end:/\)(-*)"/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]"(-*)\{/,end:/\}(-*)"/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]"(-*)\[/,end:/\](-*)"/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]'(-*)\(/,end:/\)(-*)'/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]'(-*)\{/,end:/\}(-*)'/
+}),e.END_SAME_AS_BEGIN({begin:/[rR]'(-*)\[/,end:/\](-*)'/}),{begin:'"',end:'"',
+relevance:0},{begin:"'",end:"'",relevance:0}]},{relevance:0,variants:[{scope:{
+1:"operator",2:"number"},match:[i,a]},{scope:{1:"operator",2:"number"},
+match:[/%[^%]*%/,a]},{scope:{1:"punctuation",2:"number"},match:[r,a]},{scope:{
+2:"number"},match:[/[^a-zA-Z0-9._]|^/,a]}]},{scope:{3:"operator"},
+match:[t,/\s+/,/<-/,/\s+/]},{scope:"operator",relevance:0,variants:[{match:i},{
+match:/%[^%]*%/}]},{scope:"punctuation",relevance:0,match:r},{begin:"`",end:"`",
+contains:[{begin:/\\./}]}]}},grmr_ruby:e=>{
+const n=e.regex,t="([a-zA-Z_]\\w*[!?=]?|[-+~]@|<<|>>|=~|===?|<=>|[<>]=?|\\*\\*|[-/+%^&*~`|]|\\[\\]=?)",a=n.either(/\b([A-Z]+[a-z0-9]+)+/,/\b([A-Z]+[a-z0-9]+)+[A-Z]+/),i=n.concat(a,/(::\w+)*/),r={
+"variable.constant":["__FILE__","__LINE__","__ENCODING__"],
+"variable.language":["self","super"],
+keyword:["alias","and","begin","BEGIN","break","case","class","defined","do","else","elsif","end","END","ensure","for","if","in","module","next","not","or","redo","require","rescue","retry","return","then","undef","unless","until","when","while","yield","include","extend","prepend","public","private","protected","raise","throw"],
+built_in:["proc","lambda","attr_accessor","attr_reader","attr_writer","define_method","private_constant","module_function"],
+literal:["true","false","nil"]},s={className:"doctag",begin:"@[A-Za-z]+"},o={
+begin:"#<",end:">"},l=[e.COMMENT("#","$",{contains:[s]
+}),e.COMMENT("^=begin","^=end",{contains:[s],relevance:10
+}),e.COMMENT("^__END__",e.MATCH_NOTHING_RE)],c={className:"subst",begin:/#\{/,
+end:/\}/,keywords:r},d={className:"string",contains:[e.BACKSLASH_ESCAPE,c],
+variants:[{begin:/'/,end:/'/},{begin:/"/,end:/"/},{begin:/`/,end:/`/},{
+begin:/%[qQwWx]?\(/,end:/\)/},{begin:/%[qQwWx]?\[/,end:/\]/},{
+begin:/%[qQwWx]?\{/,end:/\}/},{begin:/%[qQwWx]?</,end:/>/},{begin:/%[qQwWx]?\//,
+end:/\//},{begin:/%[qQwWx]?%/,end:/%/},{begin:/%[qQwWx]?-/,end:/-/},{
+begin:/%[qQwWx]?\|/,end:/\|/},{begin:/\B\?(\\\d{1,3})/},{
+begin:/\B\?(\\x[A-Fa-f0-9]{1,2})/},{begin:/\B\?(\\u\{?[A-Fa-f0-9]{1,6}\}?)/},{
+begin:/\B\?(\\M-\\C-|\\M-\\c|\\c\\M-|\\M-|\\C-\\M-)[\x20-\x7e]/},{
+begin:/\B\?\\(c|C-)[\x20-\x7e]/},{begin:/\B\?\\?\S/},{
+begin:n.concat(/<<[-~]?'?/,n.lookahead(/(\w+)(?=\W)[^\n]*\n(?:[^\n]*\n)*?\s*\1\b/)),
+contains:[e.END_SAME_AS_BEGIN({begin:/(\w+)/,end:/(\w+)/,
+contains:[e.BACKSLASH_ESCAPE,c]})]}]},g="[0-9](_?[0-9])*",u={className:"number",
+relevance:0,variants:[{
+begin:`\\b([1-9](_?[0-9])*|0)(\\.(${g}))?([eE][+-]?(${g})|r)?i?\\b`},{
+begin:"\\b0[dD][0-9](_?[0-9])*r?i?\\b"},{begin:"\\b0[bB][0-1](_?[0-1])*r?i?\\b"
+},{begin:"\\b0[oO][0-7](_?[0-7])*r?i?\\b"},{
+begin:"\\b0[xX][0-9a-fA-F](_?[0-9a-fA-F])*r?i?\\b"},{
+begin:"\\b0(_?[0-7])+r?i?\\b"}]},b={variants:[{match:/\(\)/},{
+className:"params",begin:/\(/,end:/(?=\))/,excludeBegin:!0,endsParent:!0,
+keywords:r}]},m=[d,{variants:[{match:[/class\s+/,i,/\s+<\s+/,i]},{
+match:[/\b(class|module)\s+/,i]}],scope:{2:"title.class",
+4:"title.class.inherited"},keywords:r},{match:[/(include|extend)\s+/,i],scope:{
+2:"title.class"},keywords:r},{relevance:0,match:[i,/\.new[. (]/],scope:{
+1:"title.class"}},{relevance:0,match:/\b[A-Z][A-Z_0-9]+\b/,
+className:"variable.constant"},{relevance:0,match:a,scope:"title.class"},{
+match:[/def/,/\s+/,t],scope:{1:"keyword",3:"title.function"},contains:[b]},{
+begin:e.IDENT_RE+"::"},{className:"symbol",
+begin:e.UNDERSCORE_IDENT_RE+"(!|\\?)?:",relevance:0},{className:"symbol",
+begin:":(?!\\s)",contains:[d,{begin:t}],relevance:0},u,{className:"variable",
+begin:"(\\$\\W)|((\\$|@@?)(\\w+))(?=[^@$?])(?![A-Za-z])(?![@$?'])"},{
+className:"params",begin:/\|(?!=)/,end:/\|/,excludeBegin:!0,excludeEnd:!0,
+relevance:0,keywords:r},{begin:"("+e.RE_STARTERS_RE+"|unless)\\s*",
+keywords:"unless",contains:[{className:"regexp",contains:[e.BACKSLASH_ESCAPE,c],
+illegal:/\n/,variants:[{begin:"/",end:"/[a-z]*"},{begin:/%r\{/,end:/\}[a-z]*/},{
+begin:"%r\\(",end:"\\)[a-z]*"},{begin:"%r!",end:"![a-z]*"},{begin:"%r\\[",
+end:"\\][a-z]*"}]}].concat(o,l),relevance:0}].concat(o,l)
+;c.contains=m,b.contains=m;const p=[{begin:/^\s*=>/,starts:{end:"$",contains:m}
+},{className:"meta.prompt",
+begin:"^([>?]>|[\\w#]+\\(\\w+\\):\\d+:\\d+[>*]|(\\w+-)?\\d+\\.\\d+\\.\\d+(p\\d+)?[^\\d][^>]+>)(?=[ ])",
+starts:{end:"$",keywords:r,contains:m}}];return l.unshift(o),{name:"Ruby",
+aliases:["rb","gemspec","podspec","thor","irb"],keywords:r,illegal:/\/\*/,
+contains:[e.SHEBANG({binary:"ruby"})].concat(p).concat(l).concat(m)}},
+grmr_rust:e=>{
+const n=e.regex,t=/(r#)?/,a=n.concat(t,e.UNDERSCORE_IDENT_RE),i=n.concat(t,e.IDENT_RE),r={
+className:"title.function.invoke",relevance:0,
+begin:n.concat(/\b/,/(?!let|for|while|if|else|match\b)/,i,n.lookahead(/\s*\(/))
+},s="([ui](8|16|32|64|128|size)|f(32|64))?",o=["drop ","Copy","Send","Sized","Sync","Drop","Fn","FnMut","FnOnce","ToOwned","Clone","Debug","PartialEq","PartialOrd","Eq","Ord","AsRef","AsMut","Into","From","Default","Iterator","Extend","IntoIterator","DoubleEndedIterator","ExactSizeIterator","SliceConcatExt","ToString","assert!","assert_eq!","bitflags!","bytes!","cfg!","col!","concat!","concat_idents!","debug_assert!","debug_assert_eq!","env!","eprintln!","panic!","file!","format!","format_args!","include_bytes!","include_str!","line!","local_data_key!","module_path!","option_env!","print!","println!","select!","stringify!","try!","unimplemented!","unreachable!","vec!","write!","writeln!","macro_rules!","assert_ne!","debug_assert_ne!"],l=["i8","i16","i32","i64","i128","isize","u8","u16","u32","u64","u128","usize","f32","f64","str","char","bool","Box","Option","Result","String","Vec"]
+;return{name:"Rust",aliases:["rs"],keywords:{$pattern:e.IDENT_RE+"!?",type:l,
+keyword:["abstract","as","async","await","become","box","break","const","continue","crate","do","dyn","else","enum","extern","false","final","fn","for","if","impl","in","let","loop","macro","match","mod","move","mut","override","priv","pub","ref","return","self","Self","static","struct","super","trait","true","try","type","typeof","union","unsafe","unsized","use","virtual","where","while","yield"],
+literal:["true","false","Some","None","Ok","Err"],built_in:o},illegal:"</",
+contains:[e.C_LINE_COMMENT_MODE,e.COMMENT("/\\*","\\*/",{contains:["self"]
+}),e.inherit(e.QUOTE_STRING_MODE,{begin:/b?"/,illegal:null}),{
+className:"symbol",begin:/'[a-zA-Z_][a-zA-Z0-9_]*(?!')/},{scope:"string",
+variants:[{begin:/b?r(#*)"(.|\n)*?"\1(?!#)/},{begin:/b?'/,end:/'/,contains:[{
+scope:"char.escape",match:/\\('|\w|x\w{2}|u\w{4}|U\w{8})/}]}]},{
+className:"number",variants:[{begin:"\\b0b([01_]+)"+s},{begin:"\\b0o([0-7_]+)"+s
+},{begin:"\\b0x([A-Fa-f0-9_]+)"+s},{
+begin:"\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)"+s}],relevance:0},{
+begin:[/fn/,/\s+/,a],className:{1:"keyword",3:"title.function"}},{
+className:"meta",begin:"#!?\\[",end:"\\]",contains:[{className:"string",
+begin:/"/,end:/"/,contains:[e.BACKSLASH_ESCAPE]}]},{
+begin:[/let/,/\s+/,/(?:mut\s+)?/,a],className:{1:"keyword",3:"keyword",
+4:"variable"}},{begin:[/for/,/\s+/,a,/\s+/,/in/],className:{1:"keyword",
+3:"variable",5:"keyword"}},{begin:[/type/,/\s+/,a],className:{1:"keyword",
+3:"title.class"}},{begin:[/(?:trait|enum|struct|union|impl|for)/,/\s+/,a],
+className:{1:"keyword",3:"title.class"}},{begin:e.IDENT_RE+"::",keywords:{
+keyword:"Self",built_in:o,type:l}},{className:"punctuation",begin:"->"},r]}},
+grmr_scss:e=>{const n=te(e),t=se,a=re,i="@[a-z-]+",r={className:"variable",
+begin:"(\\$[a-zA-Z-][a-zA-Z0-9_-]*)\\b",relevance:0};return{name:"SCSS",
+case_insensitive:!0,illegal:"[=/|']",
+contains:[e.C_LINE_COMMENT_MODE,e.C_BLOCK_COMMENT_MODE,n.CSS_NUMBER_MODE,{
+className:"selector-id",begin:"#[A-Za-z0-9_-]+",relevance:0},{
+className:"selector-class",begin:"\\.[A-Za-z0-9_-]+",relevance:0
+},n.ATTRIBUTE_SELECTOR_MODE,{className:"selector-tag",
+begin:"\\b("+ae.join("|")+")\\b",relevance:0},{className:"selector-pseudo",
+begin:":("+a.join("|")+")"},{className:"selector-pseudo",
+begin:":(:)?("+t.join("|")+")"},r,{begin:/\(/,end:/\)/,
+contains:[n.CSS_NUMBER_MODE]},n.CSS_VARIABLE,{className:"attribute",
+begin:"\\b("+oe.join("|")+")\\b"},{
+begin:"\\b(whitespace|wait|w-resize|visible|vertical-text|vertical-ideographic|uppercase|upper-roman|upper-alpha|underline|transparent|top|thin|thick|text|text-top|text-bottom|tb-rl|table-header-group|table-footer-group|sw-resize|super|strict|static|square|solid|small-caps|separate|se-resize|scroll|s-resize|rtl|row-resize|ridge|right|repeat|repeat-y|repeat-x|relative|progress|pointer|overline|outside|outset|oblique|nowrap|not-allowed|normal|none|nw-resize|no-repeat|no-drop|newspaper|ne-resize|n-resize|move|middle|medium|ltr|lr-tb|lowercase|lower-roman|lower-alpha|loose|list-item|line|line-through|line-edge|lighter|left|keep-all|justify|italic|inter-word|inter-ideograph|inside|inset|inline|inline-block|inherit|inactive|ideograph-space|ideograph-parenthesis|ideograph-numeric|ideograph-alpha|horizontal|hidden|help|hand|groove|fixed|ellipsis|e-resize|double|dotted|distribute|distribute-space|distribute-letter|distribute-all-lines|disc|disabled|default|decimal|dashed|crosshair|collapse|col-resize|circle|char|center|capitalize|break-word|break-all|bottom|both|bolder|bold|block|bidi-override|below|baseline|auto|always|all-scroll|absolute|table|table-cell)\\b"
+},{begin:/:/,end:/[;}{]/,relevance:0,
+contains:[n.BLOCK_COMMENT,r,n.HEXCOLOR,n.CSS_NUMBER_MODE,e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,n.IMPORTANT,n.FUNCTION_DISPATCH]
+},{begin:"@(page|font-face)",keywords:{$pattern:i,keyword:"@page @font-face"}},{
+begin:"@",end:"[{;]",returnBegin:!0,keywords:{$pattern:/[a-z-]+/,
+keyword:"and or not only",attribute:ie.join(" ")},contains:[{begin:i,
+className:"keyword"},{begin:/[a-z-]+(?=:)/,className:"attribute"
+},r,e.QUOTE_STRING_MODE,e.APOS_STRING_MODE,n.HEXCOLOR,n.CSS_NUMBER_MODE]
+},n.FUNCTION_DISPATCH]}},grmr_shell:e=>({name:"Shell Session",
+aliases:["console","shellsession"],contains:[{className:"meta.prompt",
+begin:/^\s{0,3}[/~\w\d[\]()@-]*[>%$#][ ]?/,starts:{end:/[^\\](?=\s*$)/,
+subLanguage:"bash"}}]}),grmr_sql:e=>{
+const n=e.regex,t=e.COMMENT("--","$"),a=["abs","acos","array_agg","asin","atan","avg","cast","ceil","ceiling","coalesce","corr","cos","cosh","count","covar_pop","covar_samp","cume_dist","dense_rank","deref","element","exp","extract","first_value","floor","json_array","json_arrayagg","json_exists","json_object","json_objectagg","json_query","json_table","json_table_primitive","json_value","lag","last_value","lead","listagg","ln","log","log10","lower","max","min","mod","nth_value","ntile","nullif","percent_rank","percentile_cont","percentile_disc","position","position_regex","power","rank","regr_avgx","regr_avgy","regr_count","regr_intercept","regr_r2","regr_slope","regr_sxx","regr_sxy","regr_syy","row_number","sin","sinh","sqrt","stddev_pop","stddev_samp","substring","substring_regex","sum","tan","tanh","translate","translate_regex","treat","trim","trim_array","unnest","upper","value_of","var_pop","var_samp","width_bucket"],i=a,r=["abs","acos","all","allocate","alter","and","any","are","array","array_agg","array_max_cardinality","as","asensitive","asin","asymmetric","at","atan","atomic","authorization","avg","begin","begin_frame","begin_partition","between","bigint","binary","blob","boolean","both","by","call","called","cardinality","cascaded","case","cast","ceil","ceiling","char","char_length","character","character_length","check","classifier","clob","close","coalesce","collate","collect","column","commit","condition","connect","constraint","contains","convert","copy","corr","corresponding","cos","cosh","count","covar_pop","covar_samp","create","cross","cube","cume_dist","current","current_catalog","current_date","current_default_transform_group","current_path","current_role","current_row","current_schema","current_time","current_timestamp","current_path","current_role","current_transform_group_for_type","current_user","cursor","cycle","date","day","deallocate","dec","decimal","decfloat","declare","default","define","delete","dense_rank","deref","describe","deterministic","disconnect","distinct","double","drop","dynamic","each","element","else","empty","end","end_frame","end_partition","end-exec","equals","escape","every","except","exec","execute","exists","exp","external","extract","false","fetch","filter","first_value","float","floor","for","foreign","frame_row","free","from","full","function","fusion","get","global","grant","group","grouping","groups","having","hold","hour","identity","in","indicator","initial","inner","inout","insensitive","insert","int","integer","intersect","intersection","interval","into","is","join","json_array","json_arrayagg","json_exists","json_object","json_objectagg","json_query","json_table","json_table_primitive","json_value","lag","language","large","last_value","lateral","lead","leading","left","like","like_regex","listagg","ln","local","localtime","localtimestamp","log","log10","lower","match","match_number","match_recognize","matches","max","member","merge","method","min","minute","mod","modifies","module","month","multiset","national","natural","nchar","nclob","new","no","none","normalize","not","nth_value","ntile","null","nullif","numeric","octet_length","occurrences_regex","of","offset","old","omit","on","one","only","open","or","order","out","outer","over","overlaps","overlay","parameter","partition","pattern","per","percent","percent_rank","percentile_cont","percentile_disc","period","portion","position","position_regex","power","precedes","precision","prepare","primary","procedure","ptf","range","rank","reads","real","recursive","ref","references","referencing","regr_avgx","regr_avgy","regr_count","regr_intercept","regr_r2","regr_slope","regr_sxx","regr_sxy","regr_syy","release","result","return","returns","revoke","right","rollback","rollup","row","row_number","rows","running","savepoint","scope","scroll","search","second","seek","select","sensitive","session_user","set","show","similar","sin","sinh","skip","smallint","some","specific","specifictype","sql","sqlexception","sqlstate","sqlwarning","sqrt","start","static","stddev_pop","stddev_samp","submultiset","subset","substring","substring_regex","succeeds","sum","symmetric","system","system_time","system_user","table","tablesample","tan","tanh","then","time","timestamp","timezone_hour","timezone_minute","to","trailing","translate","translate_regex","translation","treat","trigger","trim","trim_array","true","truncate","uescape","union","unique","unknown","unnest","update","upper","user","using","value","values","value_of","var_pop","var_samp","varbinary","varchar","varying","versioning","when","whenever","where","width_bucket","window","with","within","without","year","add","asc","collation","desc","final","first","last","view"].filter((e=>!a.includes(e))),s={
+match:n.concat(/\b/,n.either(...i),/\s*\(/),relevance:0,keywords:{built_in:i}}
+;function o(e){
+return n.concat(/\b/,n.either(...e.map((e=>e.replace(/\s+/,"\\s+")))),/\b/)}
+const l={scope:"keyword",
+match:o(["create table","insert into","primary key","foreign key","not null","alter table","add constraint","grouping sets","on overflow","character set","respect nulls","ignore nulls","nulls first","nulls last","depth first","breadth first"]),
+relevance:0};return{name:"SQL",case_insensitive:!0,illegal:/[{}]|<\//,keywords:{
+$pattern:/\b[\w\.]+/,keyword:((e,{exceptions:n,when:t}={})=>{const a=t
+;return n=n||[],e.map((e=>e.match(/\|\d+$/)||n.includes(e)?e:a(e)?e+"|0":e))
+})(r,{when:e=>e.length<3}),literal:["true","false","unknown"],
+type:["bigint","binary","blob","boolean","char","character","clob","date","dec","decfloat","decimal","float","int","integer","interval","nchar","nclob","national","numeric","real","row","smallint","time","timestamp","varchar","varying","varbinary"],
+built_in:["current_catalog","current_date","current_default_transform_group","current_path","current_role","current_schema","current_transform_group_for_type","current_user","session_user","system_time","system_user","current_time","localtime","current_timestamp","localtimestamp"]
+},contains:[{scope:"type",
+match:o(["double precision","large object","with timezone","without timezone"])
+},l,s,{scope:"variable",match:/@[a-z0-9][a-z0-9_]*/},{scope:"string",variants:[{
+begin:/'/,end:/'/,contains:[{match:/''/}]}]},{begin:/"/,end:/"/,contains:[{
+match:/""/}]},e.C_NUMBER_MODE,e.C_BLOCK_COMMENT_MODE,t,{scope:"operator",
+match:/[-+*/=%^~]|&&?|\|\|?|!=?|<(?:=>?|<|>)?|>[>=]?/,relevance:0}]}},
+grmr_swift:e=>{const n={match:/\s+/,relevance:0},t=e.COMMENT("/\\*","\\*/",{
+contains:["self"]}),a=[e.C_LINE_COMMENT_MODE,t],i={match:[/\./,m(...ke,...xe)],
+className:{2:"keyword"}},r={match:b(/\./,m(...Me)),relevance:0
+},s=Me.filter((e=>"string"==typeof e)).concat(["_|0"]),o={variants:[{
+className:"keyword",
+match:m(...Me.filter((e=>"string"!=typeof e)).concat(Oe).map(Ne),...xe)}]},l={
+$pattern:m(/\b\w+/,/#\w+/),keyword:s.concat(Ce),literal:Ae},c=[i,r,o],g=[{
+match:b(/\./,m(...Te)),relevance:0},{className:"built_in",
+match:b(/\b/,m(...Te),/(?=\()/)}],u={match:/->/,relevance:0},p=[u,{
+className:"operator",relevance:0,variants:[{match:Ie},{match:`\\.(\\.|${De})+`}]
+}],_="([0-9]_*)+",h="([0-9a-fA-F]_*)+",f={className:"number",relevance:0,
+variants:[{match:`\\b(${_})(\\.(${_}))?([eE][+-]?(${_}))?\\b`},{
+match:`\\b0x(${h})(\\.(${h}))?([pP][+-]?(${_}))?\\b`},{match:/\b0o([0-7]_*)+\b/
+},{match:/\b0b([01]_*)+\b/}]},E=(e="")=>({className:"subst",variants:[{
+match:b(/\\/,e,/[0\\tnr"']/)},{match:b(/\\/,e,/u\{[0-9a-fA-F]{1,8}\}/)}]
+}),y=(e="")=>({className:"subst",match:b(/\\/,e,/[\t ]*(?:[\r\n]|\r\n)/)
+}),w=(e="")=>({className:"subst",label:"interpol",begin:b(/\\/,e,/\(/),end:/\)/
+}),v=(e="")=>({begin:b(e,/"""/),end:b(/"""/,e),contains:[E(e),y(e),w(e)]
+}),N=(e="")=>({begin:b(e,/"/),end:b(/"/,e),contains:[E(e),w(e)]}),k={
+className:"string",
+variants:[v(),v("#"),v("##"),v("###"),N(),N("#"),N("##"),N("###")]
+},x=[e.BACKSLASH_ESCAPE,{begin:/\[/,end:/\]/,relevance:0,
+contains:[e.BACKSLASH_ESCAPE]}],O={begin:/\/[^\s](?=[^/\n]*\/)/,end:/\//,
+contains:x},M=e=>{const n=b(e,/\//),t=b(/\//,e);return{begin:n,end:t,
+contains:[...x,{scope:"comment",begin:`#(?!.*${t})`,end:/$/}]}},A={
+scope:"regexp",variants:[M("###"),M("##"),M("#"),O]},S={match:b(/`/,$e,/`/)
+},C=[S,{className:"variable",match:/\$\d+/},{className:"variable",
+match:`\\$${Be}+`}],T=[{match:/(@|#(un)?)available/,scope:"keyword",starts:{
+contains:[{begin:/\(/,end:/\)/,keywords:je,contains:[...p,f,k]}]}},{
+scope:"keyword",match:b(/@/,m(...ze),d(m(/\(/,/\s+/)))},{scope:"meta",
+match:b(/@/,$e)}],R={match:d(/\b[A-Z]/),relevance:0,contains:[{className:"type",
+match:b(/(AV|CA|CF|CG|CI|CL|CM|CN|CT|MK|MP|MTK|MTL|NS|SCN|SK|UI|WK|XC)/,Be,"+")
+},{className:"type",match:Fe,relevance:0},{match:/[?!]+/,relevance:0},{
+match:/\.\.\./,relevance:0},{match:b(/\s+&\s+/,d(Fe)),relevance:0}]},D={
+begin:/</,end:/>/,keywords:l,contains:[...a,...c,...T,u,R]};R.contains.push(D)
+;const I={begin:/\(/,end:/\)/,relevance:0,keywords:l,contains:["self",{
+match:b($e,/\s*:/),keywords:"_|0",relevance:0
+},...a,A,...c,...g,...p,f,k,...C,...T,R]},L={begin:/</,end:/>/,
+keywords:"repeat each",contains:[...a,R]},B={begin:/\(/,end:/\)/,keywords:l,
+contains:[{begin:m(d(b($e,/\s*:/)),d(b($e,/\s+/,$e,/\s*:/))),end:/:/,
+relevance:0,contains:[{className:"keyword",match:/\b_\b/},{className:"params",
+match:$e}]},...a,...c,...p,f,k,...T,R,I],endsParent:!0,illegal:/["']/},$={
+match:[/(func|macro)/,/\s+/,m(S.match,$e,Ie)],className:{1:"keyword",
+3:"title.function"},contains:[L,B,n],illegal:[/\[/,/%/]},F={
+match:[/\b(?:subscript|init[?!]?)/,/\s*(?=[<(])/],className:{1:"keyword"},
+contains:[L,B,n],illegal:/\[|%/},z={match:[/operator/,/\s+/,Ie],className:{
+1:"keyword",3:"title"}},j={begin:[/precedencegroup/,/\s+/,Fe],className:{
+1:"keyword",3:"title"},contains:[R],keywords:[...Se,...Ae],end:/}/},U={
+begin:[/(struct|protocol|class|extension|enum|actor)/,/\s+/,$e,/\s*/],
+beginScope:{1:"keyword",3:"title.class"},keywords:l,contains:[L,...c,{begin:/:/,
+end:/\{/,keywords:l,contains:[{scope:"title.class.inherited",match:Fe},...c],
+relevance:0}]};for(const e of k.variants){
+const n=e.contains.find((e=>"interpol"===e.label));n.keywords=l
+;const t=[...c,...g,...p,f,k,...C];n.contains=[...t,{begin:/\(/,end:/\)/,
+contains:["self",...t]}]}return{name:"Swift",keywords:l,contains:[...a,$,F,{
+match:[/class\b/,/\s+/,/func\b/,/\s+/,/\b[A-Za-z_][A-Za-z0-9_]*\b/],scope:{
+1:"keyword",3:"keyword",5:"title.function"}},{match:[/class\b/,/\s+/,/var\b/],
+scope:{1:"keyword",3:"keyword"}},U,z,j,{beginKeywords:"import",end:/$/,
+contains:[...a],relevance:0},A,...c,...g,...p,f,k,...C,...T,R,I]}},
+grmr_typescript:e=>{
+const n=e.regex,t=ve(e),a=me,i=["any","void","number","boolean","string","object","never","symbol","bigint","unknown"],r={
+begin:[/namespace/,/\s+/,e.IDENT_RE],beginScope:{1:"keyword",3:"title.class"}
+},s={beginKeywords:"interface",end:/\{/,excludeEnd:!0,keywords:{
+keyword:"interface extends",built_in:i},contains:[t.exports.CLASS_REFERENCE]
+},o={$pattern:me,
+keyword:pe.concat(["type","interface","public","private","protected","implements","declare","abstract","readonly","enum","override","satisfies"]),
+literal:_e,built_in:we.concat(i),"variable.language":ye},l={className:"meta",
+begin:"@"+a},c=(e,n,t)=>{const a=e.contains.findIndex((e=>e.label===n))
+;if(-1===a)throw Error("can not find mode to replace");e.contains.splice(a,1,t)}
+;Object.assign(t.keywords,o),t.exports.PARAMS_CONTAINS.push(l)
+;const d=t.contains.find((e=>"attr"===e.scope)),g=Object.assign({},d,{
+match:n.concat(a,n.lookahead(/\s*\?:/))})
+;return t.exports.PARAMS_CONTAINS.push([t.exports.CLASS_REFERENCE,d,g]),
+t.contains=t.contains.concat([l,r,s,g]),
+c(t,"shebang",e.SHEBANG()),c(t,"use_strict",{className:"meta",relevance:10,
+begin:/^\s*['"]use strict['"]/
+}),t.contains.find((e=>"func.def"===e.label)).relevance=0,Object.assign(t,{
+name:"TypeScript",aliases:["ts","tsx","mts","cts"]}),t},grmr_vbnet:e=>{
+const n=e.regex,t=/\d{1,2}\/\d{1,2}\/\d{4}/,a=/\d{4}-\d{1,2}-\d{1,2}/,i=/(\d|1[012])(:\d+){0,2} *(AM|PM)/,r=/\d{1,2}(:\d{1,2}){1,2}/,s={
+className:"literal",variants:[{begin:n.concat(/# */,n.either(a,t),/ *#/)},{
+begin:n.concat(/# */,r,/ *#/)},{begin:n.concat(/# */,i,/ *#/)},{
+begin:n.concat(/# */,n.either(a,t),/ +/,n.either(i,r),/ *#/)}]
+},o=e.COMMENT(/'''/,/$/,{contains:[{className:"doctag",begin:/<\/?/,end:/>/}]
+}),l=e.COMMENT(null,/$/,{variants:[{begin:/'/},{begin:/([\t ]|^)REM(?=\s)/}]})
+;return{name:"Visual Basic .NET",aliases:["vb"],case_insensitive:!0,
+classNameAliases:{label:"symbol"},keywords:{
+keyword:"addhandler alias aggregate ansi as async assembly auto binary by byref byval call case catch class compare const continue custom declare default delegate dim distinct do each equals else elseif end enum erase error event exit explicit finally for friend from function get global goto group handles if implements imports in inherits interface into iterator join key let lib loop me mid module mustinherit mustoverride mybase myclass namespace narrowing new next notinheritable notoverridable of off on operator option optional order overloads overridable overrides paramarray partial preserve private property protected public raiseevent readonly redim removehandler resume return select set shadows shared skip static step stop structure strict sub synclock take text then throw to try unicode until using when where while widening with withevents writeonly yield",
+built_in:"addressof and andalso await directcast gettype getxmlnamespace is isfalse isnot istrue like mod nameof new not or orelse trycast typeof xor cbool cbyte cchar cdate cdbl cdec cint clng cobj csbyte cshort csng cstr cuint culng cushort",
+type:"boolean byte char date decimal double integer long object sbyte short single string uinteger ulong ushort",
+literal:"true false nothing"},
+illegal:"//|\\{|\\}|endif|gosub|variant|wend|^\\$ ",contains:[{
+className:"string",begin:/"(""|[^/n])"C\b/},{className:"string",begin:/"/,
+end:/"/,illegal:/\n/,contains:[{begin:/""/}]},s,{className:"number",relevance:0,
+variants:[{begin:/\b\d[\d_]*((\.[\d_]+(E[+-]?[\d_]+)?)|(E[+-]?[\d_]+))[RFD@!#]?/
+},{begin:/\b\d[\d_]*((U?[SIL])|[%&])?/},{begin:/&H[\dA-F_]+((U?[SIL])|[%&])?/},{
+begin:/&O[0-7_]+((U?[SIL])|[%&])?/},{begin:/&B[01_]+((U?[SIL])|[%&])?/}]},{
+className:"label",begin:/^\w+:/},o,l,{className:"meta",
+begin:/[\t ]*#(const|disable|else|elseif|enable|end|externalsource|if|region)\b/,
+end:/$/,keywords:{
+keyword:"const disable else elseif enable end externalsource if region then"},
+contains:[l]}]}},grmr_wasm:e=>{e.regex;const n=e.COMMENT(/\(;/,/;\)/)
+;return n.contains.push("self"),{name:"WebAssembly",keywords:{$pattern:/[\w.]+/,
+keyword:["anyfunc","block","br","br_if","br_table","call","call_indirect","data","drop","elem","else","end","export","func","global.get","global.set","local.get","local.set","local.tee","get_global","get_local","global","if","import","local","loop","memory","memory.grow","memory.size","module","mut","nop","offset","param","result","return","select","set_global","set_local","start","table","tee_local","then","type","unreachable"]
+},contains:[e.COMMENT(/;;/,/$/),n,{match:[/(?:offset|align)/,/\s*/,/=/],
+className:{1:"keyword",3:"operator"}},{className:"variable",begin:/\$[\w_]+/},{
+match:/(\((?!;)|\))+/,className:"punctuation",relevance:0},{
+begin:[/(?:func|call|call_indirect)/,/\s+/,/\$[^\s)]+/],className:{1:"keyword",
+3:"title.function"}},e.QUOTE_STRING_MODE,{match:/(i32|i64|f32|f64)(?!\.)/,
+className:"type"},{className:"keyword",
+match:/\b(f32|f64|i32|i64)(?:\.(?:abs|add|and|ceil|clz|const|convert_[su]\/i(?:32|64)|copysign|ctz|demote\/f64|div(?:_[su])?|eqz?|extend_[su]\/i32|floor|ge(?:_[su])?|gt(?:_[su])?|le(?:_[su])?|load(?:(?:8|16|32)_[su])?|lt(?:_[su])?|max|min|mul|nearest|neg?|or|popcnt|promote\/f32|reinterpret\/[fi](?:32|64)|rem_[su]|rot[lr]|shl|shr_[su]|store(?:8|16|32)?|sqrt|sub|trunc(?:_[su]\/f(?:32|64))?|wrap\/i64|xor))\b/
+},{className:"number",relevance:0,
+match:/[+-]?\b(?:\d(?:_?\d)*(?:\.\d(?:_?\d)*)?(?:[eE][+-]?\d(?:_?\d)*)?|0x[\da-fA-F](?:_?[\da-fA-F])*(?:\.[\da-fA-F](?:_?[\da-fA-D])*)?(?:[pP][+-]?\d(?:_?\d)*)?)\b|\binf\b|\bnan(?::0x[\da-fA-F](?:_?[\da-fA-D])*)?\b/
+}]}},grmr_xml:e=>{
+const n=e.regex,t=n.concat(/[\p{L}_]/u,n.optional(/[\p{L}0-9_.-]*:/u),/[\p{L}0-9_.-]*/u),a={
+className:"symbol",begin:/&[a-z]+;|&#[0-9]+;|&#x[a-f0-9]+;/},i={begin:/\s/,
+contains:[{className:"keyword",begin:/#?[a-z_][a-z1-9_-]+/,illegal:/\n/}]
+},r=e.inherit(i,{begin:/\(/,end:/\)/}),s=e.inherit(e.APOS_STRING_MODE,{
+className:"string"}),o=e.inherit(e.QUOTE_STRING_MODE,{className:"string"}),l={
+endsWithParent:!0,illegal:/</,relevance:0,contains:[{className:"attr",
+begin:/[\p{L}0-9._:-]+/u,relevance:0},{begin:/=\s*/,relevance:0,contains:[{
+className:"string",endsParent:!0,variants:[{begin:/"/,end:/"/,contains:[a]},{
+begin:/'/,end:/'/,contains:[a]},{begin:/[^\s"'=<>`]+/}]}]}]};return{
+name:"HTML, XML",
+aliases:["html","xhtml","rss","atom","xjb","xsd","xsl","plist","wsf","svg"],
+case_insensitive:!0,unicodeRegex:!0,contains:[{className:"meta",begin:/<![a-z]/,
+end:/>/,relevance:10,contains:[i,o,s,r,{begin:/\[/,end:/\]/,contains:[{
+className:"meta",begin:/<![a-z]/,end:/>/,contains:[i,r,o,s]}]}]
+},e.COMMENT(/<!--/,/-->/,{relevance:10}),{begin:/<!\[CDATA\[/,end:/\]\]>/,
+relevance:10},a,{className:"meta",end:/\?>/,variants:[{begin:/<\?xml/,
+relevance:10,contains:[o]},{begin:/<\?[a-z][a-z0-9]+/}]},{className:"tag",
+begin:/<style(?=\s|>)/,end:/>/,keywords:{name:"style"},contains:[l],starts:{
+end:/<\/style>/,returnEnd:!0,subLanguage:["css","xml"]}},{className:"tag",
+begin:/<script(?=\s|>)/,end:/>/,keywords:{name:"script"},contains:[l],starts:{
+end:/<\/script>/,returnEnd:!0,subLanguage:["javascript","handlebars","xml"]}},{
+className:"tag",begin:/<>|<\/>/},{className:"tag",
+begin:n.concat(/</,n.lookahead(n.concat(t,n.either(/\/>/,/>/,/\s/)))),
+end:/\/?>/,contains:[{className:"name",begin:t,relevance:0,starts:l}]},{
+className:"tag",begin:n.concat(/<\//,n.lookahead(n.concat(t,/>/))),contains:[{
+className:"name",begin:t,relevance:0},{begin:/>/,relevance:0,endsParent:!0}]}]}
+},grmr_yaml:e=>{
+const n="true false yes no null",t="[\\w#;/?:@&=+$,.~*'()[\\]]+",a={
+className:"string",relevance:0,variants:[{begin:/"/,end:/"/},{begin:/\S+/}],
+contains:[e.BACKSLASH_ESCAPE,{className:"template-variable",variants:[{
+begin:/\{\{/,end:/\}\}/},{begin:/%\{/,end:/\}/}]}]},i=e.inherit(a,{variants:[{
+begin:/'/,end:/'/,contains:[{begin:/''/,relevance:0}]},{begin:/"/,end:/"/},{
+begin:/[^\s,{}[\]]+/}]}),r={end:",",endsWithParent:!0,excludeEnd:!0,keywords:n,
+relevance:0},s={begin:/\{/,end:/\}/,contains:[r],illegal:"\\n",relevance:0},o={
+begin:"\\[",end:"\\]",contains:[r],illegal:"\\n",relevance:0},l=[{
+className:"attr",variants:[{begin:/[\w*@][\w*@ :()\./-]*:(?=[ \t]|$)/},{
+begin:/"[\w*@][\w*@ :()\./-]*":(?=[ \t]|$)/},{
+begin:/'[\w*@][\w*@ :()\./-]*':(?=[ \t]|$)/}]},{className:"meta",
+begin:"^---\\s*$",relevance:10},{className:"string",
+begin:"[\\|>]([1-9]?[+-])?[ ]*\\n( +)[^ ][^\\n]*\\n(\\2[^\\n]+\\n?)*"},{
+begin:"<%[%=-]?",end:"[%-]?%>",subLanguage:"ruby",excludeBegin:!0,excludeEnd:!0,
+relevance:0},{className:"type",begin:"!\\w+!"+t},{className:"type",
+begin:"!<"+t+">"},{className:"type",begin:"!"+t},{className:"type",begin:"!!"+t
+},{className:"meta",begin:"&"+e.UNDERSCORE_IDENT_RE+"$"},{className:"meta",
+begin:"\\*"+e.UNDERSCORE_IDENT_RE+"$"},{className:"bullet",begin:"-(?=[ ]|$)",
+relevance:0},e.HASH_COMMENT_MODE,{beginKeywords:n,keywords:{literal:n}},{
+className:"number",
+begin:"\\b[0-9]{4}(-[0-9][0-9]){0,2}([Tt \\t][0-9][0-9]?(:[0-9][0-9]){2})?(\\.[0-9]*)?([ \\t])*(Z|[-+][0-9][0-9]?(:[0-9][0-9])?)?\\b"
+},{className:"number",begin:e.C_NUMBER_RE+"\\b",relevance:0},s,o,{
+className:"string",relevance:0,begin:/'/,end:/'/,contains:[{match:/''/,
+scope:"char.escape",relevance:0}]},a],c=[...l]
+;return c.pop(),c.push(i),r.contains=c,{name:"YAML",case_insensitive:!0,
+aliases:["yml"],contains:l}}});const Pe=ne;for(const e of Object.keys(Ue)){
+const n=e.replace("grmr_","").replace("_","-");Pe.registerLanguage(n,Ue[e])}
+return Pe}()
+;"object"==typeof exports&&"undefined"!=typeof module&&(module.exports=hljs);

--- a/skills/repo-mastery/references/index-script-spec.md
+++ b/skills/repo-mastery/references/index-script-spec.md
@@ -1,0 +1,52 @@
+# Index Script Spec — `scripts/index_repo.py`
+
+> **Read in**: Phase 0, when the repo is judged large. Run the script and use `code-map.json` to build the course map and learn on demand — instead of cramming the whole repo into context.
+
+## When you need the index
+
+Phase 0 "large" judgment (any hit): ≥ 100k source lines, ≥ 20 top-level modules, or complex/multi-language dependencies. When unsure, actually measure with `find` + `wc -l`; don't guess.
+
+## Run
+
+```bash
+python3 ~/.claude/skills/repo-mastery/scripts/index_repo.py <repo_path> -o <repo_path>/.learning/code-map.json
+```
+
+- Pure stdlib, **no dependencies to install**.
+- Read-only scan; skips blacklisted dirs (`.git`, `node_modules`, `.venv`, `dist`, etc.).
+- Writes to a temp file then atomically renames, so no half-written output.
+
+## `code-map.json` structure
+
+```jsonc
+{
+  "repo": "owner/name",
+  "summary": {
+    "total_source_files": 1234,
+    "total_lines": 182340,
+    "languages": { "python": 800, "typescript": 300 },
+    "top_dirs": [ { "name": "deeptutor", "files": 600 } ]   // top-level dir stats
+  },
+  "entry_points": [ "package.json/main: src/index.js", "main.py" ],
+  "dependency_graph": { "src/pipeline.py": ["deeptutor", "core"] },  // in-project edges only
+  "files": [ { "path": "src/pipeline.py", "lang": "python", "lines": 640 } ],
+  "symbol_lookup": { "python": [ "src/pipeline.py", "..." ] }  // heaviest 30 files per language
+}
+```
+
+## How to use it for the course map (Phase 1)
+
+1. **Module division** ← `summary.top_dirs` + `dependency_graph`: top-level dirs are natural module boundaries; clusters of dependency edges are strong "key implementations" candidates.
+2. **Key-implementation location** ← `symbol_lookup` + `files` sorted by `lines` desc: the heaviest files are often core.
+3. **Usage-module evidence** ← `entry_points`: entry files ground the "build / core workflows" modules.
+4. **Read on demand during learning** ← from the map's knowledge points → the `path` in `files` → Read the relevant `file:line`. No more whole-repo scans.
+
+## Known limitations (honest)
+
+- Dependency extraction is **heuristic regex, not a syntax tree** — dynamic imports and indirect references are missed. It's for "finding candidates", not "exhaustive enumeration".
+- Multi-language repos (e.g. Rust core + Python wrapper) are grouped by extension only; cross-language boundaries still need README/docs.
+- For extreme monorepos (millions of lines), build an index per sub-directory, or index only the subsystem you care about.
+
+## Where to put the index
+
+- Default: `<repo>/.learning/code-map.json` (travels with the repo). For very large repos, `~/.repo-mastery/caches/<repo-id>/code-map.json` keeps the target repo clean — pick one and stay consistent.

--- a/skills/repo-mastery/references/learning-records-template.md
+++ b/skills/repo-mastery/references/learning-records-template.md
@@ -1,0 +1,47 @@
+# Learning Records Template — ADR-style Learning Records
+
+> **Read in**: all phases. Learning records and notes are **two layers**:
+> - `notes/<module>.md` = content notes — what each module covered (knowledge accumulation).
+> - `records/NNNN-slug.md` = decision records — **how the learner's understanding evolved** (non-obvious learnings, stated prior knowledge, corrected misconceptions). These feed ZPD decisions and future sessions.
+>
+> Format absorbed from mattpocock teach skill's `LEARNING-RECORD-FORMAT.md` (the teaching-world ADR).
+
+## Location & numbering
+
+- Location: `<repo>/.learning/records/`, filenames `0001-slug.md`, `0002-slug.md`, … incrementing.
+- Lazy creation: only create the directory when the first record is written.
+
+## Template (minimal)
+
+```md
+# {one-line title: what was learned / established}
+
+{1-3 sentences: what was learned (or what prior knowledge was established), and why it matters for future sessions.}
+
+Status: active | superseded by LR-NNNN   ← only when needed
+Evidence: {how the user demonstrated this: answered a question / ran a demo / cited prior experience}
+Implications: {what this unlocks or rules out for future sessions}
+```
+
+**The whole format is these few lines.** The value of a record is capturing "this is now known" + "it changes what to teach next" — not filling out sections.
+
+## When to write one
+
+1. **The user demonstrated genuine understanding of something non-trivial** — not just exposure, but evidence they can use it correctly (answered, demo ran). This sets a new floor for what to teach next.
+2. **The user disclosed prior knowledge** — "I already know X." Record it, and the claimed depth, so future sessions don't re-teach it.
+3. **A misconception was corrected** — the user believed something wrong and now sees why. High value: predicts future stumbling blocks for related topics.
+4. **The Mission shifted in response to learning** — the user discovered they care about something different. Update `MISSION.md` and cross-link.
+
+### What does *not* qualify
+
+- Material merely covered. Coverage is not learning; wait for evidence.
+- Anything already captured tersely as a glossary term. Don't duplicate.
+- Session-by-session activity logs. Records are not a journal — they're decision-grade insights.
+
+## Supersession
+
+When a later record contradicts an earlier one (understanding deepened or corrected), mark the old record `Status: superseded by LR-NNNN` rather than deleting it — the history of how understanding evolved is itself useful signal (absorbed from teach's supersession).
+
+## Relationship to ZPD
+
+Each record updates the baseline of "what the user already knows". At session start, read `records/` + `progress.json` to judge the **zone of proximal development**: teach what's "just challenging enough" — not re-covering established knowledge, not leaping too far.

--- a/skills/repo-mastery/references/mastery-policy.md
+++ b/skills/repo-mastery/references/mastery-policy.md
@@ -1,0 +1,142 @@
+# Mastery Policy — Mastery, Gates, Spaced Review, Error Diagnosis
+
+> **Read in**: Phase 3. This is the pure decision engine — **no LLM calls, no I/O**. The tutor consults these rules every learning turn. Three core questions: **Is this knowledge point mastered? What should the learner work on next? What does the whole map look like?**
+
+This policy is ported from DeepTutor's `learning/` module (`mastery.py` / `policy.py` / `scheduler.py` / `models.py`), replacing "subject knowledge" with "code knowledge".
+
+> **Every formula in this document is implemented in `scripts/learning_engine.py`.**
+> The tutor (in any tool) MUST call the script for gate decisions
+> (`compute-mastery`, `schedule`, `record-attempt`, `next-objective`,
+> `validate-map`, `init`) rather than re-deriving the math by hand — this keeps
+> mastery judgment identical across Claude Code, Codex, Gemini CLI, etc.
+
+## 0. Design rationale: Fluency vs Storage Strength (absorbed from the teach skill)
+
+Distinguish two kinds of "knowing":
+
+- **Fluency**: retrievable in the moment — the "I get it" right after an explanation. It creates the **illusion of mastery**.
+- **Storage**: long-term retention — still usable after a gap. This is the real goal.
+
+All mechanisms in this policy fight the fluency illusion:
+
+- Confidence ceiling (one lucky answer ≠ mastery) → prevents fluency masquerading as mastery.
+- Feynman recital (not nodding along) → forces retrieval from storage.
+- Spaced review (delayed review) → only what survives forgetting counts as storage.
+
+**ZPD (zone of proximal development)**: what to teach next = challenge "just enough". Its inputs = `records/` (established understanding) + `progress.json` (mastery) + Mission (why the learner is here). Don't re-cover what's mastered; don't leap too far.
+
+## 1. Knowledge types and gates
+
+| type | Gate kind | Pass condition |
+|---|---|---|
+| `memory` | quantitative | recency-weighted accuracy ≥ **0.9** |
+| `procedure` | quantitative | recency-weighted accuracy ≥ **0.9** (with the key hands-on task passing as evidence) |
+| `concept` | qualitative | tutor judges the Feynman recital passed (`mastery_assess`) |
+| `design` | qualitative | tutor judges the recital + design-tradeoff follow-ups passed |
+
+**Design axiom**: quantitative types (memory/procedure) use exact grading because most have a single correct answer; concept/design use qualitative judgment because "why is it designed this way" has no single canonical answer — this is exactly how DeepTutor splits it.
+
+## 2. Quantitative mastery (`compute_mastery`)
+
+```text
+Input: a knowledge point's chronological answer correctness [bool, ...]
+Take the most recent up-to-5 attempts; weights oldest→newest = (0.5, 0.7, 0.85, 0.95, 1.0)
+score = Σ(weight × right/wrong) / Σ(weights)
+Confidence ceiling: only 1 recorded attempt → score capped at 0.5; only 2 → capped at 0.8
+mastery = min(score, ceiling)
+```
+
+Meaning:
+
+- Newer attempts weigh more — recovery after early mistakes is rewarded.
+- **One lucky answer is not mastery** — the confidence ceiling keeps mastery below 0.9 until enough evidence accumulates.
+- The judgment is deterministic, recorded in `progress.json`, independent of tutor memory.
+
+## 3. Spaced-repetition scheduling
+
+One interval sequence per type (days):
+
+| type | interval sequence |
+|---|---|
+| `memory` | `[0, 1, 3, 7, 14, 30]` |
+| `concept` | `[3, 7, 14, 30]` |
+| `procedure` | `[3, 7, 14]` |
+| `design` | `[14, 28]` |
+
+**Scheduling rules** (`schedule_next`):
+
+- Correct: `consecutive_correct += 1`; if `consecutive_correct ≥ 2` → index +2; else +1.
+- Wrong: `consecutive_wrong += 1`; index steps back 1 (floor 0); if `consecutive_wrong ≥ 2` → reset the counter.
+- Index clamped to `[0, max_index]`; `next_review_at = now + interval[index]`.
+
+**Priority**: knowledge points with **error records** (active/retrying status) get priority 1 (highest); otherwise by type `memory:2 / concept:3 / procedure:4 / design:5`. Due review tasks sort by priority.
+
+## 4. What to learn next (`next_objective`)
+
+**Advancement is computed from what is already mastered — never from a stage counter.** Priority, high to low:
+
+1. **A pending question** (`pending_question`) → grade it first (`answer_pending`).
+2. **A due review** → review first, so mastered ground doesn't decay (`review`).
+3. **The first unmastered knowledge point** (by module order, then point order):
+   - Never touched → `probe` (test whether it can be skipped — **test-out path**: already-proven points are skipped, not forced through fixed stages).
+   - Quantitative type below its gate → `practice` (keep working it until it clears).
+   - Qualitative type → `assess` (Feynman check).
+4. **All mastered and nothing due** → `complete`.
+
+`NextStep` actions: `answer_pending / review / probe / practice / assess / complete`.
+
+## 5. Error diagnosis and metacognition
+
+When the learner is wrong/stuck, classify the **error type** (DeepTutor's four categories, mapped to code learning):
+
+| ErrorType | Meaning | Code-learning example |
+|---|---|---|
+| `structural` | missing prerequisite knowledge/context | "can't understand this async framework because I don't know `asyncio`" |
+| `deviation` | a concept is understood wrong | "thought RAG trains the model; it's actually retrieval-augmented" |
+| `application` | concept right but wrong scenario | "knows locks exist but used them where they don't apply" |
+| `metacognitive` | doesn't know what they don't know | "thought I got it, then the recital exposed the gaps" |
+
+Each error record: `error_type` + user's self-attribution + tutor confirmation + retry history. **Status flow**: `active → retrying → review → graduated`. active/retrying errors raise that point's review priority.
+
+## 6. Qualitative judgment (`mastery_assess`)
+
+Pass criteria for the Feynman check on concept/design points:
+
+- **concept**: the user can explain in their own words "what + why + relation to adjacent concepts". Can't → not passed → return to explanation, record the error type.
+- **design**: beyond the recital, add design-tradeoff follow-ups — "why not the alternative? in what scenario would it fail? where is the extension point?" Being able to answer the tradeoffs = mastery.
+
+Qualitative results live in `qualitative_mastery: {kp_id: bool}`; the map shows full value once passed, but the judgment itself is a boolean, not a score.
+
+## 7. Progress data structure (`progress.json`)
+
+```jsonc
+{
+  "repo": "owner/name",
+  "diagnostic": { "module_mastery": {} },
+  "modules": [
+    { "id": "m01", "name": "Build & environment", "order": 1,
+      "pass_threshold": 0.7,
+      "knowledge_points": [ { "id": "kp01-01", "name": "...", "type": "procedure" } ] }
+  ],
+  "mastery_levels": { "kp01-01": 0.42 },       // quantitative mastery 0..1
+  "qualitative_mastery": { "kp01-02": true },  // qualitative judgment
+  "knowledge_types": { "kp01-01": "procedure" },
+  "quiz_attempts": [ { "question_id": "q1", "knowledge_point_id": "kp01-01",
+                       "is_correct": false, "error_type": "deviation",
+                       "mastery_estimate": 0.0, "timestamp": 1754567890 } ],
+  "error_records": [ { "id": "e1", "knowledge_point_id": "kp01-01",
+                       "error_type": "deviation", "status": "active" } ],
+  "repetition_states": { "kp01-01": { "interval_index": 0, "next_review_at": 1754571490 } },
+  "review_queue": [ { "id": "review_kp01-01", "knowledge_point_id": "kp01-01",
+                      "due_at": 1754571490, "priority": 1 } ],
+  "pending_question": { "question_id": "q3", "knowledge_point_id": "kp01-01",
+                        "prompt": "...", "question_type": "short", "expected_answer": "..." },
+  "version": 1
+}
+```
+
+Key points:
+
+- `pending_question.expected_answer` **lives server-side (this file)** and never round-trips to the user — grading never drifts (DeepTutor's `PendingQuestion`).
+- All timestamps are Unix seconds.
+- Once the file exists, **write it back atomically** (temp file + rename) at the end of each turn to avoid corruption.

--- a/skills/repo-mastery/references/mastery-policy.md
+++ b/skills/repo-mastery/references/mastery-policy.md
@@ -52,9 +52,9 @@ Meaning:
 - **One lucky answer is not mastery** — the confidence ceiling keeps mastery below 0.9 until enough evidence accumulates.
 - The judgment is deterministic, recorded in `progress.json`, independent of tutor memory.
 
-## 3. Spaced-repetition scheduling
+## 3. Spaced-repetition scheduling (FSRS-inspired personalization)
 
-One interval sequence per type (days):
+Base interval sequence per type (days), as before:
 
 | type | interval sequence |
 |---|---|
@@ -63,13 +63,41 @@ One interval sequence per type (days):
 | `procedure` | `[3, 7, 14]` |
 | `design` | `[14, 28]` |
 
-**Scheduling rules** (`schedule_next`):
+**Personalization parameters** — each knowledge point carries two learned
+values (FSRS-inspired, simplified to pure deterministic math; see `ADOPTION.md` §6):
 
-- Correct: `consecutive_correct += 1`; if `consecutive_correct ≥ 2` → index +2; else +1.
-- Wrong: `consecutive_wrong += 1`; index steps back 1 (floor 0); if `consecutive_wrong ≥ 2` → reset the counter.
-- Index clamped to `[0, max_index]`; `next_review_at = now + interval[index]`.
+- `difficulty` (0.1–1.0, default 0.5): how hard this point is for the learner.
+- `stability` (1.0–5.0, default 1.0): how durable the memory is.
 
-**Priority**: knowledge points with **error records** (active/retrying status) get priority 1 (highest); otherwise by type `memory:2 / concept:3 / procedure:4 / design:5`. Due review tasks sort by priority.
+**Update rules** (`schedule_next`):
+
+- Correct:
+  - `consecutive_correct += 1`; if `≥ 2` → index +2; else +1.
+  - `difficulty = max(0.1, difficulty − 0.05)`.
+  - `stability = min(5.0, stability × (1 + 0.2 × min(consecutive_correct, 5)))`.
+- Wrong:
+  - `consecutive_wrong += 1`; index steps back 1 (floor 0); if `≥ 2` → reset.
+  - `difficulty = min(1.0, difficulty + 0.15)`.
+  - `stability = max(1.0, stability × 0.5)`.
+
+Index is clamped to `[0, max_index]`.
+
+**Effective interval** (replaces `next_review_at = now + interval[index]`):
+
+```text
+effective_days = base_days[interval_index] × stability × (1 − difficulty × 0.5)
+next_review_at = now + effective_days × 86400
+```
+
+- Higher `difficulty` → shorter interval (review sooner).
+- Higher `stability` → longer interval (defer).
+
+**Priority** (unchanged): error-record points get priority 1; else by type
+`memory:2 / concept:3 / procedure:4 / design:5`.
+
+**Interleaving** (`next_objective`): among due reviews of equal priority, a
+review whose `knowledge_type` differs from `progress.last_review_type` is picked
+first, so consecutive reviews interleave types instead of stacking one type.
 
 ## 4. What to learn next (`next_objective`)
 
@@ -105,6 +133,12 @@ Pass criteria for the Feynman check on concept/design points:
 - **concept**: the user can explain in their own words "what + why + relation to adjacent concepts". Can't → not passed → return to explanation, record the error type.
 - **design**: beyond the recital, add design-tradeoff follow-ups — "why not the alternative? in what scenario would it fail? where is the extension point?" Being able to answer the tradeoffs = mastery.
 
+**Causal questioning** (absorbed from RetainCraft): after the recital, push with
+causal probes to expose whether understanding is causal or merely associative —
+"why this design instead of X?", "if we swapped Y in, what would break and
+where?", "which single change flips this behavior?" Causal answers count as
+mastery evidence; vague recall does not.
+
 Qualitative results live in `qualitative_mastery: {kp_id: bool}`; the map shows full value once passed, but the judgment itself is a boolean, not a score.
 
 ## 7. Progress data structure (`progress.json`)
@@ -126,11 +160,14 @@ Qualitative results live in `qualitative_mastery: {kp_id: bool}`; the map shows 
                        "mastery_estimate": 0.0, "timestamp": 1754567890 } ],
   "error_records": [ { "id": "e1", "knowledge_point_id": "kp01-01",
                        "error_type": "deviation", "status": "active" } ],
-  "repetition_states": { "kp01-01": { "interval_index": 0, "next_review_at": 1754571490 } },
+  "repetition_states": { "kp01-01": { "interval_index": 0, "consecutive_correct": 0,
+                                       "consecutive_wrong": 0, "difficulty": 0.5,
+                                       "stability": 1.0, "next_review_at": 1754571490 } },
   "review_queue": [ { "id": "review_kp01-01", "knowledge_point_id": "kp01-01",
-                      "due_at": 1754571490, "priority": 1 } ],
+                      "knowledge_type": "procedure", "due_at": 1754571490, "priority": 1 } ],
   "pending_question": { "question_id": "q3", "knowledge_point_id": "kp01-01",
                         "prompt": "...", "question_type": "short", "expected_answer": "..." },
+  "last_review_type": "concept",
   "version": 1
 }
 ```
@@ -140,3 +177,6 @@ Key points:
 - `pending_question.expected_answer` **lives server-side (this file)** and never round-trips to the user — grading never drifts (DeepTutor's `PendingQuestion`).
 - All timestamps are Unix seconds.
 - Once the file exists, **write it back atomically** (temp file + rename) at the end of each turn to avoid corruption.
+- `repetition_states[].difficulty` / `stability` are FSRS-inspired personalization
+  parameters (default 0.5 / 1.0; missing → treated as defaults for old data).
+  `last_review_type` is updated on each attempt and used to interleave review types.

--- a/skills/repo-mastery/references/mastery-policy.md
+++ b/skills/repo-mastery/references/mastery-policy.md
@@ -20,7 +20,9 @@ Distinguish two kinds of "knowing":
 All mechanisms in this policy fight the fluency illusion:
 
 - Confidence ceiling (one lucky answer ≠ mastery) → prevents fluency masquerading as mastery.
-- Feynman recital (not nodding along) → forces retrieval from storage.
+- Reference-answer restatement in the learner's own words (not nodding along) →
+  forces reconstruction that exposes gaps the given answer can hide; during
+  review it is true retrieval from storage.
 - Spaced review (delayed review) → only what survives forgetting counts as storage.
 
 **ZPD (zone of proximal development)**: what to teach next = challenge "just enough". Its inputs = `records/` (established understanding) + `progress.json` (mastery) + Mission (why the learner is here). Don't re-cover what's mastered; don't leap too far.
@@ -29,12 +31,17 @@ All mechanisms in this policy fight the fluency illusion:
 
 | type | Gate kind | Pass condition |
 |---|---|---|
-| `memory` | quantitative | recency-weighted accuracy ≥ **0.9** |
 | `procedure` | quantitative | recency-weighted accuracy ≥ **0.9** (with the key hands-on task passing as evidence) |
-| `concept` | qualitative | tutor judges the Feynman recital passed (`mastery_assess`) |
-| `design` | qualitative | tutor judges the recital + design-tradeoff follow-ups passed |
+| `concept` | qualitative | tutor judges the reference-answer restatement passed (`mastery_assess`) |
+| `design` | qualitative | tutor judges the restatement + design-tradeoff follow-ups passed |
 
-**Design axiom**: quantitative types (memory/procedure) use exact grading because most have a single correct answer; concept/design use qualitative judgment because "why is it designed this way" has no single canonical answer — this is exactly how DeepTutor splits it.
+> **`memory` has no gate.** It is a reference-notes type (cheatsheet), not a
+> knowledge-point type — see `curriculum-design.md`. The engine still accepts
+> `memory` in old maps for backward compatibility but treats it as already
+> covered (`is_mastered` returns true) and never creates review tasks for it, so
+> it can never block advancement.
+
+**Design axiom**: quantitative types (procedure) use exact grading because most have a single correct answer; concept/design use qualitative judgment because "why is it designed this way" has no single canonical answer — this is exactly how DeepTutor splits it.
 
 ## 2. Quantitative mastery (`compute_mastery`)
 
@@ -104,14 +111,37 @@ first, so consecutive reviews interleave types instead of stacking one type.
 **Advancement is computed from what is already mastered — never from a stage counter.** Priority, high to low:
 
 1. **A pending question** (`pending_question`) → grade it first (`answer_pending`).
-2. **A due review** → review first, so mastered ground doesn't decay (`review`).
-3. **The first unmastered knowledge point** (by module order, then point order):
+2. **The `flow_phase` gate** — the whole picture comes before the nodes. When
+   `flow_phase` is `overview` → `{action: "overview"}`; `module_overview` →
+   `{action: "module_overview", module_id: current_module_id}`. While the gate is
+   open the engine **refuses to hand out knowledge points**. A missing
+   `flow_phase` (old data) is treated as `learning` — the gate is skipped,
+   point-by-point continues (backward compatible).
+3. **The chapter gate** (textbook mode) — an in-progress `chapter` resumes it:
+   `{action: "chapter", module_id, module_name, chapter_status, section_index,
+   sections, due_review_count}`. Chapter learning is a continuous run, so a
+   resume continues the chapter, not a node; `due_review_count` signposts the
+   reviews waiting at the next natural pause.
+4. **A due review** → review first, so mastered ground doesn't decay (`review`).
+5. **The first unmastered knowledge point** (by module order, then point order),
+   **skipping modules in `chapter_covered_modules`** — a module whose chapter
+   gate passed is *covered*: its points were either engine-verified at after-class
+   checking or get validated via spaced review, never re-offered as fresh nodes.
+   The skip lives in the module-iteration layer, NOT in `is_mastered` (which has
+   no `module_id`). Their due reviews still surface (step 4) — covered ≠ forgotten.
+   - **`memory` points are skipped outright** — reference-only, never a next objective (engine-level; old maps stay valid).
    - Never touched → `probe` (test whether it can be skipped — **test-out path**: already-proven points are skipped, not forced through fixed stages).
    - Quantitative type below its gate → `practice` (keep working it until it clears).
    - Qualitative type → `assess` (Feynman check).
-4. **All mastered and nothing due** → `complete`.
+6. **All mastered and nothing due** → `complete`.
 
-`NextStep` actions: `answer_pending / review / probe / practice / assess / complete`.
+`NextStep` actions: `answer_pending / overview / module_overview / chapter / review / probe / practice / assess / complete`.
+
+**`mode: "review"`** (the `/repo-mastery review` command): skips the `flow_phase`
+gate, the **chapter gate**, and the unmastered-point step — pending question →
+due review → complete. So an unfinished overview *or* an in-progress chapter
+never blocks scattered-time review; review drains only what is due (including
+covered modules' points) and says `complete` when nothing is.
 
 ## 5. Error diagnosis and metacognition
 
@@ -128,16 +158,45 @@ Each error record: `error_type` + user's self-attribution + tutor confirmation +
 
 ## 6. Qualitative judgment (`mastery_assess`)
 
-Pass criteria for the Feynman check on concept/design points:
+The user sees the **reference answer first** (see `session-flow.md` §2) — the
+judgment is whether they can *critically engage with and restate* it, not
+verbatim recall. Pass criteria for the Feynman check on concept/design points:
 
-- **concept**: the user can explain in their own words "what + why + relation to adjacent concepts". Can't → not passed → return to explanation, record the error type.
-- **design**: beyond the recital, add design-tradeoff follow-ups — "why not the alternative? in what scenario would it fail? where is the extension point?" Being able to answer the tradeoffs = mastery.
+- **concept**: the user can restate the reference answer in their own words —
+  "what + why + relation to adjacent concepts" — moving beyond its phrasing to
+  their own mental model. Can't → not passed → return to explanation +
+  reference answer, record the error type.
+- **design**: beyond the restatement, add design-tradeoff follow-ups — "why not
+  the alternative? in what scenario would it fail? where is the extension
+  point?" Being able to answer the tradeoffs = mastery; echoing the reference
+  answer without engaging the tradeoffs ≠ mastery.
 
-**Causal questioning** (absorbed from RetainCraft): after the recital, push with
-causal probes to expose whether understanding is causal or merely associative —
+**Causal questioning** (absorbed from RetainCraft): after the restatement, push
+with causal probes to expose whether understanding is causal or merely echoed —
 "why this design instead of X?", "if we swapped Y in, what would break and
 where?", "which single change flips this behavior?" Causal answers count as
 mastery evidence; vague recall does not.
+
+**Vs-peer probing (ecosystem points, `m00`)** — the canonical three questions
+for module 0 / any design point whose reference answer involves a peer
+comparison (single source of truth; `quiz-design.md` and `session-flow.md`
+only cross-reference this). Pick the applicable one(s); the peer facts must be
+in `.learning/positioning.md` (cited `[web]` / `[src]`), never tutor memory:
+
+- **Swap** — "if we swapped this repo for <peer> in the setup your
+  Mission motivates, what breaks, what survives, and where does the migration
+  pain concentrate?" Passing = naming concrete touchpoints from the matrix
+  rows, not a vague "it'd be different".
+- **Decision** — "give me the decision rule: under what conditions
+  is <peer> the right pick, and under what conditions is this repo? Point to
+  the matrix row that makes the call." Passing = a transferable criterion, not
+  a feature list.
+- **Boundary** — "this repo chose X over Y vs <peer>. What scenario
+  makes that choice *fail* — where does X's weakness show?" Passing = naming
+  the failure mode on the other side of the tradeoff, echoing neither side.
+
+An unsourced vs-peer claim is a "facts to verify" search seed, never the reference
+answer behind these probes.
 
 Qualitative results live in `qualitative_mastery: {kp_id: bool}`; the map shows full value once passed, but the judgment itself is a boolean, not a score.
 
@@ -147,6 +206,8 @@ Qualitative results live in `qualitative_mastery: {kp_id: bool}`; the map shows 
 {
   "repo": "owner/name",
   "diagnostic": { "module_mastery": {} },
+  "flow_phase": "learning",             // overview | module_overview | learning (missing → learning)
+  "current_module_id": "m01",           // module whose overview is pending (module_overview phase)
   "modules": [
     { "id": "m01", "name": "Build & environment", "order": 1,
       "pass_threshold": 0.7,
@@ -167,6 +228,9 @@ Qualitative results live in `qualitative_mastery: {kp_id: bool}`; the map shows 
                       "knowledge_type": "procedure", "due_at": 1754571490, "priority": 1 } ],
   "pending_question": { "question_id": "q3", "knowledge_point_id": "kp01-01",
                         "prompt": "...", "question_type": "short", "expected_answer": "..." },
+  "chapter": { "module_id": "m01", "status": "teaching",   // textbook mode: teaching | qna | verifying
+               "section_index": 2, "sections": 5 },       // (absent when no chapter in progress)
+  "chapter_covered_modules": ["m01"],                     // modules whose chapter gate passed
   "last_review_type": "concept",
   "version": 1
 }
@@ -174,9 +238,59 @@ Qualitative results live in `qualitative_mastery: {kp_id: bool}`; the map shows 
 
 Key points:
 
+- `flow_phase` (`overview` → `module_overview` → `learning`) gates
+  `next_objective`: while an overview is unfinished the engine refuses new
+  points. Missing defaults to `learning` (old data continues point-by-point).
+  `current_module_id` records which module's overview is pending. Advance via
+  `set-phase <progress> <phase> [--module <id>]`.
 - `pending_question.expected_answer` **lives server-side (this file)** and never round-trips to the user — grading never drifts (DeepTutor's `PendingQuestion`).
 - All timestamps are Unix seconds.
 - Once the file exists, **write it back atomically** (temp file + rename) at the end of each turn to avoid corruption.
 - `repetition_states[].difficulty` / `stability` are FSRS-inspired personalization
   parameters (default 0.5 / 1.0; missing → treated as defaults for old data).
   `last_review_type` is updated on each attempt and used to interleave review types.
+- `knowledge_types` may still hold `memory` (old maps) but the engine never
+  builds review tasks for it — memory is reference-only (see `curriculum-design.md`).
+
+### Module-level gate (`chapter-complete`) — review-init rules
+
+Textbook mode (the default chapter flow) ends a module with `chapter-complete`,
+the engine's module-level gate. For each **non-`memory`** knowledge point in
+the module:
+
+1. **No `repetition_states`** → initialise a fresh first-review state
+   (written directly, **never via `schedule_next`** — that would fabricate a
+   "answered correctly" record the learner never produced):
+   `{interval_index: 0, consecutive_correct: 0, consecutive_wrong: 0,
+   difficulty: 0.5, stability: 1.0, next_review_at: now + INTERVAL_SEQUENCES[type][0] * 86400}`.
+2. **Has state but not mastered** (procedure: `mastery_levels < 0.9`;
+   concept/design: `qualitative_mastery != true`) → **reset** to the same
+   first-review state, so a lucky review streak can't inherit a lengthened interval.
+3. **Has state and mastered** (key node verified at after-class checking) →
+   **keep** the existing state and real engine records
+   (`qualitative_mastery` / `quiz_attempts`) untouched.
+
+Always write `knowledge_types[kp_id] = kp_type` and rebuild the review queue
+(`_rebuild_review_queue`) — `_rebuild_review_queue` reads `knowledge_types` and
+drops points whose type is missing (treated as `memory`), which would silently
+remove covered points from review. The module is then added to
+`chapter_covered_modules` (dedup) and the `chapter` state cleared.
+
+**Display convention (status / COVERAGE.md)**: a point whose module is in
+`chapter_covered_modules` is shown as **"Covered · awaiting review verification"**, not as
+unmastered — covered means "module studied, true mastery pending spaced
+review", a third state alongside unmastered and mastered (real engine
+records). Never list a covered point under the unmastered column. Display
+labels localize to the teaching language. English canonical: not-yet-learned /
+Covered · awaiting review verification / mastered.
+
+**This gate never fabricates mastery**: unverified points get real spaced
+review and build mastery only from actual correct/incorrect attempts — the
+"fluency ≠ storage" axiom holds (no fake `mastery_levels`, no broken confidence
+ceiling). Key nodes checked after class keep their genuine engine records.
+
+`set-qualitative <progress> --kp <id> --type concept|design --pass|--fail`
+records an after-class qualitative judgment: writes `qualitative_mastery[kp]`,
+and on `--pass` initialises the point's first review (same fresh state above)
+if none exists, then rebuilds the queue — so a passed concept/design point is
+scheduled for spaced review instead of being dropped.

--- a/skills/repo-mastery/references/module-brief-template.md
+++ b/skills/repo-mastery/references/module-brief-template.md
@@ -6,6 +6,8 @@
 
 To explain a knowledge point well, you usually need 2–4 key source snippets. Re-reading whole files every turn burns tokens repeatedly. **Pre-extraction** condenses "what this code does" into the brief; the tutor quotes the brief and only Reads source when the brief lacks detail.
 
+> **Feeds the source walk**: the pre-extracted snippets in `briefs/` feed the chapter's source walk — the key fragment (3-15 lines) directly, and the full `<details>` source when the slice is within the brief's 20-line cap. For longer slices the tutor Reads the wider range from the repo (located via `code-map.json`), so the full source is never truncated.
+
 ## When to write a brief
 
 - Large repos (Phase 0 judgment): one brief per module before learning it.
@@ -17,7 +19,7 @@ To explain a knowledge point well, you usually need 2–4 key source snippets. R
 Write to `<repo>/.learning/briefs/<module>.md`:
 
 ```md
-# Module Brief — <module title>（<module_id>）
+# Module Brief — <module title> (<module_id>)
 
 **Evidence locations**
 - Top-level dir / core file: <path>

--- a/skills/repo-mastery/references/module-brief-template.md
+++ b/skills/repo-mastery/references/module-brief-template.md
@@ -1,0 +1,67 @@
+# Module Brief Template — Pre-extracted Source Snippets
+
+> **Read in**: Phase 3, **for large repos** (or when the user asks to save tokens). Before learning a module, write a brief that pre-extracts the module's **key source snippets + evidence locations**, so later turns don't re-Read the source repeatedly. Absorbed from docs-to-course's `module-brief-template.md` (it pre-extracts commands/config; we pre-extract source).
+
+## Why it saves tokens
+
+To explain a knowledge point well, you usually need 2–4 key source snippets. Re-reading whole files every turn burns tokens repeatedly. **Pre-extraction** condenses "what this code does" into the brief; the tutor quotes the brief and only Reads source when the brief lacks detail.
+
+## When to write a brief
+
+- Large repos (Phase 0 judgment): one brief per module before learning it.
+- Small/medium repos: worth it when a module has lots of source or a long call chain.
+- Keep the brief at `.learning/briefs/`; reuse it in later review sessions.
+
+## Brief template
+
+Write to `<repo>/.learning/briefs/<module>.md`:
+
+```md
+# Module Brief — <module title>（<module_id>）
+
+**Evidence locations**
+- Top-level dir / core file: <path>
+- Entry function: <file>:<line>
+
+## Teaching arc
+- One-line "why care" (practical payoff)
+- The key mental model (one core picture the user should leave with)
+- Key-implementation highlights of this module (if any)
+
+## Knowledge point → evidence map (core)
+| Knowledge point | type | snippet (file:line) | one-line note |
+|---|---|---|---|
+| kp01-01 | procedure | `src/main.py:42-58` | the launch entry, responsible for… |
+| kp01-02 | concept | `src/pipeline.py:120-160` | RAG retrieval main chain |
+
+## Pre-extracted snippets (verbatim, with file:line)
+> Only include snippets needed to teach the points; each ≤ 20 lines. Longer → split or write "see <file>:<range> to expand".
+
+### Snippet A — Launch flow (src/main.py:42-58)
+```python
+<verbatim source>
+```
+**Note**: what this does, why this order, where it's easy to go wrong.
+
+### Snippet B — RAG main chain (src/pipeline.py:120-160)
+```python
+<verbatim source>
+```
+**Note**: …
+
+## Pitfalls / traps
+- Where the user is likely to get stuck (anticipate via error types: structural/deviation/application/metacognitive)
+
+## Neighboring module handoff
+- Previous module covers: …
+- Next module covers: …
+
+## Feynman follow-ups for this module (design type)
+- Why not approach B? → evidence-backed answer: …
+```
+
+## Iron rules
+
+- **Snippets must be verbatim**: copy the source unchanged, with `file:line`. Keep notes separate from source; never mix.
+- **Less is more**: only pre-extract what's needed to teach the points. Snippets over 20 lines get a location (`file:line`) in the brief, not the full text.
+- **The brief is an evidence cache, not the authority**: if learning reveals the brief is unclear, go back to source, verify, and update the brief.

--- a/skills/repo-mastery/references/note-template.md
+++ b/skills/repo-mastery/references/note-template.md
@@ -1,6 +1,6 @@
 # Note Template — Note Format
 
-> **Read in**: Phase 3. After each module's explanations/judgments, the tutor **automatically** accumulates key points into `notes/<module>.md`; the user appends personal thoughts/questions/blockers at any time with `/repo-mastery note "<text>"`. Notes are the context for later review and sessions (absorbed from DeepTutor's notebook idea).
+> **Read in**: Phase 3. After each section's discussion, the tutor **automatically consolidates** the conversation (key takeaways + your Q&A conclusions + cheatsheet + blockers + Feynman records) into `notes/<module>.md` — the **per-turn diary**, always fresh on substance (mechanical turns skip it; see `session-flow.md` §7). `/repo-mastery note ["<text>"]` is the **manual interval complement**: it consolidates **the discussion since the last note** (deduplicated against the auto diary) into a `### Interval synthesis (区间整理)` recap block + the relevant sections, updates `notes/.boundary.json`, and appends any `<text>` verbatim to "My notes". Notes are the context for later review and sessions (absorbed from DeepTutor's notebook idea).
 
 ## Note file organization
 
@@ -8,6 +8,7 @@
 <repo>/.learning/notes/
   ├── m01-run-build.md     # one per module; named <module_id>-<slug>.md
   ├── m02-architecture.md
+  ├── .boundary.json       # /note interval boundary: {"module_id": "m01", "last_consolidated_at": <unix>}
   └── README.md            # note index: module → file + one-line status
 ```
 
@@ -33,8 +34,16 @@
 deeptutor kb create physics --doc ch1.pdf
 ```
 
-## My notes (/note appended)
-> User-appended content, kept verbatim; the tutor never rewrites the user's words.
+## Interval consolidation (/repo-mastery note)
+> Manual, on-demand synthesis of the discussion **since the last note** — the differentiator vs the per-turn auto diary above. **Deduplicated**: never re-write what auto already wrote (repetition is wasted tokens). Boundary tracked in `notes/.boundary.json` — read it for the interval start, update it after each note; absent → from session/module start. Cross-session / pre-compaction intervals are recovered from this note + `records/`; unrecoverable detail is marked 「需回顾」 ("needs review"), never invented.
+
+### Interval synthesis (区间整理) — <ISO date> <UTC>, since last note <time> — <one-line recap>
+- <2–4 distilled takeaways from this interval's discussion>
+- <new Mission links, if any>
+- <Q&A conclusions / new blockers / cheatsheet additions / Feynman records — landed in their sections above, deduplicated>
+
+## My notes (/note text)
+> User-appended content via `/repo-mastery note "<text>"`, kept verbatim; the tutor never rewrites the user's words.
 
 - 2026-08-07: I don't get why message queue instead of RPC here —— <user text>
 - …
@@ -64,8 +73,91 @@ deeptutor kb create physics --doc ch1.pdf
 
 ## Division of labor: auto vs manual
 
-- **Auto-accumulated** (tutor's job): key points, command cheatsheet, blocker table, Feynman self-checks, due reviews. Updated after each explanation and judgment.
-- **Manual append** (user's job): `/repo-mastery note "..."` goes verbatim into the "My notes" section. **The tutor never rewrites the user's words** — but may register it as a blocker/review point in the Blockers section.
+- **Auto-consolidated** (tutor's job): after each section's discussion — and every other **substantive** turn — consolidate key points + Q&A conclusions + command cheatsheet + blocker table + Feynman self-checks + due reviews into the module note. Updated after each explanation and judgment; mechanical turns (review drain, simple confirmation) skip it and defer to the next substantive turn (see `session-flow.md` §7).
+- **Manual trigger** (user's job): `/repo-mastery note ["<text>"]` consolidates **the discussion since the last note** — read `notes/.boundary.json` for the interval start (absent → session/module start), extract that interval's Q&A conclusions / new blockers / cheatsheet additions / Feynman records **deduplicated against the auto diary**, write a `### Interval synthesis (区间整理)` recap block, then update `notes/.boundary.json`. Any `<text>` goes verbatim into "My notes". **The tutor never rewrites the user's words** — but may register it as a blocker/review point in the Blockers section.
+
+## Chapter material (textbook-mode) template — `chapters/<module>.md`
+
+The textbook-mode deliverable (the default on entering each new module): a **complete chapter**
+written up front, then taught section by section. It is the *material the tutor
+teaches from* — distinct from the module note above (which stays a fragmented,
+auto-consolidated diary of the discussion). One file per module, generated on
+entering the module (large repos: pre-extract snippets via
+`module-brief-template.md` into `briefs/` first).
+
+```md
+# Chapter N — <module title>（教材式）
+
+> 学习方式：跟随材料逐节学习 → 课后答疑 → 课后检验 → 章节完成（模块级闸门）
+> 材料生成: <ISO date> | 章节状态: teaching → qna → verifying → complete
+
+## 0. 章节导言
+> 为什么学这一章（价值 brief 里的一句话）→ 这一章解决什么问题 → 与前/后章的衔接。
+> 一张全景图：模块在整体架构中的位置、模块内部结构、核心数据流。
+
+## 1. <Section 标题 — 对应知识点>
+> 每节 = 一个知识点。以下子结构逐节循环：
+
+### 1.1 学习目标
+> 本节学完你能回答什么问题（1-2 条，可检验）。
+
+### 1.2 讲解 + 源码走读
+> 讲解（概念 + 一个比喻 + 为什么这样设计）。源码走读用三段式：`file:line` 定位 →
+> **关键片段**（教学核心）→ `<details>` 折叠的完整源码。逐节循环：
+
+**Source walk** — `src/pipeline.py:120-125`
+
+```python
+# Key fragment (teaching core, 3-15 lines) — 教学核心，短而美
+def build_chain(self):
+    return rag_chain  # 检索 + 生成 串成一条链
+```
+
+<details><summary>Full source · `src/pipeline.py:120-125` (click to expand)</summary>
+
+```python
+# Full implementation — 完整实现，折叠展示
+def build_chain(self):
+    retriever = self._make_retriever(top_k=5)
+    prompt = hub.pull("rag/prompt")
+    llm = self._model
+    return rag_chain
+```
+</details>
+
+> Source-walk format notes（三段式格式说明）：
+> - `file:line` stays as a locator — 仅作定位，学习者可回 IDE 看更广的上下文。
+> - The key fragment is the teaching core — 教学核心，短而美（3-15 行）。It is cut
+>   from the full source below (a subset of it) — 从下方完整源码中剪出的教学核心（子集）。
+> - The full source lives in a `<details>` block（Markdown-compatible）：Claude Code
+>   终端与 GitHub 上均可折叠，HTML 课程渲染同样折叠。
+> - The code-fence language follows the source file's extension (py/c/ts/go/rs…) —
+>   代码围栏语言跟随文件扩展名（py/c/ts/go/rs…）。Otherwise the HTML course
+>   highlighting breaks — 否则 HTML 课程语法高亮失效。
+
+### 1.3 小结
+> 3-4 条 takeaways，可自查。
+
+### 1.4 课后思考题
+> 1-2 题深度题（trace / why / tradeoff，非记忆题）。
+> **kp_id 标注**：必须对应 course-map 的 knowledge_point_id——
+> 课后检验时 tutor 用这些题走引擎判定（concept/design → set-qualitative，
+> procedure → record-attempt）。
+
+## 2. 章节总结
+> 一张「本章学到了什么」的收束：模块心智模型 + 关键 file:line 索引 + 与整体架构的钩子。
+
+## 3. Cheatsheet
+> 命令/参数/API 拼写 verbatim（memory 型内容，参考性，不进闸门）。
+
+## 4. 课后检验记录
+> （课后阶段追加）关键节点检验结果：kp_id → 判定 passed/failed →
+> 引擎返回（qualitative_mastery / mastery）→ 未检验点初始化的复习计划。
+```
+
+Key differences vs the per-module note: written **up front, complete**; sections
+map 1:1 to knowledge points **with kp_id on the after-class reflection questions (课后思考题)**; it is a teaching
+carrier (the tutor walks it), not a discussion diary.
 
 ## Iron rules
 
@@ -73,3 +165,5 @@ deeptutor kb create physics --doc ch1.pdf
 - Commands/config must be verbatim (the user will copy them).
 - Notes update **incrementally**: append new content, don't rewrite the whole file (token economy).
 - Review sessions read notes first rather than re-reading source — notes are your long-term memory.
+- Chapter after-class reflection questions (课后思考题) must carry the course-map `kp_id` — without it after-class checking cannot go through the engine gate.
+- `/repo-mastery note` consolidates the **interval since the last note**, deduplicated against the auto diary — never re-write what auto already wrote; pre-compaction interval content is recovered from notes/`records/`, never invented.

--- a/skills/repo-mastery/references/note-template.md
+++ b/skills/repo-mastery/references/note-template.md
@@ -1,0 +1,75 @@
+# Note Template — Note Format
+
+> **Read in**: Phase 3. After each module's explanations/judgments, the tutor **automatically** accumulates key points into `notes/<module>.md`; the user appends personal thoughts/questions/blockers at any time with `/repo-mastery note "<text>"`. Notes are the context for later review and sessions (absorbed from DeepTutor's notebook idea).
+
+## Note file organization
+
+```text
+<repo>/.learning/notes/
+  ├── m01-run-build.md     # one per module; named <module_id>-<slug>.md
+  ├── m02-architecture.md
+  └── README.md            # note index: module → file + one-line status
+```
+
+## Per-module note structure
+
+```md
+# Module N — <title>
+
+> Status: in-progress / mastered / has-blockers
+> Mastery: <module-level average | qualitative result>
+> Last updated: <ISO date> <UTC time>
+
+## Key points (auto-accumulated)
+> Appended after each explanation. Each = one self-checkable takeaway with a source reference (file:line).
+
+- **Takeaway title** — one-sentence conclusion. `src/pipeline.py:120` `RAG main chain: …`
+- …
+
+## Command / config cheatsheet
+> Verbatim, so the user can copy-and-use.
+
+```bash
+deeptutor kb create physics --doc ch1.pdf
+```
+
+## My notes (/note appended)
+> User-appended content, kept verbatim; the tutor never rewrites the user's words.
+
+- 2026-08-07: I don't get why message queue instead of RPC here —— <user text>
+- …
+
+## Blockers
+> Diagnosed blockers (error type + attribution), mapped to review tasks.
+
+| Knowledge point | Blocker | Error type | Status |
+|---|---|---|---|
+| kp01-01 | don't understand async prerequisite | structural | active |
+
+## Feynman self-check
+> When a qualitative point passes, record the distilled version of the user's recital (one line).
+
+- kp01-02 (concept): user recital = "…"
+
+## Resources / primary sources (absorbed from the teach skill)
+> Recommend 1 high-quality primary source per module for going deeper — official docs / design docs / papers / maintainer talks. This is the "keep going on your own" entry point.
+
+- Official docs: <link>
+- Design doc / ADR: <link>
+- Source file worth reading closely: `file:line`
+
+## Due reviews
+> Synced from `progress.json`'s `review_queue`, for quick entry into review in later sessions.
+```
+
+## Division of labor: auto vs manual
+
+- **Auto-accumulated** (tutor's job): key points, command cheatsheet, blocker table, Feynman self-checks, due reviews. Updated after each explanation and judgment.
+- **Manual append** (user's job): `/repo-mastery note "..."` goes verbatim into the "My notes" section. **The tutor never rewrites the user's words** — but may register it as a blocker/review point in the Blockers section.
+
+## Iron rules
+
+- Source references in notes carry `file:line` for traceability.
+- Commands/config must be verbatim (the user will copy them).
+- Notes update **incrementally**: append new content, don't rewrite the whole file (token economy).
+- Review sessions read notes first rather than re-reading source — notes are your long-term memory.

--- a/skills/repo-mastery/references/positioning-brief.md
+++ b/skills/repo-mastery/references/positioning-brief.md
@@ -1,0 +1,95 @@
+# Positioning Brief (read in Phase 2)
+
+> **Read in**: Phase 2. Turns the value brief's "what makes it stand out vs
+> peers" from an improvised one-liner into a **sourced, persistent comparison
+> matrix**. A developer learning a large open-source project wants to know
+> *what it is, how it trades off against its natural peers, and when to pick it*
+> before diving into architecture — this brief is that deliverable. Produces
+> `<repo>/.learning/positioning.md`.
+
+## Three names, three roles — keep them straight
+
+| Name | Role | Kind |
+|---|---|---|
+| `references/positioning-brief.md` | this file — the skill's template/protocol (Phase 2) | skill reference |
+| `<repo>/.learning/positioning.md` | the per-repo **persistent output** (comparison matrix + sources + decision rules) | learning artifact |
+| **value brief** (existing, `clarification-interview.md` §0) | the Phase 2 in-chat proposal (teaching-capability inventory + differentiation) | conversation |
+
+The value brief stays a conversation proposal; it is **not** merged into
+`positioning.md`. Its differentiation section is *read from* `positioning.md`
+— never improvised on the spot.
+
+## Flow (Phase 2, after the Phase 1 repo-internal pre-scan)
+
+1. **External ecosystem scan** — if a web/search tool is available
+   (WebSearch in Claude Code, any MCP search), compare against the repo's
+   natural peers. If not, skip straight to a repo-evidence-only brief (see
+   Source rules).
+2. **Produce `positioning.md` in two passes** (the Mission is settled *after*
+   the value brief, so the matrix must not depend on it before it exists):
+   - **Pass 1 (before the Mission interview)**: a generalized draft — the
+     repo's natural peers, categorized rows. Do not over-research; breadth of
+     categories first.
+   - **Pass 2 (after the Mission is settled)**: prune/deepen the rows the
+     Mission actually cares about (e.g. Mission = "borrow the design" →
+     deepen the agent-loop/architecture rows; Mission = "use it" → deepen
+     operations/ecosystem rows). Write the 3–5 line summary into `MISSION.md`.
+3. **Present the value brief** — differentiation section = 2–4 key matrix rows
+   + the "when to pick it" rule. Do **not** dump the full matrix into chat; it
+   lives in `positioning.md`.
+4. **Global overview (Phase 3.0)** later reuses the same one-liner/rows — one
+   source, three touchpoints (value brief teaser → overview summary → m00
+   module if kept).
+
+## Output structure — `<repo>/.learning/positioning.md`
+
+```markdown
+# Positioning — <repo>
+> Updated: <ISO date> ｜ Sources: [src]=repo 源码 · [web]=外部 URL+访问日期 · [unv]=未验证 tutor 记忆
+> The ecosystem goes stale: when facts change, update this file and write a learning record per the learning-records rules.
+
+## One-line positioning
+<what niche, for whom, what it deliberately is not>  [src] <file:line> or [web] <URL>
+
+## Ecosystem comparison table
+| Peer 同类项目 | Dimension 维度 | Peer's approach 同类做法 | This repo's approach 本项目做法 | Key tradeoff 关键取舍 | When to pick this 何时选本项目 | Source 来源 |
+|---|---|---|---|---|---|---|
+| <peer> | <dimension> | <peer's approach> | <this repo's approach> | <key tradeoff> | <when to pick this> | [web] URL(date) or [src] or [unv] |
+| ...    | ...    | ...    | ...    | ...    | ...    | ...    |
+
+## When to pick it / when to pick a peer (transferable criteria)
+- Pick this repo if: ...
+- Pick a peer if: ...
+- Criteria (rules transferable across projects): ...
+
+## Facts to verify (never enter the comparison table)
+- <claim> — no source; needs a WebSearch or mark [unv]
+
+## Anti-patterns
+- An uncited comparison row → may only enter "facts to verify（待验证）", never the table
+- Passing off tutor memory as a source-walk conclusion → forbidden
+- External facts into MISSION.md / COVERAGE.md → forbidden; this file only
+```
+
+The matrix has **7 fixed columns** (peer × dimension × peer's approach × this
+repo's approach × key tradeoff × when to pick this repo × source). Rows are
+peer×dimension — one peer may appear in several rows (different dimensions).
+The "when to pick it" column is the evidence anchor for m00's `kp00-03`.
+
+## Source rules (facts never mix)
+
+- **Repo facts** (what *this* repo does / its architecture / its code): from
+  source only — cite `file:line` / README. A web result about the repo itself
+  **never overrides a source walk**; the repo is the authority for itself.
+- **Peer / ecosystem facts** (what a comparable project does, benchmark
+  numbers, ecosystem context): from an external search **only** when a search
+  tool is available. Cite `[web] <URL>` + access date. Prefer primary sources
+  (official docs/README/release notes/benchmark repos) over blog posts over
+  aggregator lists; 1+ URL per comparison claim when possible; when sources
+  contradict, present both and note the difference instead of resolving
+  silently; date-stamp every external fact.
+- **`[unv]`** — an uncited tutor-memory claim. Allowed only as a *seed for a
+  search* or as a row in "facts to verify（待验证）". **Never** as a gated
+  reference answer, never as a MISSION.md claim, never in a quiz.
+- **Degraded mode**: no search tool → build the brief from repo evidence and
+  mark peer rows `[unv]` / "待验证". **Never fabricate a source.**

--- a/skills/repo-mastery/references/preview-brief.md
+++ b/skills/repo-mastery/references/preview-brief.md
@@ -1,0 +1,62 @@
+# Preview Brief (read before Phase 0, optional)
+
+> **Read in**: before Phase 0 (optional pre-flight). The user has a new repo
+> and may only want to see "what it is, what the architecture looks like, how
+> it differs functionally, what's worth learning deeply" — **whether to start a
+> course is decided later**. `preview` is that scouting entry — it **only
+> produces a macro brief in chat**: no `.learning/`, no engine, no files
+> written (zero side effects).
+
+## 1. Trigger
+
+`/repo-mastery preview <local-path | github:owner/repo>` — user wants to scout
+first; has not yet committed to starting a course.
+
+## 2. Output — the macro brief (in chat, five sections)
+
+1. **What it is（这是什么）** — one-line positioning + tech stack + scale (lines
+   of code / top-level module count; for very large repos `index_repo.py` may
+   be used ad hoc to produce a `code-map.json` for orientation, but **not
+   persisted to `.learning/`**).
+2. **Architecture panorama（架构全景）** — entry → core data flow → key modules,
+   a 1–2 paragraph narrative (reuses the Phase 3.0 global-overview output
+   style, see `session-flow.md`).
+3. **Functional differentiation vs peers（功能差异点）** — 2–4 lines, tagged
+   `[src]` / `[web]` (source discipline identical to `positioning-brief.md`:
+   repo facts `file:line`, peer facts `[web]` + URL, uncited facts marked
+   「待验证」, never fabricated; **preview does not persist `positioning.md`** —
+   that full matrix is built only when `start` opens a course).
+4. **Key implementation highlights（关键实现亮点）** — 3–5 points most worth
+   learning, each with `file:line` evidence.
+5. **Suggested deep-dive candidates（建议深学候选）** — which modules/points
+   warrant a course (feeds the `start` course-map proposal).
+
+## 3. Zero side effects (hard)
+
+- No `.learning/`; no MISSION / positioning / course-map / progress / notes.
+- No engine (no state change); `index_repo.py` only ever produces a temporary
+  `code-map.json` for very large repos (in `/tmp` or read in place, **not**
+  into `.learning/`).
+- No Mission clarification, no map confirmation — that belongs to `start`.
+  preview ends and leaves nothing behind.
+
+## 4. Handoff to start (deep-dive)
+
+User says deep-dive（深学）→ in the same session, run `/repo-mastery start
+<repo>` directly. The preview brief's content (architecture narrative +
+differentiation + highlights) becomes the input to start's Phase 2 value brief,
+so start skips the redundant re-scouting (Phase 0 complexity check + Phase 1
+pre-scan re-read) and proceeds through: Phase 1 course-map proposal → Phase 2
+value brief + Mission/confirmation. preview persists nothing; `start` builds
+the formal files from the brief (MISSION.md / positioning.md / course-map.json).
+
+Cross-session handoff (user says deep-dive later) → `start` re-runs Phase 0/1/2
+and the brief is regenerated at `start` time.
+
+## 5. Relationship to positioning-brief.md
+
+preview is **lightweight scouting** (in-chat brief, nothing persisted, no
+matrix); positioning-brief is **course positioning** (Phase 2 builds the full
+`positioning.md` comparison matrix that drives course trimming). Both share the
+same `[src]` / `[web]` source discipline; preview never writes `positioning.md`
+and never builds the positioning matrix.

--- a/skills/repo-mastery/references/quiz-design.md
+++ b/skills/repo-mastery/references/quiz-design.md
@@ -1,0 +1,60 @@
+# Quiz Design — Principles (Test Application, Not Memory)
+
+> **Read in**: Phase 3, when posing quantitative questions. This principle is absorbed from docs-to-course's `content-philosophy.md`, adapted for "code understanding".
+
+## The iron rule: test application, not memory
+
+The value of a question is: **a wrong answer reveals "can't use / don't understand", not "didn't memorize"**. Definitions are the job of a glossary tooltip, not a quiz.
+
+**What to test (best first)**:
+1. **"What would you do" scenarios** — "to add feature X to this project, which extension point/module would you use?" Gold standard.
+2. **Tracing** — "which modules does this request pass through, from entry to storage?" Tests call-chain understanding.
+3. **Troubleshooting scenarios** — "startup fails with `ImportError: xxx` — most likely cause and first thing to check?"
+4. **Tradeoff/decision questions** — "for task Z, would you pick A or B? Why?" Tests design understanding.
+5. **"What is it / why"** — short definition + one why.
+
+**What NOT to test**:
+- ❌ Verbatum definitions (that's memory, and scrollable).
+- ❌ Exact flag/argument spelling (unless the point is explicitly a memory type).
+- ❌ Anything answerable by scrolling up.
+
+## Question formats (for code learning)
+
+| Form | Use for | Example |
+|---|---|---|
+| Multiple choice (with scenario) | fast grading, most memory/procedure | "which is the correct config-load precedence? A) … B) … C) …" |
+| Sequencing | call chains / flows | "arrange build → install → launch in the real order" |
+| Fill-in / short answer | procedure, must write it | "after `deeptutor kb create`, which command searches the KB?" |
+| Small code change | understanding a function's behavior | "change one line here to make it output X — which line?" |
+
+## Tone of grading and feedback
+
+- **Wrong answers get encouraging, teaching explanations**: "not quite — B is right here because A bypasses the config-loading layer…" Never punitive, no score anxiety.
+- Correct answers **reinforce the principle**, not just praise.
+- Quantity: 1–3 questions per point is enough to judge; don't inflate.
+
+## Option formatting: no clues (absorbed from the teach skill)
+
+- In multiple choice, keep **every option roughly equal in length** — don't let "the long one is right" leak the answer.
+- Avoid "all of the above / none of the above" cop-out distractors.
+- Distractors should look real — taken from genuinely confusable configs/modules/calls, not invented.
+
+## Retrieval practice first (absorbed from the teach skill)
+
+Grading should force **retrieval from memory**, not "recognizing the answer feels right":
+
+- Short-answer/fill-in > recognition multiple-choice: being able to write the call chain proves storage better than recognizing the right option.
+- Review turns especially use short-answer: the whole point of spaced review is retrieving after forgetting.
+- Frame multiple-choice as "scenario → what would you do", so the user forms the answer in their head before comparing options.
+
+## How grading drives mastery
+
+- Each attempt appends to that point's `quiz_attempts`.
+- `compute_mastery` recomputes (recency-weighted + confidence ceiling; see `mastery-policy.md`).
+- ≥ 0.9 advances; below → back to explain, then pose a **different question** (never the same one — avoid memorizing the answer).
+
+## When not to quiz
+
+- A point already has 2 correct attempts and mastery ≥ 0.9 → pose a harder "deepening" question or just advance.
+- The user explicitly wants to hear the explanation first → respect the pace, explain first.
+- A hands-on verification (procedure) already passed → it counts as evidence; no need to pile on a pointless question.

--- a/skills/repo-mastery/references/quiz-design.md
+++ b/skills/repo-mastery/references/quiz-design.md
@@ -58,3 +58,30 @@ Grading should force **retrieval from memory**, not "recognizing the answer feel
 - A point already has 2 correct attempts and mastery ≥ 0.9 → pose a harder "deepening" question or just advance.
 - The user explicitly wants to hear the explanation first → respect the pace, explain first.
 - A hands-on verification (procedure) already passed → it counts as evidence; no need to pile on a pointless question.
+
+## Flashcard quality standards (absorbed from the flashcards skill)
+
+A quiz/review card is a **self-test, not a reading note**. These rules govern how to craft **`memory`-type and review cards**; the iron rule above still holds — application questions remain the gold standard for comprehension points. Quality rules:
+
+1. **Force recall, not recognition** — ask open questions where the answer must
+   be reconstructed, not recognized from options.
+2. **One card, one fact** — each card asks exactly one thing; keep it short.
+3. **One unambiguous answer** — the question has a single correct answer.
+4. **Answer ≤ 3 lines** — a too-long answer can't be retrieved.
+5. **Understanding before memorizing** — cover fundamentals first, then build up.
+6. **Elaborate and connect** — link the fact to something known, a vivid image, a
+   concrete example; extra retrieval paths make recall easier.
+7. **Context built into the question** — good: "What does `git stash pop`
+   restore?"; bad: "[Git] What does stash pop do?"
+8. **Break up lists** — split enumerations into single questions, or use
+   overlapping cards (A then B, B then C).
+9. **Distinguish similar concepts** — give confusable items distinguishing context.
+10. **Ask both directions** — A→B and B→A strengthen retention.
+11. **Timestamp perishable facts** — add "as of [year]" to current numbers.
+
+Avoid: trivial facts, answers longer than three or four lines, ambiguous
+questions, opinions instead of facts, lists as an answer.
+
+> Low-effectiveness techniques to avoid: summarizing, highlighting, and rereading
+> create **illusions of learning** (recognition ≠ recall). A tutor must never
+> substitute "re-read the summary" for a retrieval question.

--- a/skills/repo-mastery/references/quiz-design.md
+++ b/skills/repo-mastery/references/quiz-design.md
@@ -11,11 +11,15 @@ The value of a question is: **a wrong answer reveals "can't use / don't understa
 2. **Tracing** — "which modules does this request pass through, from entry to storage?" Tests call-chain understanding.
 3. **Troubleshooting scenarios** — "startup fails with `ImportError: xxx` — most likely cause and first thing to check?"
 4. **Tradeoff/decision questions** — "for task Z, would you pick A or B? Why?" Tests design understanding.
-5. **"What is it / why"** — short definition + one why.
+5. **Ecosystem-pick questions** — "this repo or <peer> for setup Z — which and why? Under what conditions would the other win?" Tests positioning understanding (module 0). The canonical vs-peer probes live in `mastery-policy.md` §6 — cross-reference those, never maintain a second source here.
+6. **"What is it / why"** — short definition + one why.
 
 **What NOT to test**:
-- ❌ Verbatum definitions (that's memory, and scrollable).
-- ❌ Exact flag/argument spelling (unless the point is explicitly a memory type).
+- ❌ Verbatim definitions (that's memory, and scrollable).
+- ❌ **Exact flag/argument spelling, CLI commands, parameter names** — these are
+  reference-note material (cheatsheet), never quizzed. They're numerous,
+  project-specific, and don't build transferable skill (learner field feedback;
+  see `curriculum-design.md`). The engine never gates on `memory` points.
 - ❌ Anything answerable by scrolling up.
 
 ## Question formats (for code learning)
@@ -39,13 +43,38 @@ The value of a question is: **a wrong answer reveals "can't use / don't understa
 - Avoid "all of the above / none of the above" cop-out distractors.
 - Distractors should look real — taken from genuinely confusable configs/modules/calls, not invented.
 
-## Retrieval practice first (absorbed from the teach skill)
+## Retrieval practice: learning vs review (absorbed from the teach skill)
 
-Grading should force **retrieval from memory**, not "recognizing the answer feels right":
+**Learning a new point is reference-answer-first, not blank recall** (learner
+field feedback; absorbed from mattpocock's `grill-me`): after explaining, give
+the reference answer and let the user **react to the proposal** — agree, push
+back, restate in their own words. There is **no independent blank-prompt
+answering** for concept/design.
 
-- Short-answer/fill-in > recognition multiple-choice: being able to write the call chain proves storage better than recognizing the right option.
-- Review turns especially use short-answer: the whole point of spaced review is retrieving after forgetting.
+**Review stays recall-first**: the whole point of spaced review is retrieving
+after forgetting. But a stuck user gets the reference answer as a catch-up,
+never a grinding blank prompt:
+
+- Short-answer/fill-in > recognition multiple-choice for review turns: being able to write the call chain proves storage better than recognizing the right option.
 - Frame multiple-choice as "scenario → what would you do", so the user forms the answer in their head before comparing options.
+- For a graded procedure question during learning, the user answers first, then you **immediately show the reference answer** for self-check.
+
+## Reference-answer interaction (grill-me style)
+
+The default interaction for learning a new point:
+
+1. **Explain** the point from source (discussion-first).
+2. **Present a reference answer** — the standard one-line statement, with `file:line`.
+3. **User reacts to the proposal**: agree, push back, ask where it differs from
+   their understanding, restate it in their own words.
+4. **Judge the reaction** — the quality of the engagement (did they catch the
+   mechanism, can they restate it, can they point at what would change), not a
+   verbatim recall.
+
+**Boundary** (the one place the answer is withheld): a **graded** procedure
+question keeps the expected answer in `progress.json.pending_question` and
+never shows it *before* the user answers; it is shown *right after*, for
+self-check. That is the only case where the answer is hidden at all.
 
 ## How grading drives mastery
 

--- a/skills/repo-mastery/references/session-flow.md
+++ b/skills/repo-mastery/references/session-flow.md
@@ -1,0 +1,99 @@
+# Session Flow — Interactive Learning Session Protocol
+
+> **Read in**: Phase 3. This is the operating manual for each learning turn. The tutor acts per this protocol every turn; decisions consult the rules in `mastery-policy.md`.
+
+## 0. Session preamble: Mission + ZPD (absorbed from the teach skill)
+
+Before each learning session:
+
+1. **Read MISSION.md** — why the user wants to master this repo. Align every explanation, question, and Feynman follow-up to the Mission (learning to use it? to modify it? to teach it?). If the Mission isn't filled in, ask — don't guess.
+2. **Read `records/` + `progress.json`** — judge the user's **zone of proximal development (ZPD)**: the next thing to teach should be "just challenging enough". Don't re-teach what the user has proven; bridge missing prerequisites before leaping.
+3. Then enter the knowledge point selected by `next_objective`.
+
+## Per-turn learning loop (single knowledge point)
+
+Run the flow for the action `next_objective` returns. **Core loop**:
+
+```text
+diagnostic (probe; includes test-out)
+   → explain
+   → feynman_check
+   → practice (quiz / hands-on)
+   → error_diagnosis (if wrong)
+   → review (spaced-review scheduling)
+   → write back progress.json + auto-note
+```
+
+## 1. diagnostic — first contact with each knowledge point
+
+- Purpose: **probe how much is known and skip what can be skipped (test-out)**; don't force every point through fixed stages.
+- Method: an open probe question — "first, in your own words, what does this knowledge point / module do?" — or a lightweight question.
+- Judgment: if the user explains/answers well → record `mastery_assess passed` or a high-scoring attempt → advance directly, **skipping the explanation**. This is the gate-as-cursor compression path.
+- Can't explain → enter explain.
+
+## 2. explain
+
+- **Explain from source, not from air**: cite specific files, functions, call chains (`file:line`).
+- Follow the per-module arc absorbed from docs-to-course: *"why care" first (1–2 sentences of practical payoff) → concept + one fresh metaphor → look at the code / walk the call chain → recap (3–4 takeaways)*.
+- **Auto-note** after explaining (see `note-template.md`).
+- Control length: one knowledge point, one layer at a time — don't dump three concepts at once.
+
+## 3. feynman_check — qualitative gate (concept / design)
+
+- Have the user recital in their own words: "now explain it back to me as if I'm a beginner."
+- **concept**: judge "what + why + relation to adjacent concepts".
+- **design**: add design-tradeoff follow-ups (see `mastery-policy.md` §6).
+- Result → `qualitative_mastery`; not passed → back to explain, record the error type.
+- **Input form**: the user types their recital in chat (no voice requirement).
+
+## 4. practice — quantitative gate / hands-on
+
+### Quiz (memory / procedure)
+- Follow `quiz-design.md` (**test application, not memory**).
+- **The expected answer goes only into `progress.json.pending_question` — never shown back in the question**.
+- User answers → grade via the **engine script** (deterministic, tool-agnostic):
+  ```bash
+  python3 scripts/learning_engine.py record-attempt <path>/.learning/progress.json \
+      --kp <kp_id> --type procedure --correct --question <qid> --write
+  ```
+- Advance only when the script reports `passed_gate: true` (≥ 0.9); otherwise return to explain + practice more.
+
+### Hands-on on demand (procedure especially)
+- Guide the user to actually verify: "verify it now — run `pytest tests/test_x.py`" or "write a 20-line demo calling this API."
+- **Command convention**:
+  - Read-only/no-side-effect commands (`build`, `test`, `--help`, `git log`): may run directly.
+  - Mutating operations (writing files, installing deps, writing data): **show the command and request approval first**.
+- Record the hands-on result (passed/behavior/user's demo code) as mastery evidence for that point.
+
+## 5. error_diagnosis — when wrong or stuck
+
+- First ask the user to self-attribute: "where do you think you got stuck?" (`self_attribution`).
+- The tutor classifies `error_type` (structural / deviation / application / metacognitive; see `mastery-policy.md` §5) and writes an `error_records` entry (status=active).
+- Create the matching review task (that point's review priority → 1).
+- Reteach: targeted explanation for the error type, then practice again.
+
+## 6. review — due spaced-review tasks
+
+- Pull due tasks by `scheduler`'s `next_review_at` (triggered by `/repo-mastery review`, or automatically when `next_objective` finds something due).
+- Review form: one question per due point (quantitative) or a quick recital (qualitative).
+- Results update `repetition_states` + `review_queue`.
+
+## 7. End of each turn (mandatory)
+
+1. **Atomically write back** `progress.json` (temp file + rename).
+2. **Auto-note / update** the module notes (`notes/<module>.md`).
+3. Update global `~/.repo-mastery/index.json` (where you left off).
+4. Report to the user in one line: current progress (e.g. "module 3/6, points 7/24, mastery 45%").
+
+## Tutor voice during sessions
+
+- You're present (Claude Code session); advance one knowledge point at a time; never cram the whole repo into context.
+- Explain from source, judge by engine — **never replace the gate with "do you feel you've got it?"**.
+- A stuck user is a diagnostic signal, not a teaching failure — guide self-attribution.
+- Keep momentum: close the loop on one point per turn where possible (judge + write back + note).
+
+## Token-saving rules for large repos
+
+- When learning a point, only Read files relevant to it (locate via `course-map.json` evidence paths / `code-map.json`); **don't read the whole repo**.
+- Large repos: consult `code-map.json`'s symbol table to locate `file:line`, then Read the needed slice.
+- Once source snippets are captured in notes, prefer reading the notes over re-reading source in later sessions.

--- a/skills/repo-mastery/references/session-flow.md
+++ b/skills/repo-mastery/references/session-flow.md
@@ -1,74 +1,228 @@
-# Session Flow — Interactive Learning Session Protocol
+# Session Flow — Learning Session Protocol (overview-first, discussion-driven)
 
 > **Read in**: Phase 3. This is the operating manual for each learning turn. The tutor acts per this protocol every turn; decisions consult the rules in `mastery-policy.md`.
 
-## 0. Session preamble: Mission + ZPD (absorbed from the teach skill)
+## 0. Session preamble: Session Preamble + Mission + ZPD (absorbed from the teach skill)
 
 Before each learning session:
 
-0. **Recall warm-up** (absorbed from claude-teach-skill): pose **2–3 quick
+0. **Session Preamble** (SKILL.md "Session Preamble", **mandatory** on every
+   resume — `continue`, or the bare command that routes into it, display-only —
+   no questions). **New course vs resume**:
+   - **New course** (current dir has no `.learning/`, or a fresh `start` on a
+     new target): start **clean** — do NOT read `~/.repo-mastery/` preferences
+     or `index.json`; teaching language follows the user's current input.
+   - **Resume** (current dir has `.learning/`): the preamble below reads the
+     current dir's files. Global memory (`~/.repo-mastery/profile.md`) is
+     referenced **only if the user explicitly asks** ("use my saved
+     preferences").
+   **Layered by session
+   type**: a **cross-session resume** (fresh session / long gap) replays the
+   **full preamble** — **value replay** (read `MISSION.md` + `positioning.md`
+   when present; one line: what this repo teaches + differentiation — the
+   "stands out vs peers" part is read from `positioning.md`, never improvised),
+   **current map + progress** (read `MASTERY.md` — the one-page status
+   dashboard, §8: module list, done X/Y, mastery %, review due, current
+   module/chapter, next objective), and **due review / chapter** (if
+   `next_objective` returns `action: "review"`, recall first, signposted; if
+   `action: "chapter"`, resume the textbook-mode chapter from its current
+   section; entering a new module defaults to the textbook-mode chapter flow).
+   A **same-session continue** (context already holds Mission / map / progress)
+   uses the **slim preamble** — one line: "Last session: learned X, next Y, N
+   reviews due",
+   read from `MASTERY.md`, no re-replay. Only after this does the cursor
+   advance.
+
+1. **Recall warm-up** (absorbed from claude-teach-skill): pose **2–3 quick
    recall questions** drawn from `review_queue` (due first, then soonest
    `due_at`). Each answer goes through `record_attempt` (updates mastery /
    difficulty / stability / schedule). A forgotten point → re-teach it before
    anything new, and record the error. This forces retrieval from storage, not
    recognition. A correct warm-up answer feeds `consecutive_correct` →
    `stability`, so a good warm-up streak lengthens the next interval.
+   (*memory-only content is never warm-up material — it's reference notes.*)
 
-1. **Read MISSION.md** — why the user wants to master this repo. Align every explanation, question, and Feynman follow-up to the Mission (learning to use it? to modify it? to teach it?). If the Mission isn't filled in, ask — don't guess.
+2. **Read MISSION.md** — why the user wants to master this repo. Align every explanation, question, and Feynman follow-up to the Mission (learning to use it? to modify it? to teach it?). If the Mission isn't filled in, ask — don't guess.
 2. **Read `records/` + `progress.json`** — judge the user's **zone of proximal development (ZPD)**: the next thing to teach should be "just challenging enough". Don't re-teach what the user has proven; bridge missing prerequisites before leaping.
-3. Then enter the knowledge point selected by `next_objective`.
+3. Then enter the phase below. For a fresh session this is the **global overview**; otherwise the module/node selected by `next_objective`.
 
-## Per-turn learning loop (single knowledge point)
+## Overview-first (the whole picture before the nodes)
 
-Run the flow for the action `next_objective` returns. **Core loop**:
+Learning starts with **the whole knowledge organization, then key-node
+discussion** — not point-by-point grinding (learner field feedback). This order
+is **engine-enforced**: `progress.json.flow_phase` gates `next_objective`
+(`overview` → `module_overview` → `learning`; missing defaults to `learning`),
+so while an overview is unfinished the engine refuses to hand out knowledge
+points. Two non-graded levels, run in this order, advancing the phase with
+`set-phase` after presenting each level:
+
+**Phase 3.0 — Global overview** (once, at the start of learning):
+deliver a one-page **architecture narrative** (entry → core data flow → key
+modules), a **module map** (each module in one line), **key-implementation
+highlights**, and a **differentiation summary** ("what makes this project stand
+out vs peers" — reuse the one-liner/rows from `.learning/positioning.md`, see
+`positioning-brief.md`; the full matrix stays there, see positioning.md).
+Write it to `notes/overview.md`. No grading, no interruption — the learner sees
+the skeleton before any node. Then advance:
+
+```bash
+python3 scripts/learning_engine.py set-phase <path>/.learning/progress.json module_overview --module m01
+```
+
+**Phase 3.1 — Module overview** (at the start of each module): deliver that
+module's knowledge-point map + its local **cheatsheet** (verbatim commands /
+parameters, auto-accumulated from `reference_notes`). Then advance:
+
+```bash
+python3 scripts/learning_engine.py set-phase <path>/.learning/progress.json learning
+```
+
+After the overviews, each knowledge point runs the per-point loop below. The
+engine's `next_objective` stays the cursor — it just never returns `memory`
+points (reference-only). Scattered-time review uses `/repo-mastery review`
+(`--mode review`), which bypasses the `flow_phase` gate and drains only due
+reviews — an unfinished overview never blocks it.
+
+## Per-point learning loop (single knowledge point) — interactive supplement
+
+The **supplement** to the default textbook-mode chapter, for three narrow uses:
+**test-out** (an already-known point is skipped via `next_objective`'s `probe`,
+not re-taught chapter-long), **single-point deep-dive** (deeper on one knowledge
+point), and **post-review reteach** (a failed review point retaught at point
+level). Run the flow for the action `next_objective` returns. **Core loop**
+(**discussion-first**: explain and discuss are the default; verification is
+lightweight and follows the explanation, never the other way around):
 
 ```text
-diagnostic (probe; includes test-out)
-   → explain
-   → feynman_check
-   → practice (quiz / hands-on)
-   → error_diagnosis (if wrong)
-   → review (spaced-review scheduling)
+overview (global + module)            ← once each, not per point
+   → explain (from source, discussion)
+   → reference answer + discuss (user reacts to the proposal, grill-me style)
+   → verify: Feynman recital (concept/design) | light question + self-check (procedure) | none (memory→cheatsheet)
+   → error_diagnosis (if wrong/stuck)
+   → review (spaced-review scheduling, concept/design/procedure only)
    → write back progress.json + auto-note
 ```
 
-## 1. diagnostic — first contact with each knowledge point
+## Textbook-mode chapter flow (flipped classroom)
 
-- Purpose: **probe how much is known and skip what can be skipped (test-out)**; don't force every point through fixed stages.
-- Method: an open probe question — "first, in your own words, what does this knowledge point / module do?" — or a lightweight question.
-- Judgment: if the user explains/answers well → record `mastery_assess passed` or a high-scoring attempt → advance directly, **skipping the explanation**. This is the gate-as-cursor compression path.
-- Can't explain → enter explain.
+**The default on entering each new module.** After the module overview, the
+tutor auto-starts this flow (`chapter-start`) unless the learner asks for the
+interactive per-point mode for that module (conversational switch — no flag, no
+persistence; one line of notice first, not a confirmation gate). Instead of the
+per-point loop above, a module is learned as a **complete chapter** first, then
+checked as a whole. Engine actions per step (`chapter_start` /
+`chapter_advance` / `chapter_complete` / `set-qualitative`; see
+`mastery-policy.md` §7 for the `chapter` state):
 
-## 2. explain
+```text
+1. generate chapters/<module>.md   (full teaching material; its HTML page is generated with the HTML course — confirmed at start + refreshed on completion, output to .learning/export/)
+     → chapter-start --module <m> --sections N      (validates flow_phase=learning, module exists, not covered, no pending)
+2. walk the chapter section by section    tutor explains section by section; the user follows the material and may interrupt with questions anytime
+     → [must pause after each section] give a natural confirmation point; call chapter-advance --section N only after an explicit user reply
+       (supports interrupt/resume); never advance multiple sections in a row without confirmation
+     → after all sections, pause for confirmation the same way before advance --status qna
+3. after-class Q&A → status=qna          user asks freely; the tutor answers and digests (may write a learning record)
+4. after-class checking → status=verifying  pose 1-2 deep questions on the chapter's key nodes:
+     concept/design → deep Q&A + tutor judgment → set-qualitative --kp <id> --type concept|design --pass|--fail
+     procedure     → pending_question + record-attempt (reuse the existing mechanism) + optional hands-on run verification
+5. chapter-complete                      module-level gate: key nodes keep their real records; unverified points get initialized
+                                         spaced-review; module added to chapter_covered_modules
+```
 
+Each section's source walk **pastes the relevant source directly** — a `file:line` locator, an inline key fragment (3-15 core lines), and the full source in a `<details>` collapsible block (see `note-template.md`). The tutor reads the source from the repo (or `code-map.json`/`briefs/` for large repos) and pastes it, instead of only citing the location.
+
+**Section-by-section confirmation (mandatory).** After finishing each section the
+tutor **stops and hands control back** — never auto-advance. Give a natural
+confirmation point ("This section is done. Any questions? If not, let's move on
+to the next."), then
+**wait for an explicit user reply** (a question, or "continue / got it"). Only after the
+user confirms does the tutor call `chapter-advance --section N`. Use the same
+pause before advancing out of `teaching` into `--status qna` (after-class Q&A). The
+engine cannot see the conversation, so *this pause is the protocol's job, not
+the engine's* — chaining several sections in one turn is a violation even if
+every `chapter-advance` call is individually valid.
+
+The chapter's **after-class reflection questions must align with the course-map `knowledge_point_ids`** —
+that is what lets after-class checking go through the engine's gate
+(`set-qualitative` / `record-attempt`). Large repos: pre-extract source
+snippets into `briefs/<module>.md` (module-brief-template) before writing the
+chapter, to save tokens.
+
+When `next_objective` returns `action: "chapter"`, the tutor **resumes that
+chapter** (it outranks due review in auto mode; `due_review_count` signposts how
+many reviews are waiting at the next natural pause). `mode="review"` bypasses
+the chapter gate so scattered-time review never blocks mid-chapter.
+
+## 1. explain — discussion-first (the default station)
+
+- **Discussion is the main event.** Explain from source, then **invite the
+  learner to engage**: ask what they think, compare with what they know, let
+  them push back. The pacing is conversational, not a Socratic interrogation.
 - **Explain from source, not from air**: cite specific files, functions, call chains (`file:line`).
 - Follow the per-module arc absorbed from docs-to-course: *"why care" first (1–2 sentences of practical payoff) → concept + one fresh metaphor → look at the code / walk the call chain → recap (3–4 takeaways)*.
-- **Auto-note** after explaining (see `note-template.md`).
+- **Auto-consolidate** the section's discussion into the module note after explaining (see `note-template.md`); this stays the per-turn diary — `/repo-mastery note` does the *interval* consolidation instead (see §6.5). Explanations are substantive turns: they always earn a consolidation; mechanical turns defer theirs to the next substantive one (see §7).
 - Control length: one knowledge point, one layer at a time — don't dump three concepts at once.
-- **Vivid encoding (optional, `memory`-type points)**: offer a memorable
-  hook — an exaggerated image, a color/action cue, a pun, an interaction
-  (SMASHIN-style: Senses, Movement, Action, Humor, Imagination, Numbers) — or let the learner ask for a mnemonic / mini memory-palace.
-  Encoding is a *suggested* aid, never graded.
+- **Light diagnostic on first contact (test-out)**: before teaching a fresh
+  point, one open question — "in your own words, what does this point do?" — so
+  an already-known point is skipped, not re-taught. This is the gate-as-cursor
+  compression path, not a per-point quiz.
+- **`memory` content → cheatsheet**: parameters / commands / API spellings are
+  *auto-accumulated verbatim* into the module's "Command / config cheatsheet"
+  and marked covered — **no quiz, no gate** (they don't build transferable
+  skill; see `curriculum-design.md`).
 
-## 3. feynman_check — qualitative gate (concept / design)
+## 2. reference answer + discuss (grill-me style, the default follow-up)
 
-- Have the user recital in their own words: "now explain it back to me as if I'm a beginner."
-- **concept**: judge "what + why + relation to adjacent concepts".
-- **design**: add design-tradeoff follow-ups (see `mastery-policy.md` §6).
-- Result → `qualitative_mastery`; not passed → back to explain, record the error type.
+- After explaining, **present a reference answer**: the standard one-line
+  statement of this point, with `file:line`. The learner **reacts to this
+  proposal** — agree, push back, ask where it differs from their mental model,
+  or restate it in their own words. This is "reacting to a proposal, not
+  staring at a blank prompt" (absorbed from mattpocock's `grill-me`).
+- **No independent blank-prompt answering** for concept/design — the reference
+  answer is the material the learner engages with. The judgment (next step)
+  rests on the *quality of the reaction*: did they catch the key mechanism, can
+  they restate it, can they point at what would change?
+- For `procedure`, the reference answer is the **graded question's answer,
+  shown right after the user answers** (self-check) — never shown *before*, so
+  the attempt stays honest.
+
+## 3. verify — Feynman recital (qualitative gate, concept / design)
+
+- After the reference-answer discussion, have the user **restate the point in
+  their own words** — "now put the reference answer in your own words as if I'm
+  a beginner." The expected answer is **not hidden to test recall** — the user
+  already saw it; the judgment is whether they can *critically engage with and
+  restate* it.
+- **concept**: judge "what + why + relation to adjacent concepts" — can they
+  move beyond the reference answer's phrasing to their own mental model?
+- **design**: add design-tradeoff follow-ups (see `mastery-policy.md` §6) —
+  "why not the alternative?" probes whether they adopted the idea or only
+  echoed the reference answer. For ecosystem points (`m00`), add the **vs-peer
+  probing** questions from `mastery-policy.md` §6 (swap / decision / boundary);
+  the reference answer cites its source — repo facts `file:line`, peer facts
+  the `positioning.md` row + `[web]` URL. Never improvise an unsourced peer
+  claim into the reference answer.
+- Result → `qualitative_mastery`; not passed → back to explain + reference
+  answer, record the error type.
 - **Input form**: the user types their recital in chat (no voice requirement).
 
-## 4. practice — quantitative gate / hands-on
+## 4. verify — quantitative gate / hands-on (procedure only)
 
-### Quiz (memory / procedure)
-- Follow `quiz-design.md` (**test application, not memory**).
-- **The expected answer goes only into `progress.json.pending_question` — never shown back in the question**.
-- User answers → grade via the **engine script** (deterministic, tool-agnostic):
+### Lightweight question with self-check (procedure — never memory)
+- Follow `quiz-design.md` (**test application, not memory**). Parameter/flag
+  spelling is never quizzed — that is reference-note material.
+- **The expected answer lives in `progress.json.pending_question` — never shown
+  before the user answers** (the attempt stays honest).
+- **Immediately after the user answers, show the reference answer** for
+  self-check: "compare with what you said — where did you diverge?" Judge the
+  attempt = answer + self-check correction, then record it via the **engine
+  script** (deterministic, tool-agnostic):
   ```bash
   python3 scripts/learning_engine.py record-attempt <path>/.learning/progress.json \
       --kp <kp_id> --type procedure --correct --question <qid> --write
   ```
-- Advance only when the script reports `passed_gate: true` (≥ 0.9); otherwise return to explain + practice more.
+- Advance only when the script reports `passed_gate: true` (≥ 0.9); otherwise
+  return to explain + practice more (pose a *different* question).
 
 ### Hands-on on demand (procedure especially)
 - Guide the user to actually verify: "verify it now — run `pytest tests/test_x.py`" or "write a 20-line demo calling this API."
@@ -88,17 +242,105 @@ diagnostic (probe; includes test-out)
 
 - Pull due tasks by `scheduler`'s `next_review_at` (triggered by `/repo-mastery review`, or automatically when `next_objective` finds something due).
 - Review form: one question per due point (quantitative) or a quick recital (qualitative).
+- Review stays **recall-first** (that's the point — retrieval after
+  forgetting), but a stuck user is never left staring at a blank prompt: offer
+  the reference answer as a **catch-up** when they ask or after one
+  attempt, record the error, and reschedule. Retrieval intent is preserved
+  without grinding the user.
 - Results update `repetition_states` + `review_queue`.
 - **Interleave types**: when several reviews are due, alternate knowledge types
   (memory → concept → procedure → design) instead of grinding one type; `next_objective`
   already prefers a type different from `last_review_type`.
+- **Covered modules' points review too**: points in `chapter_covered_modules`
+  carry real `repetition_states` and appear in the queue — covered ≠ forgotten.
+  `--mode review` drains them even mid-chapter.
 
-## 7. End of each turn (mandatory)
+## 6.5 `/repo-mastery note ["<text>"]` — interval consolidation (manual complement)
 
+The per-turn **auto-consolidate** (after every explanation / judgment / other
+**substantive** turn — see §1 / §7; **mechanical turns defer it to the next
+substantive one**) keeps the module note fresh as a **per-turn diary** and stays
+**unchanged**. `/repo-mastery note` is the **manual interval complement**: it
+consolidates the discussion **since the last note** — not what auto already
+wrote — and distills it into the note. Execute it this way:
+
+1. **Interval start**: read `notes/.boundary.json`
+   (`{"module_id": ..., "last_consolidated_at": <unix>}`). Present → the interval
+   is that boundary → now; absent (first note) → from session / module start.
+2. **Extract the interval**: from context, pull that interval's Q&A conclusions,
+   new blockers, cheatsheet additions, Feynman records, and the user's own
+   words. If the interval start predates a context compaction (cross-session
+   resume), recover from `notes/<module>.md` + `records/` — unrecoverable detail
+   is marked needs-review, never invented.
+3. **Consolidate into `notes/<module>.md`** (route to each module's note when the
+   interval spans modules):
+   - **Key points / Q&A / cheatsheet / blockers / Feynman** sections: **deduplicated**
+     — only what auto hasn't already written (re-writing it is wasted tokens).
+   - A **`### Interval synthesis (<ISO date> <UTC>, since last note <time>) — <one-line recap>`**
+     block: 2–4 distilled takeaways + any new Mission links. This is note's
+     differentiator — auto is the per-turn diary, note is the interval synthesis.
+   - `<text>` (if given) → **verbatim** into "My notes" (never rewritten; may be
+     registered as a blocker/review point).
+4. **Update boundary**: write `notes/.boundary.json` →
+   `{"module_id": <current module>, "last_consolidated_at": <now unix>}`.
+5. **Refresh index**: if `notes/README.md` exists, refresh that module's line
+   (don't create it — respect the current layout).
+
+**Iron rules**: never re-write what auto already consolidated; never fabricate
+pre-compaction content; the tutor writes `.boundary.json` directly — the engine
+is untouched.
+
+## 7. End of each turn — layered wrap-up
+
+Close each turn at the depth its content earned. Two layers:
+
+**Substantive turn** — an explanation, a judgment, an error diagnosis, or a new
+conclusion: **full wrap-up**.
 1. **Atomically write back** `progress.json` (temp file + rename).
-2. **Auto-note / update** the module notes (`notes/<module>.md`).
+2. **Auto-consolidate** the module notes (`notes/<module>.md`); `/repo-mastery
+   note` interval consolidation (see §6.5) is the manual, on-demand complement
+   — it doesn't replace this.
 3. Update global `~/.repo-mastery/index.json` (where you left off).
-4. Report to the user in one line: current progress (e.g. "module 3/6, points 7/24, mastery 45%").
+4. **Refresh `MASTERY.md`** — the one-page status dashboard (see §8), so
+   "where am I" reflects this turn's state.
+5. Report to the user in one line: current progress (e.g. "module 3/6, points
+   7/24, mastery 45%").
+
+**Mechanical turn** — a review drain, a simple confirmation, or Q&A digesting
+with no new conclusion: **slim wrap-up** — steps 1, 3, 5 only. **Skip
+auto-consolidate and the MASTERY refresh**: the next substantive turn's
+consolidation covers this stretch (its interval runs from the last
+consolidation), so nothing is lost — the diary is "always fresh on substance",
+not "always rewritten".
+
+Engine write-back (step 1) is already built into `record-attempt` /
+`set-qualitative --write`; it is a *tutor* action only when progress.json needs
+a direct state change.
+
+## 8. MASTERY.md — the one-page status dashboard
+
+`/repo-mastery status` reads `progress.json` + `course-map.json` and writes
+`MASTERY.md` — the single page where "where am I" lives. Sections:
+
+- **Progress** — modules covered X/Y (`chapter_covered_modules`), verified
+  points N/M, current module + chapter section/status.
+- **Mastery** — overall % and per-knowledge-type lines (from `mastery_levels` /
+  `quiz_attempts` / `qualitative_mastery`); chapter-covered modules carry the
+  "Covered · awaiting review verification" display convention, never "unmastered".
+- **Review due** — `review_queue` count + earliest `due_at`; `--mode review`
+  drains it.
+- **Next objective** — what `next_objective` returned (review / chapter /
+  knowledge point), so the next session resumes instantly.
+
+**Refreshed** by `/repo-mastery status` explicitly, and automatically on a
+substantive turn's full wrap-up (§7). Mechanical turns don't refresh it — their
+state changes surface on the next substantive refresh. The Session Preamble
+(§0) reads it, display-only.
+
+**Division vs COVERAGE.md** — COVERAGE.md is the **content** note
+(explanations, cheatsheet, blockers, notes; grows with learning). MASTERY.md is
+the **state** note (numbers + next step; regenerated from JSON, never
+hand-written). Status lives in MASTERY.md, not in COVERAGE.md's header.
 
 ## Tutor voice during sessions
 
@@ -113,3 +355,24 @@ diagnostic (probe; includes test-out)
 - When learning a point, only Read files relevant to it (locate via `course-map.json` evidence paths / `code-map.json`); **don't read the whole repo**.
 - Large repos: consult `code-map.json`'s symbol table to locate `file:line`, then Read the needed slice.
 - Once source snippets are captured in notes, prefer reading the notes over re-reading source in later sessions.
+
+## Failure recovery — concrete steps when something breaks
+
+- **`set-phase` fails** → read the current `flow_phase` from `progress.json`,
+  re-run `next-objective` (the CLI subcommand; `next_objective` is the
+  engine's function/return value — don't type the underscore form) so the
+  cursor resumes from the actual phase, then retry the matching command
+  (`set-phase ... module_overview --module mNN` while the overview is
+  unfinished, else `set-phase ... learning`).
+- **`chapter-advance` rejected by the engine** → read the error and branch:
+  (a) the message says "no active chapter" → re-run `chapter-start
+  --module <m> --sections N` first; (b) invalid `--status` → pass a valid
+  `teaching|qna|verifying`. Separately, as a protocol rule: after each section,
+  pause and wait for an explicit learner reply before advancing — never chain
+  sections in one turn (the engine can't see the conversation).
+- **`.boundary.json` missing** → the interval starts at the session / module
+  start (first note), not an invented earlier boundary. Consolidate from there,
+  then write the boundary (`{"module_id": ..., "last_consolidated_at": <now unix>}`).
+- **Value brief with no search tool** → degraded repo-evidence mode: build the
+  brief from repo facts only, mark unsourced peer rows `[unv]`, and **never
+  fabricate a source** (see `positioning-brief.md` §Source rules).

--- a/skills/repo-mastery/references/session-flow.md
+++ b/skills/repo-mastery/references/session-flow.md
@@ -6,6 +6,14 @@
 
 Before each learning session:
 
+0. **Recall warm-up** (absorbed from claude-teach-skill): pose **2–3 quick
+   recall questions** drawn from `review_queue` (due first, then soonest
+   `due_at`). Each answer goes through `record_attempt` (updates mastery /
+   difficulty / stability / schedule). A forgotten point → re-teach it before
+   anything new, and record the error. This forces retrieval from storage, not
+   recognition. A correct warm-up answer feeds `consecutive_correct` →
+   `stability`, so a good warm-up streak lengthens the next interval.
+
 1. **Read MISSION.md** — why the user wants to master this repo. Align every explanation, question, and Feynman follow-up to the Mission (learning to use it? to modify it? to teach it?). If the Mission isn't filled in, ask — don't guess.
 2. **Read `records/` + `progress.json`** — judge the user's **zone of proximal development (ZPD)**: the next thing to teach should be "just challenging enough". Don't re-teach what the user has proven; bridge missing prerequisites before leaping.
 3. Then enter the knowledge point selected by `next_objective`.
@@ -37,6 +45,10 @@ diagnostic (probe; includes test-out)
 - Follow the per-module arc absorbed from docs-to-course: *"why care" first (1–2 sentences of practical payoff) → concept + one fresh metaphor → look at the code / walk the call chain → recap (3–4 takeaways)*.
 - **Auto-note** after explaining (see `note-template.md`).
 - Control length: one knowledge point, one layer at a time — don't dump three concepts at once.
+- **Vivid encoding (optional, `memory`-type points)**: offer a memorable
+  hook — an exaggerated image, a color/action cue, a pun, an interaction
+  (SMASHIN-style: Senses, Movement, Action, Humor, Imagination, Numbers) — or let the learner ask for a mnemonic / mini memory-palace.
+  Encoding is a *suggested* aid, never graded.
 
 ## 3. feynman_check — qualitative gate (concept / design)
 
@@ -77,6 +89,9 @@ diagnostic (probe; includes test-out)
 - Pull due tasks by `scheduler`'s `next_review_at` (triggered by `/repo-mastery review`, or automatically when `next_objective` finds something due).
 - Review form: one question per due point (quantitative) or a quick recital (qualitative).
 - Results update `repetition_states` + `review_queue`.
+- **Interleave types**: when several reviews are due, alternate knowledge types
+  (memory → concept → procedure → design) instead of grinding one type; `next_objective`
+  already prefers a type different from `last_review_type`.
 
 ## 7. End of each turn (mandatory)
 
@@ -91,6 +106,7 @@ diagnostic (probe; includes test-out)
 - Explain from source, judge by engine — **never replace the gate with "do you feel you've got it?"**.
 - A stuck user is a diagnostic signal, not a teaching failure — guide self-attribution.
 - Keep momentum: close the loop on one point per turn where possible (judge + write back + note).
+- Ask **one question at a time** (batching is bewildering). When a decision is needed, offer your evidence-based recommendation with the question; assessment questions (quiz / Feynman) never carry a hint (absorbed from the grilling skill).
 
 ## Token-saving rules for large repos
 

--- a/skills/repo-mastery/scripts/index_repo.py
+++ b/skills/repo-mastery/scripts/index_repo.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""index_repo.py — 为大型仓库生成 code-map.json（模块 / 依赖 / 符号定位）。
+
+repo-mastery 在 Phase 0 判定仓库为大型时运行本脚本。输出一个轻量代码索引，
+让学习会话可以按"文件:行"按需定位源码，而不用把整仓塞进上下文。
+
+纯标准库实现，无第三方依赖。定位粒度是"模块边界 + 依赖边 + 入口点"，
+不做完整语法树 —— 那是 tree-sitter 的事，对这个 skill 是过度设计。
+
+用法:
+    python3 index_repo.py <repo_path> [-o code-map.json] [--top N]
+
+输出:
+    code-map.json —— 结构见下方 SCHEMA 常量。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections import Counter
+
+# 目录/文件黑名单：绝不进索引（避免把依赖、构建产物、版本库扫进来）。
+SKIP_DIRS = {
+    ".git", ".hg", ".svn", "node_modules", "vendor", ".venv", "venv",
+    "__pycache__", ".next", ".nuxt", "dist", "build", "target", "out",
+    ".idea", ".vscode", ".gradle", "coverage", ".tox", ".mypy_cache",
+    ".pytest_cache", ".ruff_cache", "site-packages", "bower_components",
+}
+SKIP_FILES = {"package-lock.json", "yarn.lock", "pnpm-lock.yaml", "poetry.lock", "Cargo.lock"}
+
+# 语言 → 扩展名集合。只统计这些"源文件"，其余（图片/文档/二进制）不进统计。
+LANG_EXTS: dict[str, set[str]] = {
+    "python": {".py", ".pyi"},
+    "typescript": {".ts", ".tsx"},
+    "javascript": {".js", ".jsx", ".mjs", ".cjs"},
+    "rust": {".rs"},
+    "go": {".go"},
+    "java": {".java"},
+    "kotlin": {".kt", ".kts"},
+    "c": {".c", ".h"},
+    "cpp": {".cpp", ".cc", ".hpp", ".hxx", ".cxx"},
+    "ruby": {".rb"},
+    "php": {".php"},
+    "swift": {".swift"},
+    "shell": {".sh", ".bash", ".zsh"},
+    "sql": {".sql"},
+    "vue": {".vue"},
+    "svelte": {".svelte"},
+}
+
+# 各语言的"本地模块/依赖"提取正则（保守，只抓明显的相对导入）。
+# 组 1 = 被导入的路径。匹配相对导入（以 . 开头）或项目内顶层模块。
+IMPORT_PATTERNS: dict[str, re.Pattern] = {
+    "python": re.compile(r"^\s*(?:from\s+([.\w]+)\s+import|import\s+([.\w]+))", re.M),
+    "typescript": re.compile(r"(?:import\s+(?:[\w*{},\s]+\s+from\s+)?|from\s+)['\"]([^'\"]+)['\"]"),
+    "javascript": re.compile(r"(?:import\s+(?:[\w*{},\s]+\s+from\s+)?|require\s*\(\s*)['\"]([^'\"]+)['\"]"),
+    "go": re.compile(r"^\s*\"([^\"]+)\"|^\s*[a-z0-9_]+\s+\"([^\"]+)\"", re.M),
+    "rust": re.compile(r"^\s*(?:use\s+|mod\s+|pub\s+use\s+)([^\s;]+)", re.M),
+    "java": re.compile(r"^\s*import\s+([.\w]+);", re.M),
+    "kotlin": re.compile(r"^\s*import\s+([.\w]+)", re.M),
+    "c": re.compile(r"^\s*#\s*include\s*[<\"]([^>\"]+)[>\"]", re.M),
+    "cpp": re.compile(r"^\s*#\s*include\s*[<\"]([^>\"]+)[>\"]", re.M),
+}
+
+
+def classify(rel_path: str) -> str | None:
+    """按扩展名返回语言名，非源文件返回 None。"""
+    ext = os.path.splitext(rel_path)[1].lower()
+    for lang, exts in LANG_EXTS.items():
+        if ext in exts:
+            return lang
+    return None
+
+
+def is_skip_dir(name: str) -> bool:
+    return name in SKIP_DIRS or name.startswith(".")
+
+
+def scan(repo: str, top: int) -> dict:
+    """扫描仓库，返回 code-map 字典。"""
+    by_lang: Counter = Counter()
+    by_topdir: Counter = Counter()
+    files: list[dict] = []
+    imports: dict[str, list[str]] = {}
+    entry_points: list[str] = []
+    total_lines = 0
+
+    for dirpath, dirnames, filenames in os.walk(repo):
+        # 原地过滤黑名单目录，避免继续下探。
+        dirnames[:] = [d for d in dirnames if not is_skip_dir(d)]
+        for fname in filenames:
+            if fname in SKIP_FILES:
+                continue
+            full = os.path.join(dirpath, fname)
+            rel = os.path.relpath(full, repo)
+            lang = classify(rel)
+            if lang is None:
+                continue
+            try:
+                with open(full, "r", encoding="utf-8", errors="ignore") as fh:
+                    content = fh.read()
+            except OSError:
+                continue
+            line_count = content.count("\n") + 1
+            total_lines += line_count
+            by_lang[lang] += 1
+            topdir = rel.split(os.sep)[0]
+            by_topdir[topdir] += 1
+            files.append({"path": rel, "lang": lang, "lines": line_count})
+
+            # 提取依赖边。
+            pat = IMPORT_PATTERNS.get(lang)
+            if pat:
+                deps = []
+                for m in pat.finditer(content):
+                    dep = m.group(1) or m.group(2)
+                    if dep:
+                        deps.append(dep)
+                imports[rel] = deps[:40]  # 单文件最多记 40 条，防失控
+
+    # 探测入口点（常见约定）。
+    entry_points = detect_entry_points(repo)
+
+    # 顶层目录统计（前 top 名）。
+    topdirs = [{"name": k, "files": v} for k, v in by_topdir.most_common(top)]
+
+    # 依赖图只保留"项目内"边（相对导入 或 与某顶层目录同名的模块），
+    # 外部包/标准库不进入图 —— 图的目的是看模块间耦合，不是依赖清单。
+    internal = {d["path"] for d in files}
+    topdir_set = {d["name"] for d in topdirs}
+    graph: dict[str, list[str]] = {}
+    for src, deps in imports.items():
+        kept = []
+        for dep in deps:
+            d = dep.lstrip(".")
+            d = d.split("/")[0].split(".")[0]
+            if d in internal or d in topdir_set or d in {"src", "lib"}:
+                kept.append(d)
+        if kept:
+            graph[src] = sorted(set(kept))
+
+    return {
+        "repo": os.path.basename(os.path.abspath(repo)),
+        "generated": True,
+        "summary": {
+            "total_source_files": len(files),
+            "total_lines": total_lines,
+            "languages": dict(by_lang.most_common()),
+            "top_dirs": topdirs,
+        },
+        "entry_points": entry_points,
+        "dependency_graph": graph,          # 仅项目内边
+        "files": files,                     # 未排序；tutor 可按 lines 降序取最重文件
+        "symbol_lookup": build_symbol_lookup(files),  # 语言 → 重文件清单
+    }
+
+
+def detect_entry_points(repo: str) -> list[str]:
+    """常见入口约定：package.json bin/main、pyproject 脚本、main.* 等。"""
+    found: list[str] = []
+
+    pkg = os.path.join(repo, "package.json")
+    if os.path.isfile(pkg):
+        try:
+            with open(pkg, encoding="utf-8") as fh:
+                data = json.load(fh)
+        except Exception:
+            data = {}
+        for key in ("bin", "main"):
+            val = data.get(key)
+            if isinstance(val, str):
+                found.append(f"package.json/{key}: {val}")
+            elif isinstance(val, dict):
+                for name, path in list(val.items())[:10]:
+                    found.append(f"package.json/bin.{name}: {path}")
+
+    for name in ("pyproject.toml", "setup.py"):
+        if os.path.isfile(os.path.join(repo, name)):
+            found.append(f"{name}（含入口脚本配置，见内容）")
+
+    for pattern in ("main.py", "app.py", "cli.py", "manage.py"):
+        if os.path.isfile(os.path.join(repo, pattern)):
+            found.append(pattern)
+
+    return found
+
+
+def build_symbol_lookup(files: list[dict]) -> dict[str, list[str]]:
+    """为最重的文件生成"符号级定位提示"：语言 → 可能含定义的重文件清单。
+
+    不做语法分析，启发式足够：tutor 拿到清单后再 Read 对应文件精确定位。
+    按行数降序取每语言前 30 个文件，供 map 阶段优先审视。
+    """
+    buckets: dict[str, list[tuple[int, str]]] = {}
+    for f in files:
+        if f["lines"] < 60:
+            continue
+        buckets.setdefault(f["lang"], []).append((f["lines"], f["path"]))
+    return {
+        lang: [p for _, p in sorted(items, reverse=True)[:30]]
+        for lang, items in buckets.items()
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="生成 repo-mastery 的代码索引 code-map.json")
+    ap.add_argument("repo", help="要索引的仓库路径")
+    ap.add_argument("-o", "--output", default="code-map.json", help="输出文件路径")
+    ap.add_argument("--top", type=int, default=15, help="顶层目录统计数量")
+    args = ap.parse_args()
+
+    code_map = scan(args.repo, args.top)
+    tmp = args.output + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(code_map, fh, ensure_ascii=False, indent=2)
+    os.replace(tmp, args.output)  # 原子写，避免半成品
+    s = code_map["summary"]
+    print(f"已生成 {args.output}")
+    print(f"  源文件 {s['total_source_files']} 个，共 {s['total_lines']} 行")
+    print(f"  语言: {', '.join(f'{k}({v})' for k, v in s['languages'].items())}")
+    print(f"  顶层目录: {', '.join(d['name'] for d in s['top_dirs'])}")
+    print(f"  入口点: {', '.join(code_map['entry_points'][:5]) or '未探测到'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/repo-mastery/scripts/install.sh
+++ b/skills/repo-mastery/scripts/install.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# install.sh — install repo-mastery as a native skill across AI CLI tools.
+#
+# By default installs to:
+#   Claude Code : ~/.claude/skills/repo-mastery
+#   Codex       : ~/.codex/skills/repo-mastery      (Agent Skills standard)
+#   Gemini CLI  : ${GEMINI_SKILLS_DIR:-~/.gemini/skills}/repo-mastery
+#
+# Options:
+#   --only <tool>    install only one tool (claude|codex|gemini)
+#   --skip <tool>    skip one tool (repeatable)
+#   --dry-run        print what would happen, don't copy
+#   --help           show this help
+#
+# Examples:
+#   ./scripts/install.sh                    # install everywhere
+#   ./scripts/install.sh --only codex       # Codex only
+#   GEMINI_SKILLS_DIR=$HOME/.config/gemini/skills ./scripts/install.sh
+
+set -euo pipefail
+
+# Resolve the skill source. When run via `curl ... | bash` there is no local
+# checkout, so fetch the latest tarball from GitHub.
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." 2>/dev/null && pwd)"
+if [ ! -f "$SRC/SKILL.md" ]; then
+  echo "No local checkout — fetching repo-mastery from GitHub…"
+  TMP="$(mktemp -d)"
+  trap 'rm -rf "$TMP"' EXIT
+  curl -fsSL https://github.com/DieselZhang/repo-mastery/archive/refs/heads/main.tar.gz \
+    | tar -xz -C "$TMP"
+  SRC="$TMP/repo-mastery-main"
+fi
+
+CLAUDE_DIR="${CLAUDE_SKILLS_DIR:-$HOME/.claude/skills}"
+CODEX_DIR="${CODEX_SKILLS_DIR:-$HOME/.codex/skills}"
+GEMINI_DIR="${GEMINI_SKILLS_DIR:-$HOME/.gemini/skills}"
+
+copy_skill() {
+  local dest="$1"
+  mkdir -p "$dest"
+  # copy the skill root, excluding .git
+  cp -R "$SRC" "$dest/repo-mastery" 2>/dev/null && rm -rf "$dest/repo-mastery/.git"
+}
+
+dry_run=0
+only=""
+skip=()
+for arg in "$@"; do
+  case "$arg" in
+    --only) only="__MISSING__" ;;
+    --only=*) only="${arg#--only=}" ;;
+    --skip) skip+=("__MISSING__") ;;
+    --skip=*) skip+=("${arg#--skip=}") ;;
+    --dry-run) dry_run=1 ;;
+    --help|-h) sed -n '1,20p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) [ "$only" = "__MISSING__" ] && only="$arg" || skip+=("$arg") ;;
+  esac
+done
+
+want() { # want <tool> -> 0 if should install
+  [ -n "$only" ] && [ "$only" != "$1" ] && return 1
+  for s in ${skip[@]+"${skip[@]}"}; do [ "$s" = "$1" ] && return 1; done
+  return 0
+}
+
+installed=()
+if want claude; then
+  echo "→ Claude Code : $CLAUDE_DIR/repo-mastery"
+  [ "$dry_run" -eq 0 ] && copy_skill "$CLAUDE_DIR" && installed+=("claude")
+fi
+if want codex; then
+  echo "→ Codex       : $CODEX_DIR/repo-mastery"
+  [ "$dry_run" -eq 0 ] && copy_skill "$CODEX_DIR" && installed+=("codex")
+fi
+if want gemini; then
+  echo "→ Gemini CLI  : $GEMINI_DIR/repo-mastery"
+  [ "$dry_run" -eq 0 ] && copy_skill "$GEMINI_DIR" && installed+=("gemini")
+fi
+
+if [ "$dry_run" -eq 0 ]; then
+  echo ""
+  echo "✅ Installed repo-mastery to: ${installed[*]:-none}"
+  echo "   Restart your CLI, then try:"
+  echo "     Claude Code : /repo-mastery start <repo>"
+  echo "     Codex       : mention 'repo-mastery' or ask to master a repo"
+  echo "     Gemini      : activate_skill(repo-mastery)"
+else
+  echo ""
+  echo "（dry-run）No files were copied."
+fi

--- a/skills/repo-mastery/scripts/learning_engine.py
+++ b/skills/repo-mastery/scripts/learning_engine.py
@@ -13,7 +13,8 @@ Subcommands:
     compute-mastery <correctness.json>          recency-weighted accuracy + confidence cap
     schedule <type> <is_correct> [state.json]   spaced-repetition state transition
     record-attempt <progress.json> <opts...>    record a quiz/hands-on attempt
-    next-objective <progress.json>              what the tutor should do next
+    next-objective <progress.json> [--mode auto|review]   what the tutor should do next
+    set-phase <progress.json> <phase> [--module <id>]     advance the learning flow phase
     validate-map <course-map.json>              check a course map's schema
     init <repo_path> [--force]                  create .learning/ scaffolding + .gitignore
 
@@ -64,6 +65,12 @@ TYPE_PRIORITY: dict[str, int] = {
 VALID_TYPES: frozenset[str] = frozenset(
     {"memory", "concept", "procedure", "design"}
 )
+
+# Textbook-mode chapter lifecycle statuses (module-level gate flow).
+CHAPTER_STATUSES: tuple[str, ...] = ("teaching", "qna", "verifying")
+
+# progress.json key that lists modules whose chapter gate has passed.
+COVERED_KEY: str = "chapter_covered_modules"
 
 
 # --- core pure functions ---
@@ -130,7 +137,13 @@ def schedule_next(
 
 
 def is_mastered(progress: dict, kp_id: str, kp_type: str) -> bool:
-    """Whether a knowledge point clears its gate (quantitative or qualitative)."""
+    """Whether a knowledge point clears its gate (quantitative or qualitative).
+
+    `memory` points are demoted to reference notes (cheatsheet) and never gate
+    advancement — they count as covered so `next_objective` skips them.
+    """
+    if kp_type == "memory":
+        return True
     if kp_type in QUALITATIVE_TYPES:
         return bool(progress.get("qualitative_mastery", {}).get(kp_id, False))
     return progress.get("mastery_levels", {}).get(kp_id, 0.0) >= QUANTITATIVE_GATE
@@ -146,12 +159,29 @@ def objective_status(progress: dict, kp_id: str, kp_type: str) -> str:
     return "learning" if seen else "new"
 
 
-def next_objective(progress: dict, *, now: int | None = None) -> dict:
+def next_objective(progress: dict, *, now: int | None = None,
+                   mode: str = "auto") -> dict:
     """Decide the next thing to work on. The gate IS the cursor:
     advancement is computed from what is mastered, never a stage counter.
 
-    Precedence: 1) pending question  2) due spaced review  3) first
-    unmastered point (probe / practice / assess)  4) complete.
+    The learning flow has phases — "overview" → "module_overview" →
+    "learning" — tracked in `progress["flow_phase"]` (missing = "learning",
+    backward compatible). The whole picture comes before the nodes, and this is
+    enforced by the engine, not left to the tutor's discretion: while the flow
+    is still in an overview phase, `next_objective` REFUSES to hand out a
+    knowledge point.
+
+    Precedence (auto mode):
+      1) pending question
+      2) flow_phase gate  — overview / module_overview must finish first
+      3) due spaced review
+      4) first unmastered point (probe / practice / assess)
+      5) complete
+
+    `mode="review"` is the focused `/repo-mastery review` path: it bypasses the
+    flow_phase gate and unmastered-point steps, returning only pending →
+    due review → complete. Scattered-time review is never blocked by an
+    unfinished overview.
     """
     now = int(time.time()) if now is None else now
     kps = _all_knowledge_points(progress)
@@ -168,7 +198,50 @@ def next_objective(progress: dict, *, now: int | None = None) -> dict:
             "reason": "A posed question awaits the learner's answer.",
         }
 
-    # 2) due spaced-repetition reviews. Equal-priority reviews interleave
+    # 2) flow_phase gate: the whole picture comes before the nodes. The tutor
+    #    must present the overview first (then advance it via `set-phase`);
+    #    until then no knowledge point is handed out. Review mode bypasses
+    #    this so scattered-time review is never blocked.
+    if mode != "review":
+        flow_phase = progress.get("flow_phase", "learning")
+        if flow_phase == "overview":
+            return {
+                "action": "overview",
+                "reason": "The global overview (architecture narrative + module map) "
+                          "must be presented before any node. Run `set-phase "
+                          "module_overview` once done.",
+            }
+        if flow_phase == "module_overview":
+            return {
+                "action": "module_overview",
+                "module_id": progress.get("current_module_id"),
+                "reason": "This module's overview (knowledge-point map + cheatsheet) "
+                          "must be presented before its nodes. Run `set-phase "
+                          "learning` once done.",
+            }
+        # 2b) chapter gate: an in-progress textbook-mode chapter keeps teaching
+        #     its sections before any new point is handed out — chapter learning
+        #     is a continuous run, so a resume continues the chapter, not a node.
+        #     `mode="review"` bypasses this too (scattered-time review drains due
+        #     reviews even mid-chapter). The tutor resumes from chapters/<m>.md.
+        chapter = progress.get("chapter")
+        if chapter:
+            module = _find_module(progress.get("modules", []), chapter.get("module_id"))
+            due_count = sum(1 for t in progress.get("review_queue", [])
+                            if t.get("due_at", 0) <= now)
+            return {
+                "action": "chapter",
+                "module_id": chapter.get("module_id"),
+                "module_name": module.get("name") if module else "",
+                "chapter_status": chapter.get("status"),
+                "section_index": chapter.get("section_index"),
+                "sections": chapter.get("sections"),
+                "due_review_count": due_count,
+                "reason": "Textbook-mode chapter in progress — continue teaching "
+                          "from chapters/<module>.md.",
+            }
+
+    # 3) due spaced-repetition reviews. Equal-priority reviews interleave
     #    types: a review whose type differs from the last one wins, so
     #    consecutive reviews mix types instead of stacking one type.
     due = [t for t in progress.get("review_queue", []) if t.get("due_at", 0) <= now]
@@ -187,14 +260,34 @@ def next_objective(progress: dict, *, now: int | None = None) -> dict:
             "reason": "This objective is due for spaced-repetition review.",
         }
 
-    # 3) first unmastered point in module order, then knowledge-point order.
+    # Review mode stops here: it never opens new content.
+    if mode == "review":
+        return {
+            "action": "complete",
+            "reason": "Review mode: nothing due for review — suggest `continue` "
+                      "to advance the course.",
+        }
+
+    # 4) first unmastered point in module order, then knowledge-point order.
     error_kps = {
         e.get("knowledge_point_id") for e in progress.get("error_records", [])
         if e.get("status") in ("active", "retrying")
     }
+    # Modules whose chapter gate already passed are covered: their points were
+    # either engine-verified at after-class checking or get validated via
+    # spaced review — never re-offered as fresh nodes. The skip lives here (the
+    # module-iteration layer), NOT in `is_mastered` (which has no module_id).
+    covered = set(progress.get(COVERED_KEY, []))
     for module in sorted(progress.get("modules", []), key=lambda m: m.get("order", 0)):
+        if module.get("id") in covered:
+            continue
         for kp in module.get("knowledge_points", []):
             kp_id, kp_type = kp.get("id"), kp.get("type", "concept")
+            # `memory` points are demoted to reference notes (cheatsheet): they
+            # never gate advancement. New maps shouldn't define them as
+            # knowledge points at all; this skip keeps old maps valid & harmless.
+            if kp_type == "memory":
+                continue
             if is_mastered(progress, kp_id, kp_type):
                 continue
             status = objective_status(progress, kp_id, kp_type)
@@ -222,7 +315,7 @@ def next_objective(progress: dict, *, now: int | None = None) -> dict:
                 ),
             }
 
-    # 4) done.
+    # 5) done.
     return {"action": "complete", "reason": "All objectives mastered and nothing due."}
 
 
@@ -340,6 +433,155 @@ def _find(kps: list[dict], kp_id: str | None) -> dict | None:
     return next((k for k in kps if k.get("id") == kp_id), None)
 
 
+def _find_module(modules: list[dict], module_id: str | None) -> dict | None:
+    return next((m for m in modules if m.get("id") == module_id), None)
+
+
+def _first_review_state(kp_type: str, now: int) -> dict:
+    """A fresh first-review state (interval_index 0 on the type's base interval).
+
+    Used to initialise spaced review for points that were NOT individually
+    verified at after-class checking. It records no answer — mastery is built
+    later by real review attempts (fluency != storage; never fake a 'correct'
+    evidence by calling schedule_next with a fabricated result).
+    """
+    base = INTERVAL_SEQUENCES.get(kp_type, INTERVAL_SEQUENCES["memory"])[0]
+    return {
+        "interval_index": 0,
+        "consecutive_correct": 0,
+        "consecutive_wrong": 0,
+        "difficulty": 0.5,
+        "stability": 1.0,
+        "next_review_at": now + base * 86400,
+    }
+
+
+def chapter_start(progress: dict, *, module_id: str, sections: int) -> dict:
+    """Begin a textbook-mode chapter for a module. Validates preconditions so
+    the state machine never enters a dangling half-state."""
+    if progress.get("flow_phase", "learning") != "learning":
+        raise ValueError("flow_phase must be 'learning' before chapter-start — "
+                         "finish the overviews first (set-phase module_overview, "
+                         "then set-phase learning)")
+    modules = progress.get("modules", [])
+    module = _find_module(modules, module_id)
+    if module is None:
+        raise ValueError(f"unknown module {module_id!r} — check course-map modules")
+    if module_id in progress.get(COVERED_KEY, []):
+        raise ValueError(f"module {module_id!r} is already covered by a completed chapter")
+    if progress.get("pending_question"):
+        raise ValueError("a pending_question exists — grade it before starting a chapter")
+    if sections < 1:
+        raise ValueError("sections must be >= 1")
+
+    progress["chapter"] = {
+        "module_id": module_id,
+        "status": "teaching",
+        "section_index": 0,
+        "sections": sections,
+    }
+    progress["current_module_id"] = module_id
+    return dict(progress["chapter"])
+
+
+def chapter_advance(progress: dict, *, section_index: int | None = None,
+                    status: str | None = None) -> dict:
+    """Advance an in-progress chapter's section index and/or lifecycle status."""
+    chapter = progress.get("chapter")
+    if not chapter:
+        raise ValueError("no active chapter to advance")
+    if status is not None:
+        if status not in CHAPTER_STATUSES:
+            raise ValueError(f"invalid chapter status {status!r} — expected one of "
+                             f"{', '.join(CHAPTER_STATUSES)}")
+        chapter["status"] = status
+    if section_index is not None:
+        chapter["section_index"] = max(0, min(int(section_index), chapter["sections"]))
+    return dict(chapter)
+
+
+def chapter_complete(progress: dict, *, now: int | None = None) -> dict:
+    """Module-level gate for the active chapter.
+
+    The chapter's module counts as *covered* (learned together), but points
+    that were NOT individually verified get an initialised spaced review rather
+    than a fabricated mastery score — real mastery is built by later review
+    attempts. Key nodes verified at after-class checking keep their real engine
+    records (qualitative_mastery / quiz_attempts) untouched.
+    """
+    chapter = progress.get("chapter")
+    if not chapter:
+        raise ValueError("no active chapter to complete")
+    module_id = chapter["module_id"]
+    now = int(time.time()) if now is None else now
+    module = _find_module(progress.get("modules", []), module_id)
+    if module is None:
+        raise ValueError(f"unknown module {module_id!r} — cannot complete its chapter")
+
+    progress.setdefault("mastery_levels", {})
+    progress.setdefault("qualitative_mastery", {})
+    progress.setdefault("knowledge_types", {})
+    progress.setdefault("repetition_states", {})
+    progress.setdefault("review_queue", [])
+    progress.setdefault("error_records", [])
+
+    for kp in module.get("knowledge_points", []):
+        kp_id, kp_type = kp.get("id"), kp.get("type", "concept")
+        if kp_type == "memory":
+            continue
+        # _rebuild_review_queue reads knowledge_types and DROPS points whose
+        # type is missing (treated as `memory`). Without this write the covered
+        # points would never enter the review queue.
+        progress["knowledge_types"][kp_id] = kp_type
+        if kp_type in QUALITATIVE_TYPES:
+            mastered = bool(progress["qualitative_mastery"].get(kp_id, False))
+        else:
+            mastered = progress["mastery_levels"].get(kp_id, 0.0) >= QUANTITATIVE_GATE
+        state = progress["repetition_states"].get(kp_id)
+        if state is None or not mastered:
+            # Unverified (or verification-failed) → start spaced review from a
+            # fresh first-review state. A mastered point keeps its state; a
+            # non-mastered one is reset so a lucky review streak can't inherit a
+            # lengthened interval.
+            progress["repetition_states"][kp_id] = _first_review_state(kp_type, now)
+
+    progress["chapter"] = None
+    covered = progress.setdefault(COVERED_KEY, [])
+    if module_id not in covered:
+        covered.append(module_id)
+    _rebuild_review_queue(progress)
+    return {"module_id": module_id, "covered_modules": list(covered)}
+
+
+def set_qualitative(progress: dict, *, kp_id: str, kp_type: str,
+                    passed: bool) -> dict:
+    """Record a tutor-judged qualitative result (concept/design) and make sure
+    the point is scheduled for spaced review once passed. Without this,
+    qualitative points that pass the Feynman check would never enter the review
+    queue (an existing gap now fixed).
+    """
+    if kp_type not in QUALITATIVE_TYPES:
+        raise ValueError(f"set-qualitative requires a qualitative type "
+                         f"(concept|design), got {kp_type!r}")
+    progress.setdefault("qualitative_mastery", {})
+    progress.setdefault("knowledge_types", {})
+    progress.setdefault("repetition_states", {})
+    progress.setdefault("review_queue", [])
+    progress.setdefault("error_records", [])
+
+    progress["qualitative_mastery"][kp_id] = bool(passed)
+    progress["knowledge_types"][kp_id] = kp_type
+    if passed and kp_id not in progress["repetition_states"]:
+        progress["repetition_states"][kp_id] = _first_review_state(
+            kp_type, int(time.time()))
+    _rebuild_review_queue(progress)
+    return {
+        "kp_id": kp_id,
+        "passed": bool(passed),
+        "is_mastered": is_mastered(progress, kp_id, kp_type),
+    }
+
+
 def _rebuild_review_queue(progress: dict) -> None:
     """Rebuild review_queue from repetition_states + error priority."""
     now = int(time.time())
@@ -350,6 +592,9 @@ def _rebuild_review_queue(progress: dict) -> None:
     queue: list[dict] = []
     for kp_id, state in progress.get("repetition_states", {}).items():
         kp_type = progress.get("knowledge_types", {}).get(kp_id, "memory")
+        # `memory` points are reference notes, not review candidates.
+        if kp_type == "memory":
+            continue
         priority = 1 if kp_id in error_kps else TYPE_PRIORITY.get(kp_type, 5)
         queue.append({
             "id": f"review_{kp_id}",
@@ -397,6 +642,43 @@ def main(argv: list[str] | None = None) -> None:
 
     p = sub.add_parser("next-objective", help="what the tutor should do next")
     p.add_argument("progress", help="path to progress.json")
+    p.add_argument("--mode", choices=["auto", "review"], default="auto",
+                   help="auto = full flow (default); review = due reviews only")
+
+    p = sub.add_parser("set-phase", help="advance the learning flow phase")
+    p.add_argument("progress", help="path to progress.json")
+    p.add_argument("phase", choices=["overview", "module_overview", "learning"])
+    p.add_argument("--module", default=None,
+                   help="module id (for the module_overview phase)")
+
+    p = sub.add_parser("chapter-start", help="begin a textbook-mode chapter for a module")
+    p.add_argument("progress", help="path to progress.json")
+    p.add_argument("--module", required=True, help="module id")
+    p.add_argument("--sections", type=int, required=True,
+                   help="number of sections in the chapter")
+
+    p = sub.add_parser("chapter-advance", help="advance an in-progress chapter")
+    p.add_argument("progress", help="path to progress.json")
+    p.add_argument("--section", type=int, default=None,
+                   help="current section index (clamped to [0, sections])")
+    p.add_argument("--status", choices=list(CHAPTER_STATUSES), default=None,
+                   help="chapter lifecycle status: teaching|qna|verifying")
+
+    p = sub.add_parser("chapter-complete",
+                       help="module-level gate: mark the active chapter's module covered")
+    p.add_argument("progress", help="path to progress.json")
+
+    p = sub.add_parser("set-qualitative",
+                       help="record a tutor-judged qualitative result (concept|design)")
+    p.add_argument("progress", help="path to progress.json")
+    p.add_argument("--kp", required=True, help="knowledge point id")
+    p.add_argument("--type", choices=sorted(QUALITATIVE_TYPES), required=True,
+                   help="knowledge point type")
+    qgroup = p.add_mutually_exclusive_group(required=True)
+    qgroup.add_argument("--pass", dest="passed", action="store_true",
+                        help="qualitative judgment passed")
+    qgroup.add_argument("--fail", dest="passed", action="store_false",
+                        help="qualitative judgment failed")
 
     p = sub.add_parser("validate-map", help="check a course map's schema")
     p.add_argument("course_map", help="path to course-map.json")
@@ -427,7 +709,57 @@ def main(argv: list[str] | None = None) -> None:
 
     elif args.cmd == "next-objective":
         progress = _load_json(args.progress)
-        print(json.dumps(next_objective(progress)))
+        print(json.dumps(next_objective(progress, mode=args.mode)))
+
+    elif args.cmd == "set-phase":
+        progress = _load_json(args.progress)
+        progress["flow_phase"] = args.phase
+        if args.module:
+            progress["current_module_id"] = args.module
+        _atomic_write(args.progress, progress)
+        print(json.dumps({
+            "flow_phase": args.phase,
+            "current_module_id": progress.get("current_module_id"),
+        }))
+
+    elif args.cmd == "chapter-start":
+        progress = _load_json(args.progress)
+        try:
+            chapter = chapter_start(progress, module_id=args.module,
+                                    sections=args.sections)
+        except ValueError as exc:
+            sys.exit(f"chapter-start: {exc}")
+        _atomic_write(args.progress, progress)
+        print(json.dumps(chapter))
+
+    elif args.cmd == "chapter-advance":
+        progress = _load_json(args.progress)
+        try:
+            chapter = chapter_advance(progress, section_index=args.section,
+                                      status=args.status)
+        except ValueError as exc:
+            sys.exit(f"chapter-advance: {exc}")
+        _atomic_write(args.progress, progress)
+        print(json.dumps(chapter))
+
+    elif args.cmd == "chapter-complete":
+        progress = _load_json(args.progress)
+        try:
+            result = chapter_complete(progress)
+        except ValueError as exc:
+            sys.exit(f"chapter-complete: {exc}")
+        _atomic_write(args.progress, progress)
+        print(json.dumps(result))
+
+    elif args.cmd == "set-qualitative":
+        progress = _load_json(args.progress)
+        try:
+            result = set_qualitative(progress, kp_id=args.kp, kp_type=args.type,
+                                     passed=args.passed)
+        except ValueError as exc:
+            sys.exit(f"set-qualitative: {exc}")
+        _atomic_write(args.progress, progress)
+        print(json.dumps(result))
 
     elif args.cmd == "validate-map":
         problems = validate_map(_load_json(args.course_map))

--- a/skills/repo-mastery/scripts/learning_engine.py
+++ b/skills/repo-mastery/scripts/learning_engine.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""learning_engine.py — the deterministic mastery engine for repo-mastery.
+
+This is the single source of truth for the *gate*: whether a learner may
+advance is computed here in pure, tool-agnostic code — NOT interpreted from
+prose by whatever LLM/tool happens to be tutoring. Every platform (Claude
+Code, Codex, Gemini CLI, opencode, ...) calls this script for the same
+deterministic answers, so mastery math can never drift between tools.
+
+Pure stdlib. JSON in, JSON out. The math mirrors references/mastery-policy.md.
+
+Subcommands:
+    compute-mastery <correctness.json>          recency-weighted accuracy + confidence cap
+    schedule <type> <is_correct> [state.json]   spaced-repetition state transition
+    record-attempt <progress.json> <opts...>    record a quiz/hands-on attempt
+    next-objective <progress.json>              what the tutor should do next
+    validate-map <course-map.json>              check a course map's schema
+    init <repo_path> [--force]                  create .learning/ scaffolding + .gitignore
+
+Examples:
+    python3 learning_engine.py compute-mastery '[true,false,true]'
+    python3 learning_engine.py schedule procedure false '{"interval_index":0,"consecutive_correct":0,"consecutive_wrong":0}'
+    python3 learning_engine.py next-objective .learning/progress.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+# --- constants (single source of truth; keep in sync with mastery-policy.md) ---
+
+# Newer attempts weigh more, so recovery after early mistakes is rewarded.
+RECENCY_WEIGHTS: tuple[float, ...] = (0.5, 0.7, 0.85, 0.95, 1.0)
+
+# Mastery cannot exceed this until enough evidence accumulates: one lucky
+# answer can never "master" a point.
+CONFIDENCE_CAP: dict[int, float] = {1: 0.5, 2: 0.8}
+
+# Quantitative gate — the learner must reach this mastery before advancing
+# (~0.9 mirrors Alpha School's "90% before you advance").
+QUANTITATIVE_GATE: float = 0.9
+
+# Qualitative types are gated by a Feynman-style explanation judged by the
+# tutor (a boolean), not by graded accuracy.
+QUALITATIVE_TYPES: frozenset[str] = frozenset({"concept", "design"})
+
+# Spaced-repetition intervals in days, per knowledge type.
+INTERVAL_SEQUENCES: dict[str, list[int]] = {
+    "memory": [0, 1, 3, 7, 14, 30],
+    "concept": [3, 7, 14, 30],
+    "procedure": [3, 7, 14],
+    "design": [14, 28],
+}
+
+# Base review priority by type; error records raise it to 1 (highest).
+TYPE_PRIORITY: dict[str, int] = {
+    "memory": 2, "concept": 3, "procedure": 4, "design": 5,
+}
+
+VALID_TYPES: frozenset[str] = frozenset(
+    {"memory", "concept", "procedure", "design"}
+)
+
+
+# --- core pure functions ---
+
+def compute_mastery(correctness: list[bool]) -> float:
+    """Recency-weighted accuracy over the latest up-to-5 attempts, capped by
+    the confidence ceiling. Returns a 0..1 mastery score."""
+    if not correctness:
+        return 0.0
+    recent = correctness[-len(RECENCY_WEIGHTS):]
+    weights = RECENCY_WEIGHTS[-len(recent):]
+    score = sum(w * (1.0 if c else 0.0) for c, w in zip(recent, weights)) / sum(weights)
+    return min(score, CONFIDENCE_CAP.get(len(recent), 1.0))
+
+
+def schedule_next(
+    kp_type: str,
+    is_correct: bool,
+    state: dict,
+) -> dict:
+    """Advance a repetition state per the interval sequence for *kp_type*.
+
+    Correct: consecutive_correct += 1; two in a row → interval_index +2.
+    Wrong:   consecutive_wrong += 1; interval_index steps back 1 (floor 0).
+    Returns the new state dict with next_review_at in Unix seconds.
+    """
+    intervals = INTERVAL_SEQUENCES.get(kp_type, INTERVAL_SEQUENCES["memory"])
+    max_index = len(intervals) - 1
+    state = dict(state)
+    state.setdefault("interval_index", 0)
+    state.setdefault("consecutive_correct", 0)
+    state.setdefault("consecutive_wrong", 0)
+
+    if is_correct:
+        state["consecutive_wrong"] = 0
+        state["consecutive_correct"] += 1
+        if state["consecutive_correct"] >= 2:
+            state["interval_index"] += 2
+            state["consecutive_correct"] = 0
+        else:
+            state["interval_index"] += 1
+    else:
+        state["consecutive_wrong"] += 1
+        state["consecutive_correct"] = 0
+        state["interval_index"] = max(0, state["interval_index"] - 1)
+        if state["consecutive_wrong"] >= 2:
+            state["consecutive_wrong"] = 0
+
+    state["interval_index"] = max(0, min(state["interval_index"], max_index))
+    days = intervals[state["interval_index"]]
+    state["next_review_at"] = int(time.time()) + days * 86400
+    return state
+
+
+def is_mastered(progress: dict, kp_id: str, kp_type: str) -> bool:
+    """Whether a knowledge point clears its gate (quantitative or qualitative)."""
+    if kp_type in QUALITATIVE_TYPES:
+        return bool(progress.get("qualitative_mastery", {}).get(kp_id, False))
+    return progress.get("mastery_levels", {}).get(kp_id, 0.0) >= QUANTITATIVE_GATE
+
+
+def objective_status(progress: dict, kp_id: str, kp_type: str) -> str:
+    """'mastered' | 'learning' | 'new' for one knowledge point."""
+    if is_mastered(progress, kp_id, kp_type):
+        return "mastered"
+    seen = any(a.get("knowledge_point_id") == kp_id for a in progress.get("quiz_attempts", []))
+    if kp_id in progress.get("qualitative_mastery", {}):
+        seen = True
+    return "learning" if seen else "new"
+
+
+def next_objective(progress: dict, *, now: int | None = None) -> dict:
+    """Decide the next thing to work on. The gate IS the cursor:
+    advancement is computed from what is mastered, never a stage counter.
+
+    Precedence: 1) pending question  2) due spaced review  3) first
+    unmastered point (probe / practice / assess)  4) complete.
+    """
+    now = int(time.time()) if now is None else now
+    kps = _all_knowledge_points(progress)
+
+    # 1) grade any posed question before moving on.
+    pending = progress.get("pending_question")
+    if pending:
+        kp = _find(kps, pending.get("knowledge_point_id"))
+        return {
+            "action": "answer_pending",
+            "knowledge_point_id": pending.get("knowledge_point_id"),
+            "knowledge_point_type": kp["type"] if kp else "",
+            "pending_prompt": pending.get("prompt", ""),
+            "reason": "A posed question awaits the learner's answer.",
+        }
+
+    # 2) due spaced-repetition reviews.
+    due = [t for t in progress.get("review_queue", []) if t.get("due_at", 0) <= now]
+    due.sort(key=lambda t: t.get("priority", 99))
+    if due:
+        task = due[0]
+        kp = _find(kps, task.get("knowledge_point_id"))
+        return {
+            "action": "review",
+            "knowledge_point_id": task.get("knowledge_point_id"),
+            "knowledge_point_type": kp["type"] if kp else "",
+            "reason": "This objective is due for spaced-repetition review.",
+        }
+
+    # 3) first unmastered point in module order, then knowledge-point order.
+    error_kps = {
+        e.get("knowledge_point_id") for e in progress.get("error_records", [])
+        if e.get("status") in ("active", "retrying")
+    }
+    for module in sorted(progress.get("modules", []), key=lambda m: m.get("order", 0)):
+        for kp in module.get("knowledge_points", []):
+            kp_id, kp_type = kp.get("id"), kp.get("type", "concept")
+            if is_mastered(progress, kp_id, kp_type):
+                continue
+            status = objective_status(progress, kp_id, kp_type)
+            if status == "new":
+                action = "probe"          # test-out: probe before teaching
+            elif kp_type in QUALITATIVE_TYPES:
+                action = "assess"         # Feynman check
+            else:
+                action = "practice"       # below the quantitative gate
+            return {
+                "action": action,
+                "module_id": module.get("id"),
+                "module_name": module.get("name"),
+                "knowledge_point_id": kp_id,
+                "knowledge_point_name": kp.get("name"),
+                "knowledge_point_type": kp_type,
+                "status": status,
+                "mastery": round(progress.get("mastery_levels", {}).get(kp_id, 0.0), 3),
+                "threshold": QUANTITATIVE_GATE,
+                "has_error": kp_id in error_kps,
+                "reason": (
+                    "Untouched objective — probe to let the learner test out."
+                    if status == "new"
+                    else "Objective is below its mastery gate; keep working it."
+                ),
+            }
+
+    # 4) done.
+    return {"action": "complete", "reason": "All objectives mastered and nothing due."}
+
+
+def record_attempt(progress: dict, *, kp_id: str, kp_type: str, is_correct: bool,
+                   question_id: str = "", error_type: str | None = None,
+                   hands_on_pass: bool = False) -> dict:
+    """Apply a quiz/hands-on attempt to progress.json (in place) and return
+    the updated mastery for the point.
+
+    Updates: quiz_attempts, mastery_levels (via compute_mastery),
+    repetition_states + review_queue (via schedule_next), error_records,
+    and clears pending_question when this attempt answers it.
+    """
+    progress.setdefault("mastery_levels", {})
+    progress.setdefault("knowledge_types", {})
+    progress.setdefault("quiz_attempts", [])
+    progress.setdefault("repetition_states", {})
+    progress.setdefault("review_queue", [])
+    progress.setdefault("error_records", [])
+    progress["knowledge_types"][kp_id] = kp_type
+
+    # hands-on pass for a procedure point counts as a correct attempt.
+    correct = bool(is_correct or hands_on_pass)
+
+    progress["quiz_attempts"].append({
+        "question_id": question_id,
+        "knowledge_point_id": kp_id,
+        "is_correct": correct,
+        "error_type": error_type,
+        "timestamp": int(time.time()),
+    })
+
+    # recompute quantitative mastery from the full history of this point.
+    history = [a["is_correct"] for a in progress["quiz_attempts"] if a["knowledge_point_id"] == kp_id]
+    progress["mastery_levels"][kp_id] = compute_mastery(history)
+
+    # advance spaced repetition.
+    state = progress["repetition_states"].get(kp_id, {
+        "interval_index": 0, "consecutive_correct": 0, "consecutive_wrong": 0,
+    })
+    new_state = schedule_next(kp_type, correct, state)
+    progress["repetition_states"][kp_id] = new_state
+
+    # error record when wrong.
+    if not correct and error_type:
+        progress["error_records"].append({
+            "id": f"e{int(time.time())}",
+            "question_id": question_id,
+            "knowledge_point_id": kp_id,
+            "error_type": error_type,
+            "status": "active",
+            "created_at": int(time.time()),
+        })
+
+    # clear a pending question if this attempt answers it.
+    pending = progress.get("pending_question")
+    if pending and (not question_id or pending.get("question_id") == question_id):
+        progress["pending_question"] = None
+
+    _rebuild_review_queue(progress)
+    return {
+        "mastery": round(progress["mastery_levels"][kp_id], 3),
+        "passed_gate": progress["mastery_levels"][kp_id] >= QUANTITATIVE_GATE,
+        "next_review_at": new_state.get("next_review_at"),
+    }
+
+
+def validate_map(course_map: dict) -> list[str]:
+    """Return a list of problems in a course map (empty = valid)."""
+    problems: list[str] = []
+    if not isinstance(course_map, dict) or "modules" not in course_map:
+        return ["course-map.json must be an object with a 'modules' array"]
+    for module in course_map["modules"]:
+        mid = module.get("id", "?")
+        for kp in module.get("knowledge_points", []):
+            if kp.get("type") not in VALID_TYPES:
+                problems.append(f"{mid}/{kp.get('id')}: invalid type {kp.get('type')!r} "
+                                f"(must be one of {sorted(VALID_TYPES)})")
+        if module.get("order") is None:
+            problems.append(f"{mid}: missing 'order'")
+    return problems
+
+
+def init_scaffold(repo_path: str, force: bool = False) -> list[str]:
+    """Create .learning/ scaffolding + .gitignore under *repo_path*."""
+    learning = os.path.join(repo_path, ".learning")
+    created: list[str] = []
+    if os.path.isdir(learning) and not force:
+        return ["already exists; pass --force to re-create"]
+    for sub in ("", "notes", "records", "briefs"):
+        d = os.path.join(learning, sub)
+        if not os.path.isdir(d):
+            os.makedirs(d, exist_ok=True)
+            created.append(d)
+    gi = os.path.join(learning, ".gitignore")
+    if not os.path.isfile(gi) or force:
+        with open(gi, "w", encoding="utf-8") as fh:
+            fh.write(".learning/\n")
+        created.append(gi)
+    return created
+
+
+# --- helpers ---
+
+def _all_knowledge_points(progress: dict) -> list[dict]:
+    out: list[dict] = []
+    for module in progress.get("modules", []):
+        for kp in module.get("knowledge_points", []):
+            out.append(kp)
+    return out
+
+
+def _find(kps: list[dict], kp_id: str | None) -> dict | None:
+    return next((k for k in kps if k.get("id") == kp_id), None)
+
+
+def _rebuild_review_queue(progress: dict) -> None:
+    """Rebuild review_queue from repetition_states + error priority."""
+    now = int(time.time())
+    error_kps = {
+        e.get("knowledge_point_id") for e in progress.get("error_records", [])
+        if e.get("status") in ("active", "retrying")
+    }
+    queue: list[dict] = []
+    for kp_id, state in progress.get("repetition_states", {}).items():
+        kp_type = progress.get("knowledge_types", {}).get(kp_id, "memory")
+        priority = 1 if kp_id in error_kps else TYPE_PRIORITY.get(kp_type, 5)
+        queue.append({
+            "id": f"review_{kp_id}",
+            "knowledge_point_id": kp_id,
+            "knowledge_type": kp_type,
+            "due_at": state.get("next_review_at", now),
+            "priority": priority,
+            "state": state,
+        })
+    progress["review_queue"] = queue
+
+
+# --- CLI ---
+
+def _json_arg(value: str):
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError as exc:
+        sys.exit(f"invalid JSON: {exc}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    ap = argparse.ArgumentParser(prog="learning_engine", description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p = sub.add_parser("compute-mastery", help="recency-weighted mastery from correctness list")
+    p.add_argument("correctness", type=_json_arg, help='JSON bool list, e.g. "[true,false,true]"')
+
+    p = sub.add_parser("schedule", help="spaced-repetition state transition")
+    p.add_argument("type", choices=sorted(VALID_TYPES))
+    p.add_argument("is_correct", type=_json_arg, help="true|false")
+    p.add_argument("state", nargs="?", type=_json_arg, default="{}",
+                   help='current repetition state JSON (optional)')
+
+    p = sub.add_parser("record-attempt", help="apply an attempt to progress.json")
+    p.add_argument("progress", help="path to progress.json")
+    p.add_argument("--kp", required=True, help="knowledge point id")
+    p.add_argument("--type", choices=sorted(VALID_TYPES), required=True)
+    p.add_argument("--correct", action="store_true", help="attempt was correct")
+    p.add_argument("--hands-on", action="store_true", help="hands-on verification passed")
+    p.add_argument("--question", default="", help="question id (clears matching pending)")
+    p.add_argument("--error", default=None, help="error type: structural|deviation|application|metacognitive")
+    p.add_argument("--write", action="store_true", help="write changes back to the file")
+
+    p = sub.add_parser("next-objective", help="what the tutor should do next")
+    p.add_argument("progress", help="path to progress.json")
+
+    p = sub.add_parser("validate-map", help="check a course map's schema")
+    p.add_argument("course_map", help="path to course-map.json")
+
+    p = sub.add_parser("init", help="create .learning/ scaffolding")
+    p.add_argument("repo_path")
+    p.add_argument("--force", action="store_true")
+
+    args = ap.parse_args(argv)
+
+    if args.cmd == "compute-mastery":
+        print(json.dumps({"mastery": round(compute_mastery(args.correctness), 3)}))
+
+    elif args.cmd == "schedule":
+        out = schedule_next(args.type, bool(args.is_correct), args.state)
+        print(json.dumps(out))
+
+    elif args.cmd == "record-attempt":
+        progress = _load_json(args.progress)
+        result = record_attempt(
+            progress, kp_id=args.kp, kp_type=args.type,
+            is_correct=args.correct, question_id=args.question,
+            error_type=args.error, hands_on_pass=args.hands_on,
+        )
+        if args.write:
+            _atomic_write(args.progress, progress)
+        print(json.dumps(result))
+
+    elif args.cmd == "next-objective":
+        progress = _load_json(args.progress)
+        print(json.dumps(next_objective(progress)))
+
+    elif args.cmd == "validate-map":
+        problems = validate_map(_load_json(args.course_map))
+        if problems:
+            print(json.dumps({"valid": False, "problems": problems}))
+            sys.exit(1)
+        print(json.dumps({"valid": True, "problems": []}))
+
+    elif args.cmd == "init":
+        print(json.dumps({"created": init_scaffold(args.repo_path, args.force)}))
+
+
+def _load_json(path: str) -> dict:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.exit(f"cannot read {path}: {exc}")
+
+
+def _atomic_write(path: str, data: dict) -> None:
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+    os.replace(tmp, path)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/repo-mastery/scripts/learning_engine.py
+++ b/skills/repo-mastery/scripts/learning_engine.py
@@ -84,11 +84,13 @@ def schedule_next(
     is_correct: bool,
     state: dict,
 ) -> dict:
-    """Advance a repetition state per the interval sequence for *kp_type*.
+    """Advance a repetition state with FSRS-inspired personalized scheduling.
 
-    Correct: consecutive_correct += 1; two in a row → interval_index +2.
-    Wrong:   consecutive_wrong += 1; interval_index steps back 1 (floor 0).
-    Returns the new state dict with next_review_at in Unix seconds.
+    Each knowledge point carries a `difficulty` (0.1..1.0, how hard it is for
+    this learner) and a `stability` (1.0..5.0, how durable the memory is). The
+    review interval is the base interval scaled by stability and reduced by
+    difficulty, so hard points are reviewed sooner and stable points deferred.
+    Pure stdlib; deterministic; matches references/mastery-policy.md §3.
     """
     intervals = INTERVAL_SEQUENCES.get(kp_type, INTERVAL_SEQUENCES["memory"])
     max_index = len(intervals) - 1
@@ -96,10 +98,16 @@ def schedule_next(
     state.setdefault("interval_index", 0)
     state.setdefault("consecutive_correct", 0)
     state.setdefault("consecutive_wrong", 0)
+    state.setdefault("difficulty", 0.5)
+    state.setdefault("stability", 1.0)
 
     if is_correct:
         state["consecutive_wrong"] = 0
         state["consecutive_correct"] += 1
+        state["difficulty"] = max(0.1, state["difficulty"] - 0.05)
+        state["stability"] = min(
+            5.0, state["stability"] * (1 + 0.2 * min(state["consecutive_correct"], 5))
+        )
         if state["consecutive_correct"] >= 2:
             state["interval_index"] += 2
             state["consecutive_correct"] = 0
@@ -109,12 +117,15 @@ def schedule_next(
         state["consecutive_wrong"] += 1
         state["consecutive_correct"] = 0
         state["interval_index"] = max(0, state["interval_index"] - 1)
+        state["difficulty"] = min(1.0, state["difficulty"] + 0.15)
+        state["stability"] = max(1.0, state["stability"] * 0.5)
         if state["consecutive_wrong"] >= 2:
             state["consecutive_wrong"] = 0
 
     state["interval_index"] = max(0, min(state["interval_index"], max_index))
-    days = intervals[state["interval_index"]]
-    state["next_review_at"] = int(time.time()) + days * 86400
+    base_days = intervals[state["interval_index"]]
+    days = base_days * state["stability"] * (1 - state["difficulty"] * 0.5)
+    state["next_review_at"] = int(time.time()) + int(days * 86400)
     return state
 
 
@@ -157,9 +168,15 @@ def next_objective(progress: dict, *, now: int | None = None) -> dict:
             "reason": "A posed question awaits the learner's answer.",
         }
 
-    # 2) due spaced-repetition reviews.
+    # 2) due spaced-repetition reviews. Equal-priority reviews interleave
+    #    types: a review whose type differs from the last one wins, so
+    #    consecutive reviews mix types instead of stacking one type.
     due = [t for t in progress.get("review_queue", []) if t.get("due_at", 0) <= now]
-    due.sort(key=lambda t: t.get("priority", 99))
+    last_type = progress.get("last_review_type")
+    due.sort(key=lambda t: (
+        t.get("priority", 99),
+        1 if last_type and t.get("knowledge_type") == last_type else 0,
+    ))
     if due:
         task = due[0]
         kp = _find(kps, task.get("knowledge_point_id"))
@@ -265,6 +282,7 @@ def record_attempt(progress: dict, *, kp_id: str, kp_type: str, is_correct: bool
     if pending and (not question_id or pending.get("question_id") == question_id):
         progress["pending_question"] = None
 
+    progress["last_review_type"] = kp_type
     _rebuild_review_queue(progress)
     return {
         "mastery": round(progress["mastery_levels"][kp_id], 3),


### PR DESCRIPTION
## Summary

Add **Repo-Mastery** v3.2.0 to the skills collection. An Agent skill that turns any open-source repository into a developer-focused mastery course (usage → architecture → key implementations), with deterministic mastery gates, FSRS-inspired spaced repetition, and dual-format (Markdown + HTML) output.

## v3.2.0 — what this sync includes

1. **Skill v3 refactor** — SKILL.md rewritten to a lean English protocol; all references anglicized.
2. **Current-directory-first** — the bare command opens a course on the current dir; global memory (`~/.repo-mastery/`) is an opt-in profile.
3. **Chapter source-inline + HTML highlighting** — chapters paste source directly (file:line + inline fragment + collapsible full source); the HTML course renders code with vendored highlight.js (no CDN).

## Files
- `skills/repo-mastery/SKILL.md` + `AGENTS.md`/`GEMINI.md`/`LICENSE`
- `skills/repo-mastery/references/` (14 refs + `example-walkthrough.md` + `html-shell/` incl. vendored highlight.js)
- `skills/repo-mastery/scripts/` + `agents/openai.yaml`

MIT licensed.
