### PR TITLE
fix(hooks): stop echoing silent hook payloads

### DIFF
--- a/scripts/hooks/plugin-hook-bootstrap.js
+++ b/scripts/hooks/plugin-hook-bootstrap.js
@@ -22,15 +22,10 @@ function writeStderr(stderr) {
   }
 }
 
-function passthrough(raw, result) {
+function forwardStdout(result) {
   const stdout = typeof result?.stdout === 'string' ? result.stdout : '';
   if (stdout) {
     process.stdout.write(stdout);
-    return;
-  }
-
-  if (!Number.isInteger(result?.status) || result.status === 0) {
-    process.stdout.write(raw);
   }
 }
 
@@ -224,7 +219,6 @@ function main() {
   );
 
   if (!mode || !relPath || !rootDir) {
-    process.stdout.write(raw);
     process.exit(0);
   }
 
@@ -236,16 +230,14 @@ function main() {
       result = spawnShell(rootDir, relPath, raw, args);
     } else {
       writeStderr(`[Hook] unknown bootstrap mode: ${mode}\n`);
-      process.stdout.write(raw);
       process.exit(0);
     }
   } catch (error) {
     writeStderr(`[Hook] bootstrap resolution failed: ${error.message}\n`);
-    process.stdout.write(raw);
     process.exit(0);
   }
 
-  passthrough(raw, result);
+  forwardStdout(result);
   writeStderr(result.stderr);
 
   if (result.error || result.signal || result.status === null) {

--- a/scripts/hooks/run-with-flags.js
+++ b/scripts/hooks/run-with-flags.js
@@ -14,7 +14,14 @@ const { spawnSync } = require('child_process');
 const { isHookEnabled, isDryRun } = require('../lib/hook-flags');
 const { buildPreToolUseAdditionalContext } = require('./pretooluse-visible-output');
 
-const MAX_STDIN = 1024 * 1024;
+const DEFAULT_MAX_STDIN = 1024 * 1024;
+
+function resolveMaxStdin(value) {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_STDIN;
+}
+
+const MAX_STDIN = resolveMaxStdin(process.env.ECC_HOOK_INPUT_MAX_BYTES);
 
 function readStdinRaw() {
   return new Promise(resolve => {
@@ -68,7 +75,7 @@ function exitWithStdout(text, exitCode) {
   process.stderr.write('', exitWhenFlushed);
 }
 
-function resolveHookResult(raw, output) {
+function resolveHookResult(output) {
   if (typeof output === 'string' || Buffer.isBuffer(output)) {
     return { stdout: String(output), exitCode: 0 };
   }
@@ -83,23 +90,15 @@ function resolveHookResult(raw, output) {
     if (Object.prototype.hasOwnProperty.call(output, 'stdout')) {
       return { stdout: String(output.stdout ?? ''), exitCode };
     }
-    return { stdout: exitCode === 0 ? raw : '', exitCode };
+    return { stdout: '', exitCode };
   }
 
-  return { stdout: raw, exitCode: 0 };
+  return { stdout: '', exitCode: 0 };
 }
 
-function resolveLegacySpawnStdout(raw, result) {
+function resolveLegacySpawnStdout(result) {
   const stdout = typeof result.stdout === 'string' ? result.stdout : '';
-  if (stdout) {
-    return stdout;
-  }
-
-  if (Number.isInteger(result.status) && result.status === 0) {
-    return raw;
-  }
-
-  return '';
+  return stdout || '';
 }
 
 function getPluginRoot() {
@@ -157,7 +156,7 @@ async function main() {
   // Oversized payloads: never echo the truncated string — a JSON document
   // cut mid-stream is treated by the harness as a hook failure, blocking the
   // tool call (#2222). Empty stdout + exit 0 means "no opinion", so
-  // pass-through paths fail open. The hook itself still runs and receives
+  // silent paths fail open. The hook itself still runs and receives
   // the truncated flag (run() context / ECC_HOOK_INPUT_TRUNCATED), so
   // security hooks like config-protection can still choose to block.
   const sanitizeEcho = text => (truncated && text === raw ? '' : text);
@@ -166,19 +165,19 @@ async function main() {
   }
 
   if (!hookId || !relScriptPath) {
-    exitWithStdout(sanitizeEcho(raw), 0);
+    exitWithStdout('', 0);
     return;
   }
 
   if (!isHookEnabled(hookId, { profiles: profilesCsv })) {
-    exitWithStdout(sanitizeEcho(raw), 0);
+    exitWithStdout('', 0);
     return;
   }
 
   if (isDryRun()) {
     const preview = buildDryRunPreview(hookId, relScriptPath, profilesCsv, raw);
     process.stderr.write(preview);
-    exitWithStdout(sanitizeEcho(raw), 0);
+    exitWithStdout('', 0);
     return;
   }
 
@@ -189,13 +188,13 @@ async function main() {
   // Prevent path traversal outside the plugin root
   if (!scriptPath.startsWith(resolvedRoot + path.sep)) {
     process.stderr.write(`[Hook] Path traversal rejected for ${hookId}: ${scriptPath}\n`);
-    exitWithStdout(sanitizeEcho(raw), 0);
+    exitWithStdout('', 0);
     return;
   }
 
   if (!fs.existsSync(scriptPath)) {
     process.stderr.write(`[Hook] Script not found for ${hookId}: ${scriptPath}\n`);
-    exitWithStdout(sanitizeEcho(raw), 0);
+    exitWithStdout('', 0);
     return;
   }
 
@@ -231,11 +230,11 @@ async function main() {
         truncated,
         maxStdin: MAX_STDIN
       });
-      const result = resolveHookResult(raw, output);
+      const result = resolveHookResult(output);
       exitWithStdout(sanitizeEcho(result.stdout), result.exitCode);
     } catch (runErr) {
       process.stderr.write(`[Hook] run() error for ${hookId}: ${runErr.message}\n`);
-      exitWithStdout(sanitizeEcho(raw), 0);
+      exitWithStdout('', 0);
     }
     return;
   }
@@ -256,7 +255,7 @@ async function main() {
     timeout: 30000
   });
 
-  const legacyStdout = sanitizeEcho(resolveLegacySpawnStdout(raw, result));
+  const legacyStdout = sanitizeEcho(resolveLegacySpawnStdout(result));
   if (result.stderr) process.stderr.write(result.stderr);
 
   if (result.error || result.signal || result.status === null) {

--- a/scripts/hooks/run-with-flags.js
+++ b/scripts/hooks/run-with-flags.js
@@ -11,36 +11,62 @@
 const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const { StringDecoder } = require('string_decoder');
 const { isHookEnabled, isDryRun } = require('../lib/hook-flags');
 const { buildPreToolUseAdditionalContext } = require('./pretooluse-visible-output');
 
 const DEFAULT_MAX_STDIN = 1024 * 1024;
 
 function resolveMaxStdin(value) {
+  if (value === undefined) return DEFAULT_MAX_STDIN;
+
   const parsed = Number(value);
-  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_STDIN;
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    process.stderr.write(
+      '[Hook] ECC_HOOK_INPUT_MAX_BYTES must be a positive safe integer; using the 1 MiB default\n'
+    );
+    return DEFAULT_MAX_STDIN;
+  }
+  if (parsed > DEFAULT_MAX_STDIN) {
+    process.stderr.write(
+      '[Hook] ECC_HOOK_INPUT_MAX_BYTES exceeds the 1 MiB safety maximum; clamping to 1 MiB\n'
+    );
+    return DEFAULT_MAX_STDIN;
+  }
+  return parsed;
 }
 
 const MAX_STDIN = resolveMaxStdin(process.env.ECC_HOOK_INPUT_MAX_BYTES);
 
 function readStdinRaw() {
   return new Promise(resolve => {
+    const decoder = new StringDecoder('utf8');
     let raw = '';
+    let acceptedBytes = 0;
+    let finished = false;
     let truncated = false;
-    process.stdin.setEncoding('utf8');
     process.stdin.on('data', chunk => {
-      if (raw.length < MAX_STDIN) {
-        const remaining = MAX_STDIN - raw.length;
-        raw += chunk.substring(0, remaining);
-        if (chunk.length > remaining) {
-          truncated = true;
-        }
-      } else {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      const remaining = MAX_STDIN - acceptedBytes;
+      if (remaining <= 0) {
         truncated = true;
+        return;
       }
+
+      const accepted = buffer.subarray(0, remaining);
+      acceptedBytes += accepted.length;
+      raw += decoder.write(accepted);
+      if (accepted.length < buffer.length) truncated = true;
     });
-    process.stdin.on('end', () => resolve({ raw, truncated }));
-    process.stdin.on('error', () => resolve({ raw, truncated }));
+    const finish = () => {
+      if (finished) return;
+      finished = true;
+      const finalText = decoder.end();
+      if (!truncated) raw += finalText;
+      resolve({ raw, truncated });
+    };
+    process.stdin.once('end', finish);
+    process.stdin.once('error', finish);
   });
 }
 
@@ -130,20 +156,33 @@ function extractTargetContext(raw) {
   return result;
 }
 
+function escapeDiagnostic(value, maxLength = 160) {
+  const escaped = String(value).replace(/[\u0000-\u001f\u007f-\u009f]/g, character => {
+    if (character === '\n') return '\\n';
+    if (character === '\r') return '\\r';
+    if (character === '\t') return '\\t';
+    return `\\x${character.charCodeAt(0).toString(16).padStart(2, '0')}`;
+  });
+  return escaped.length > maxLength ? `${escaped.slice(0, maxLength)}...` : escaped;
+}
+
 // Build the [DryRun] preview line for stderr.
 
 function buildDryRunPreview(hookId, relScriptPath, profilesCsv, raw) {
   const ctx = extractTargetContext(raw);
-  const parts = [`[DryRun] Hook "${hookId}" would execute: ${relScriptPath}`, `(enabled=true, profiles=${profilesCsv || 'default'})`];
+  const parts = [
+    `[DryRun] Hook "${escapeDiagnostic(hookId)}" would execute: ${escapeDiagnostic(relScriptPath)}`,
+    `(enabled=true, profiles=${escapeDiagnostic(profilesCsv || 'default')})`
+  ];
 
   if (ctx.tool) {
-    parts.push(`tool=${ctx.tool}`);
+    parts.push(`tool=${escapeDiagnostic(ctx.tool, 64)}`);
   }
   if (ctx.filePath) {
-    parts.push(`target=${ctx.filePath}`);
+    parts.push('target=[redacted]');
   }
   if (ctx.command) {
-    parts.push(`command=${ctx.command}`);
+    parts.push('command=[redacted]');
   }
 
   return parts.join(' ') + '\n';

--- a/scripts/hooks/run-with-flags.js
+++ b/scripts/hooks/run-with-flags.js
@@ -157,12 +157,16 @@ function extractTargetContext(raw) {
 }
 
 function escapeDiagnostic(value, maxLength = 160) {
-  const escaped = String(value).replace(/[\u0000-\u001f\u007f-\u009f]/g, character => {
+  const escaped = Array.from(String(value), character => {
+    const codePoint = character.codePointAt(0);
+    if (codePoint > 0x1f && (codePoint < 0x7f || codePoint > 0x9f)) {
+      return character;
+    }
     if (character === '\n') return '\\n';
     if (character === '\r') return '\\r';
     if (character === '\t') return '\\t';
-    return `\\x${character.charCodeAt(0).toString(16).padStart(2, '0')}`;
-  });
+    return `\\x${codePoint.toString(16).padStart(2, '0')}`;
+  }).join('');
   return escaped.length > maxLength ? `${escaped.slice(0, maxLength)}...` : escaped;
 }
 

--- a/scripts/hooks/run-with-flags.js
+++ b/scripts/hooks/run-with-flags.js
@@ -157,7 +157,7 @@ function extractTargetContext(raw) {
 }
 
 function escapeDiagnostic(value, maxLength = 160) {
-  const escaped = Array.from(String(value), character => {
+  const escapedTokens = Array.from(String(value), character => {
     const codePoint = character.codePointAt(0);
     if (codePoint > 0x1f && (codePoint < 0x7f || codePoint > 0x9f)) {
       return character;
@@ -166,8 +166,16 @@ function escapeDiagnostic(value, maxLength = 160) {
     if (character === '\r') return '\\r';
     if (character === '\t') return '\\t';
     return `\\x${codePoint.toString(16).padStart(2, '0')}`;
-  }).join('');
-  return escaped.length > maxLength ? `${escaped.slice(0, maxLength)}...` : escaped;
+  });
+
+  let escaped = '';
+  for (const token of escapedTokens) {
+    if (escaped.length + token.length > maxLength) {
+      return `${escaped}...`;
+    }
+    escaped += token;
+  }
+  return escaped;
 }
 
 // Build the [DryRun] preview line for stderr.

--- a/scripts/hooks/session-start-bootstrap.js
+++ b/scripts/hooks/session-start-bootstrap.js
@@ -22,8 +22,8 @@
  *   3. Delegates to `scripts/hooks/run-with-flags.js` with the `session:start`
  *      event, which applies hook-profile gating and then runs session-start.js.
  *   4. Passes stdout/stderr through and forwards the child exit code.
- *   5. If the plugin root cannot be found, emits a warning and passes stdin
- *      through unchanged so Claude Code can continue normally.
+ *   5. If the plugin root cannot be found, emits a warning and no stdout so
+ *      Claude Code can continue normally.
  */
 
 const fs = require('fs');
@@ -58,8 +58,6 @@ if (fs.existsSync(script)) {
   const stdout = typeof result.stdout === 'string' ? result.stdout : '';
   if (stdout) {
     process.stdout.write(stdout);
-  } else {
-    process.stdout.write(raw);
   }
 
   if (result.stderr) {
@@ -82,4 +80,3 @@ if (fs.existsSync(script)) {
 process.stderr.write(
   '[SessionStart] WARNING: could not resolve ECC plugin root; skipping session-start hook\n'
 );
-process.stdout.write(raw);

--- a/tests/hooks/config-protection.test.js
+++ b/tests/hooks/config-protection.test.js
@@ -103,7 +103,7 @@ function runTests() {
   else failed++;
 
   if (
-    test('passes through safe file edits unchanged', () => {
+    test('allows safe file edits without echoing stdin', () => {
       const input = {
         tool_name: 'Write',
         tool_input: {
@@ -112,10 +112,9 @@ function runTests() {
         }
       };
 
-      const rawInput = JSON.stringify(input);
       const result = runHook(input);
       assert.strictEqual(result.code, 0, 'Expected safe file edit to pass');
-      assert.strictEqual(result.stdout, rawInput, 'Expected exact raw JSON passthrough');
+      assert.strictEqual(result.stdout, '', 'Allowed edits should not echo raw JSON');
       assert.strictEqual(result.stderr, '', 'Expected no stderr for safe edits');
     })
   )
@@ -155,10 +154,9 @@ function runTests() {
           }
         };
 
-        const rawInput = JSON.stringify(input);
         const result = runHook(input);
         assert.strictEqual(result.code, 0, `Expected exit 0 for first-time creation, got ${result.code}; stderr: ${result.stderr}`);
-        assert.strictEqual(result.stdout, rawInput, 'Expected raw passthrough when creation is allowed');
+        assert.strictEqual(result.stdout, '', 'Allowed creation should not echo raw JSON');
         assert.strictEqual(result.stderr, '', `Expected no stderr for first-time creation, got: ${result.stderr}`);
       } finally {
         try {
@@ -189,10 +187,9 @@ function runTests() {
           }
         };
 
-        const rawInput = JSON.stringify(input);
         const result = runHook(input);
         assert.strictEqual(result.code, 0, `Expected exit 0 for ENOENT path, got ${result.code}; stderr: ${result.stderr}`);
-        assert.strictEqual(result.stdout, rawInput, 'Expected raw passthrough when path does not exist');
+        assert.strictEqual(result.stdout, '', 'Allowed creation should not echo raw JSON');
       } finally {
         try {
           fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/tests/hooks/continuous-learning-observe-runner.test.js
+++ b/tests/hooks/continuous-learning-observe-runner.test.js
@@ -181,7 +181,7 @@ function runTests() {
         });
 
         assert.strictEqual(output.exitCode, 0);
-        assert.ok(!Object.prototype.hasOwnProperty.call(output, 'stdout'), 'disabled observe should preserve stdin via runner passthrough');
+        assert.ok(!Object.prototype.hasOwnProperty.call(output, 'stdout'), 'disabled observe should stay silent through the runner');
         assert.ok(output.stderr.includes('shell runtime unavailable'));
       });
     });

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -207,13 +207,7 @@ function runTests() {
       };
       const result = runHook(input, { GATEGUARD_STATE_DIR: invalidStateDir });
       assert.strictEqual(result.code, 0, 'exit code should be 0');
-      const output = parseOutput(result.stdout);
-      assert.ok(output, 'should produce valid JSON output');
-      if (output.hookSpecificOutput) {
-        assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny', 'unpersistable state must not deny a retry that can never be recorded');
-      } else {
-        assert.strictEqual(output.tool_name, 'Write', 'pass-through should preserve input');
-      }
+      assert.strictEqual(result.stdout, '', 'fail-open path should stay silent');
       assert.ok(result.stderr.includes('GateGuard state could not be persisted'), 'should warn that state persistence failed');
     })
   )
@@ -453,14 +447,7 @@ function runTests() {
       });
 
       assert.strictEqual(result.code, 0, 'exit code should be 0');
-      const output = parseOutput(result.stdout);
-      assert.ok(output, 'should produce valid JSON output');
-      if (output.hookSpecificOutput) {
-        assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny', 'should not deny when hook is disabled');
-      } else {
-        // When disabled, hook passes through raw input
-        assert.strictEqual(output.tool_name, 'Edit', 'pass-through should preserve input');
-      }
+      assert.strictEqual(result.stdout, '', 'disabled hook should not echo stdin');
     })
   )
     passed++;

--- a/tests/hooks/hook-flags.test.js
+++ b/tests/hooks/hook-flags.test.js
@@ -247,7 +247,7 @@ function runTests() {
         encoding: 'utf8',
       });
       assert.strictEqual(result.status, 0, result.stderr);
-      assert.strictEqual(result.stdout, raw);
+      assert.strictEqual(result.stdout, '', 'disabled wrapper hook must not echo stdin');
       assert.ok(!fs.existsSync(markerPath), 'disabled wrapper hook must not execute');
     } finally {
       fs.rmSync(root, { recursive: true, force: true });

--- a/tests/hooks/plugin-hook-bootstrap.test.js
+++ b/tests/hooks/plugin-hook-bootstrap.test.js
@@ -61,11 +61,11 @@ function runTests() {
   let passed = 0;
   let failed = 0;
 
-  if (test('passes stdin through when required bootstrap inputs are missing', () => {
+  if (test('stays silent when required bootstrap inputs are missing', () => {
     const result = run([], { input: '{"ok":true}' });
 
     assert.strictEqual(result.status, 0);
-    assert.strictEqual(result.stdout, '{"ok":true}');
+    assert.strictEqual(result.stdout, '');
     assert.strictEqual(result.stderr, '');
   })) passed++; else failed++;
 
@@ -143,7 +143,7 @@ process.stdout.write(JSON.stringify({
     }
   })) passed++; else failed++;
 
-  if (test('node mode passes original stdin when child exits cleanly without stdout', () => {
+  if (test('node mode stays silent when child exits cleanly without stdout', () => {
     const root = createTempDir();
     try {
       writeFile(root, path.join('scripts', 'silent.js'), 'process.exit(0);\n');
@@ -154,7 +154,7 @@ process.stdout.write(JSON.stringify({
       });
 
       assert.strictEqual(result.status, 0);
-      assert.strictEqual(result.stdout, 'raw-input');
+      assert.strictEqual(result.stdout, '');
     } finally {
       cleanup(root);
     }
@@ -237,7 +237,7 @@ process.exit(7);
       });
 
       assert.strictEqual(result.status, 0);
-      assert.strictEqual(result.stdout, 'raw-input');
+      assert.strictEqual(result.stdout, '');
       assert.ok(result.stderr.includes('shell runtime unavailable'));
     } finally {
       cleanup(root);
@@ -253,7 +253,7 @@ process.exit(7);
       });
 
       assert.strictEqual(result.status, 0);
-      assert.strictEqual(result.stdout, 'raw-input');
+      assert.strictEqual(result.stdout, '');
       assert.ok(result.stderr.includes('Path traversal rejected'));
     } finally {
       cleanup(root);
@@ -269,7 +269,7 @@ process.exit(7);
       });
 
       assert.strictEqual(result.status, 0);
-      assert.strictEqual(result.stdout, 'raw-input');
+      assert.strictEqual(result.stdout, '');
       assert.ok(result.stderr.includes('unknown bootstrap mode: python'));
     } finally {
       cleanup(root);
@@ -375,7 +375,7 @@ process.exit(7);
         });
 
         assert.strictEqual(result.status, 0);
-        assert.strictEqual(result.stdout, 'raw-input');
+        assert.strictEqual(result.stdout, '');
         assert.ok(
           result.stderr.includes('no bash binary found') ||
           result.stderr.includes('shell runtime unavailable'),

--- a/tests/hooks/plugin-hook-bootstrap.test.js
+++ b/tests/hooks/plugin-hook-bootstrap.test.js
@@ -160,6 +160,23 @@ process.stdout.write(JSON.stringify({
     }
   })) passed++; else failed++;
 
+  if (test('node mode preserves child stdout equal to stdin', () => {
+    const root = createTempDir();
+    try {
+      writeFile(root, path.join('scripts', 'echo.js'), 'process.stdin.pipe(process.stdout);\n');
+
+      const result = run(['node', path.join('scripts', 'echo.js')], {
+        root,
+        input: 'raw-input',
+      });
+
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.strictEqual(result.stdout, 'raw-input');
+    } finally {
+      cleanup(root);
+    }
+  })) passed++; else failed++;
+
   if (test('node mode forwards child stdout and exit status for blocking hooks', () => {
     const root = createTempDir();
     try {

--- a/tests/hooks/run-with-flags-no-output.test.js
+++ b/tests/hooks/run-with-flags-no-output.test.js
@@ -1,0 +1,155 @@
+/**
+ * Regression tests for #2600: silent hook paths must not echo stdin.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const runner = path.join(repoRoot, 'scripts', 'hooks', 'run-with-flags.js');
+const hooksConfig = JSON.parse(fs.readFileSync(path.join(repoRoot, 'hooks', 'hooks.json'), 'utf8'));
+const pluginRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-hook-no-output-'));
+const hooksDir = path.join(pluginRoot, 'hooks');
+fs.mkdirSync(hooksDir, { recursive: true });
+
+const payload = JSON.stringify({
+  hook_event_name: 'PostToolUse',
+  tool_name: 'Read',
+  tool_input: { file_path: 'README.md' },
+  tool_response: { content: 'payload that must not be duplicated' }
+});
+
+function writeFixture(name, source) {
+  fs.writeFileSync(path.join(hooksDir, name), source);
+}
+
+writeFixture('undefined.js', "module.exports.run = () => undefined;\n");
+writeFixture('object.js', "module.exports.run = () => ({ exitCode: 0 });\n");
+writeFixture('throws.js', "module.exports.run = () => { throw new Error('fixture failure'); };\n");
+writeFixture('explicit.js', "module.exports.run = () => 'explicit output';\n");
+writeFixture('legacy-empty.js', "process.stdin.resume(); process.stdin.on('end', () => process.exit(0));\n");
+
+function run(args, env = {}, input = payload) {
+  return spawnSync(process.execPath, [runner, ...args], {
+    input,
+    encoding: 'utf8',
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_ROOT: pluginRoot,
+      ECC_HOOK_PROFILE: 'standard',
+      ...env
+    },
+    timeout: 30000,
+    maxBuffer: 4 * 1024 * 1024
+  });
+}
+
+function runRegisteredHook(entry, env = {}) {
+  return spawnSync(entry.hooks[0].command, {
+    input: payload,
+    encoding: 'utf8',
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_ROOT: repoRoot,
+      ECC_PLUGIN_ROOT: repoRoot,
+      ECC_HOOK_PROFILE: 'standard',
+      ...env
+    },
+    shell: true,
+    timeout: 30000,
+    maxBuffer: 4 * 1024 * 1024
+  });
+}
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function assertSilent(result) {
+  assert.strictEqual(result.status, 0, result.stderr);
+  assert.strictEqual(result.stdout, '');
+}
+
+console.log('\nrun-with-flags no-output contract tests (#2600):');
+
+let passed = 0;
+let failed = 0;
+
+const cases = [
+  ['missing arguments', [], {}],
+  ['disabled hook', ['post:test', 'hooks/undefined.js', 'standard'], { ECC_DISABLED_HOOKS: 'post:test' }],
+  ['dry run', ['post:test', 'hooks/undefined.js', 'standard'], { ECC_DRY_RUN: '1' }],
+  ['missing script', ['post:test', 'hooks/missing.js', 'standard'], {}],
+  ['path traversal rejection', ['post:test', '../outside.js', 'standard'], {}],
+  ['undefined run result', ['post:test', 'hooks/undefined.js', 'standard'], {}],
+  ['object result without output', ['post:test', 'hooks/object.js', 'standard'], {}],
+  ['run exception', ['post:test', 'hooks/throws.js', 'standard'], {}],
+  ['legacy process with empty stdout', ['post:test', 'hooks/legacy-empty.js', 'standard'], {}]
+];
+
+for (const [name, args, env] of cases) {
+  if (test(`${name} emits empty stdout`, () => assertSilent(run(args, env)))) passed++;
+  else failed++;
+}
+
+if (
+  test('explicit hook output is preserved', () => {
+    const result = run(['post:test', 'hooks/explicit.js', 'standard']);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout, 'explicit output');
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('ECC_HOOK_INPUT_MAX_BYTES controls the runner cap', () => {
+    const result = run(
+      ['post:test', 'hooks/undefined.js', 'standard'],
+      { ECC_HOOK_INPUT_MAX_BYTES: '128' },
+      payload.repeat(4)
+    );
+    assertSilent(result);
+    assert.match(result.stderr, /stdin exceeded 128 bytes/);
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('registered PreToolUse bootstrap keeps a disabled hook silent', () => {
+    const entry = hooksConfig.hooks.PreToolUse[0];
+    assertSilent(runRegisteredHook(entry, { ECC_DISABLED_HOOKS: entry.id }));
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('registered SessionStart bootstrap keeps a disabled hook silent', () => {
+    const entry = hooksConfig.hooks.SessionStart[0];
+    assertSilent(runRegisteredHook(entry, { ECC_DISABLED_HOOKS: entry.id }));
+  })
+)
+  passed++;
+else failed++;
+
+fs.rmSync(pluginRoot, { recursive: true, force: true });
+
+console.log(`\n  ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/hooks/run-with-flags-no-output.test.js
+++ b/tests/hooks/run-with-flags-no-output.test.js
@@ -32,7 +32,13 @@ writeFixture('undefined.js', "module.exports.run = () => undefined;\n");
 writeFixture('object.js', "module.exports.run = () => ({ exitCode: 0 });\n");
 writeFixture('throws.js', "module.exports.run = () => { throw new Error('fixture failure'); };\n");
 writeFixture('explicit.js', "module.exports.run = () => 'explicit output';\n");
+writeFixture('direct-echo.js', 'module.exports.run = raw => raw;\n');
+writeFixture(
+  'inspect-input.js',
+  "module.exports.run = (raw, context) => JSON.stringify({ raw, bytes: Buffer.byteLength(raw, 'utf8'), truncated: context.truncated });\n"
+);
 writeFixture('legacy-empty.js', "process.stdin.resume(); process.stdin.on('end', () => process.exit(0));\n");
+writeFixture('legacy-echo.js', 'process.stdin.pipe(process.stdout);\n');
 
 function run(args, env = {}, input = payload) {
   return spawnSync(process.execPath, [runner, ...args], {
@@ -118,6 +124,26 @@ if (
 else failed++;
 
 if (
+  test('direct hook output equal to stdin is preserved under the cap', () => {
+    const result = run(['post:test', 'hooks/direct-echo.js', 'standard']);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout, payload);
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('legacy hook output equal to stdin is preserved under the cap', () => {
+    const result = run(['post:test', 'hooks/legacy-echo.js', 'standard']);
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.strictEqual(result.stdout, payload);
+  })
+)
+  passed++;
+else failed++;
+
+if (
   test('ECC_HOOK_INPUT_MAX_BYTES controls the runner cap', () => {
     const result = run(
       ['post:test', 'hooks/undefined.js', 'standard'],
@@ -126,6 +152,75 @@ if (
     );
     assertSilent(result);
     assert.match(result.stderr, /stdin exceeded 128 bytes/);
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('stdin cap counts UTF-8 bytes at an exact multibyte boundary', () => {
+    const input = 'éé';
+    const result = run(
+      ['post:test', 'hooks/inspect-input.js', 'standard'],
+      { ECC_HOOK_INPUT_MAX_BYTES: '4' },
+      input
+    );
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.deepStrictEqual(JSON.parse(result.stdout), {
+      raw: input,
+      bytes: 4,
+      truncated: false
+    });
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('stdin cap discards an incomplete UTF-8 sequence at truncation', () => {
+    const result = run(
+      ['post:test', 'hooks/inspect-input.js', 'standard'],
+      { ECC_HOOK_INPUT_MAX_BYTES: '3' },
+      'éé'
+    );
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.deepStrictEqual(JSON.parse(result.stdout), {
+      raw: 'é',
+      bytes: 2,
+      truncated: true
+    });
+    assert.match(result.stderr, /stdin exceeded 3 bytes/);
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('invalid stdin caps warn and fall back without disabling hooks', () => {
+    for (const configuredLimit of ['0', '-1', '1.5', 'not-a-number']) {
+      const result = run(
+        ['post:test', 'hooks/direct-echo.js', 'standard'],
+        { ECC_HOOK_INPUT_MAX_BYTES: configuredLimit }
+      );
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.strictEqual(result.stdout, payload);
+      assert.match(result.stderr, /must be a positive safe integer/);
+    }
+  })
+)
+  passed++;
+else failed++;
+
+if (
+  test('stdin cap override cannot exceed the 1 MiB safety maximum', () => {
+    const result = run(
+      ['post:test', 'hooks/undefined.js', 'standard'],
+      { ECC_HOOK_INPUT_MAX_BYTES: String(2 * 1024 * 1024) },
+      'x'.repeat(1024 * 1024 + 1)
+    );
+    assertSilent(result);
+    assert.match(result.stderr, /exceeds the 1 MiB safety maximum/);
+    assert.match(result.stderr, /stdin exceeded 1048576 bytes/);
   })
 )
   passed++;
@@ -151,5 +246,6 @@ else failed++;
 
 fs.rmSync(pluginRoot, { recursive: true, force: true });
 
-console.log(`\n  ${passed} passed, ${failed} failed\n`);
+console.log(`\n  Passed: ${passed}`);
+console.log(`  Failed: ${failed}\n`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/hooks/run-with-flags-truncation.test.js
+++ b/tests/hooks/run-with-flags-truncation.test.js
@@ -88,15 +88,14 @@ if (
 else failed++;
 
 if (
-  test('normal-sized payload still passes through unchanged', () => {
+  test('normal-sized no-output hook stays silent', () => {
     const payload = JSON.stringify({
       tool_name: 'Write',
       tool_input: { file_path: '/tmp/small.js', content: 'const x = 1;\n' }
     });
     const result = runRunner(['pre:write:doc-file-warning', 'scripts/hooks/doc-file-warning.js', 'standard,strict'], payload);
     assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}`);
-    assert.ok(result.stdout.length > 0, 'normal payloads keep the pass-through behavior');
-    JSON.parse(result.stdout); // stdout must remain valid JSON
+    assert.strictEqual(result.stdout, '', 'silent hooks must not echo normal payloads');
   })
 )
   passed++;
@@ -120,31 +119,27 @@ if (
 else failed++;
 
 if (
-  test('payload just under the cap echoes through completely (no 64KB pipe cut)', () => {
-    // process.exit() right after stdout.write() used to drop everything past
-    // the ~64KB pipe buffer, cutting the echoed JSON mid-stream.
+  test('missing-args path stays silent just under the cap', () => {
     const content = 'y'.repeat(MAX_STDIN - 1024);
     const payload = JSON.stringify({ tool_name: 'Write', tool_input: { file_path: '/tmp/edge.md', content } });
     assert.ok(payload.length < MAX_STDIN, 'fixture must stay under the stdin cap');
     const result = runRunner([], payload);
     assert.strictEqual(result.status, 0);
-    assert.strictEqual(result.stdout.length, payload.length, 'echo must not be cut at the pipe buffer');
-    assert.strictEqual(result.stdout, payload, 'sub-cap payloads still echo through fallthrough paths');
+    assert.strictEqual(result.stdout, '', 'missing-args path must not echo sub-cap payloads');
   })
 )
   passed++;
 else failed++;
 
 if (
-  test('disabled-hook passthrough of a >64KB payload stays valid JSON', () => {
+  test('disabled hook stays silent for a >64KB payload', () => {
     const payload = JSON.stringify({
       tool_name: 'Write',
       tool_input: { file_path: '/tmp/medium.md', content: 'z'.repeat(256 * 1024) }
     });
     const result = runRunner(['pre:write:doc-file-warning', 'scripts/hooks/doc-file-warning.js', 'standard,strict'], payload, { ECC_DISABLED_HOOKS: 'pre:write:doc-file-warning' });
     assert.strictEqual(result.status, 0);
-    assert.strictEqual(result.stdout, payload);
-    JSON.parse(result.stdout);
+    assert.strictEqual(result.stdout, '');
   })
 )
   passed++;

--- a/tests/hooks/stop-hooks-stdout.test.js
+++ b/tests/hooks/stop-hooks-stdout.test.js
@@ -1,12 +1,9 @@
 /**
  * Regression tests for #2090: "Stop hook error: JSON validation failed".
  *
- * Stop hooks follow the ECC pass-through convention (echo stdin on stdout).
- * The Stop payload carries `last_assistant_message`, which can be large; any
- * hook that caps stdin and echoes the capped string emits a JSON document cut
- * mid-stream, which the harness reports as a Stop hook JSON validation
- * failure. Worst offender: cost-tracker capped stdin at 64KB, so any Stop
- * payload with a >64KB final assistant message broke the whole Stop chain.
+ * Stop payloads carry `last_assistant_message`, which can be large. Silent
+ * wrapper paths must emit nothing; explicit hook output must remain complete
+ * and valid JSON so the harness never sees a truncated document.
  *
  * Contract under test: for every Stop hook, stdout is either empty or valid
  * JSON, and the exit code is 0 — for realistic large payloads and for
@@ -160,18 +157,14 @@ const realisticPayload = stopPayload(100 * 1024);
 // OS pipe buffer and reintroducing #2222 above the tested runner layer.
 for (const entry of hooksConfig.hooks.Stop) {
   if (
-    test(`${entry.id} registered wrapper flushes a 100KB Stop payload`, () => {
+    test(`${entry.id} disabled registered wrapper stays silent for a 100KB Stop payload`, () => {
       const result = runRegisteredStopHook(entry, realisticPayload);
       assert.strictEqual(
         result.status,
         0,
         `${entry.id}: expected exit 0, got ${result.status}: ${result.stderr}`
       );
-      assert.ok(
-        result.stdout === realisticPayload,
-        `${entry.id}: registered wrapper must echo ${realisticPayload.length} characters uncut (got ${result.stdout.length})`
-      );
-      JSON.parse(result.stdout);
+      assert.strictEqual(result.stdout, '', `${entry.id}: disabled wrapper must stay silent`);
     })
   )
     passed++;
@@ -183,17 +176,13 @@ const representativeStopEntry = hooksConfig.hooks.Stop.find(
 );
 
 if (
-  test('registered Stop wrapper flushes a 100KB dry-run payload', () => {
+  test('registered Stop wrapper stays silent for a 100KB dry-run payload', () => {
     const result = runRegisteredStopHook(representativeStopEntry, realisticPayload, {
       ECC_DISABLED_HOOKS: '',
       ECC_DRY_RUN: '1'
     });
     assert.strictEqual(result.status, 0, `expected exit 0, got ${result.status}: ${result.stderr}`);
-    assert.ok(
-      result.stdout === realisticPayload,
-      `dry-run wrapper must echo ${realisticPayload.length} characters uncut (got ${result.stdout.length})`
-    );
-    JSON.parse(result.stdout);
+    assert.strictEqual(result.stdout, '', 'dry-run wrapper must stay silent');
   })
 )
   passed++;
@@ -208,18 +197,14 @@ assert.ok(Buffer.byteLength(multibytePayload) > MAX_STDIN, 'fixture must exceed 
 
 for (const entry of hooksConfig.hooks.Stop) {
   if (
-    test(`${entry.id} registered wrapper preserves a multibyte sub-cap payload`, () => {
+    test(`${entry.id} disabled registered wrapper stays silent for a multibyte payload`, () => {
       const result = runRegisteredStopHook(entry, multibytePayload);
       assert.strictEqual(
         result.status,
         0,
         `${entry.id}: expected exit 0, got ${result.status}: ${result.stderr}`
       );
-      assert.ok(
-        result.stdout === multibytePayload,
-        `${entry.id}: registered wrapper must echo ${Buffer.byteLength(multibytePayload)} bytes uncut (got ${Buffer.byteLength(result.stdout)})`
-      );
-      JSON.parse(result.stdout);
+      assert.strictEqual(result.stdout, '', `${entry.id}: disabled wrapper must stay silent`);
     })
   )
     passed++;

--- a/tests/lib/dry-run.test.js
+++ b/tests/lib/dry-run.test.js
@@ -94,7 +94,7 @@ function runTests() {
       result.stderr.includes('target=/tmp/test.md'),
       `Expected stderr to contain target file path, got: ${result.stderr}`
     );
-    assert.strictEqual(result.stdout, input, 'Expected stdin to be passed through unchanged');
+    assert.strictEqual(result.stdout, '', 'Dry-run hook should not echo stdin');
   })) passed++; else failed++;
 
   if (test('flushes a large dry-run preview when oversized stdout is suppressed', () => {
@@ -151,7 +151,7 @@ function runTests() {
       result.stderr.includes('command=git commit --no-verify'),
       `Expected stderr to contain command, got: ${result.stderr}`
     );
-    assert.strictEqual(result.stdout, input, 'Expected stdin to be passed through unchanged');
+    assert.strictEqual(result.stdout, '', 'Dry-run hook should not echo stdin');
   })) passed++; else failed++;
 
   if (test('dry-run preview handles non-JSON stdin gracefully', () => {
@@ -180,7 +180,7 @@ function runTests() {
       !result.stderr.includes('tool='),
       'Expected no tool= when stdin is not JSON'
     );
-    assert.strictEqual(result.stdout, input, 'Expected stdin to be passed through unchanged');
+    assert.strictEqual(result.stdout, '', 'Dry-run hook should not echo stdin');
   })) passed++; else failed++;
 
   if (test('dry-run preview handles empty stdin gracefully', () => {

--- a/tests/lib/dry-run.test.js
+++ b/tests/lib/dry-run.test.js
@@ -198,6 +198,35 @@ function runTests() {
     assert.strictEqual(result.stderr.trim().split('\n').length, 1, 'Preview must remain one line');
   })) passed++; else failed++;
 
+  if (test('dry-run preview preserves Unicode and escape-token truncation boundaries', () => {
+    const runWithFlags = path.resolve(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
+    const emojiBoundary = `${'x'.repeat(63)}😀`;
+    const escapeBoundary = `${'y'.repeat(62)}\0`;
+
+    for (const [tool, expected] of [
+      [emojiBoundary, `tool=${'x'.repeat(63)}...`],
+      [escapeBoundary, `tool=${'y'.repeat(62)}...`],
+    ]) {
+      const input = JSON.stringify({ tool, tool_input: {} });
+      const result = spawnSync(process.execPath, [
+        runWithFlags,
+        'pre:test',
+        'scripts/hooks/doc-file-warning.js',
+        'standard',
+      ], {
+        input,
+        encoding: 'utf8',
+        env: { ...process.env, ECC_DRY_RUN: '1' },
+        cwd: path.resolve(__dirname, '..', '..'),
+      });
+
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(result.stderr.includes(expected), result.stderr);
+      assert.ok(!result.stderr.includes('\uFFFD'), 'Preview must not contain a replacement character');
+      assert.ok(!result.stderr.includes('\\x...'), 'Preview must not contain a partial escape token');
+    }
+  })) passed++; else failed++;
+
   if (test('dry-run preview handles non-JSON stdin gracefully', () => {
     const runWithFlags = path.resolve(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
     const hookScript = 'scripts/hooks/session-start.js';

--- a/tests/lib/dry-run.test.js
+++ b/tests/lib/dry-run.test.js
@@ -22,6 +22,37 @@ function test(name, fn) {
   }
 }
 
+function testDiagnosticTruncationBoundaries() {
+  return test('dry-run preview preserves Unicode and escape-token truncation boundaries', () => {
+    const runWithFlags = path.resolve(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
+    const emojiBoundary = `${'x'.repeat(63)}😀`;
+    const escapeBoundary = `${'y'.repeat(62)}\0`;
+
+    for (const [tool, expected] of [
+      [emojiBoundary, `tool=${'x'.repeat(63)}...`],
+      [escapeBoundary, `tool=${'y'.repeat(62)}...`],
+    ]) {
+      const input = JSON.stringify({ tool, tool_input: {} });
+      const result = spawnSync(process.execPath, [
+        runWithFlags,
+        'pre:test',
+        'scripts/hooks/doc-file-warning.js',
+        'standard',
+      ], {
+        input,
+        encoding: 'utf8',
+        env: { ...process.env, ECC_DRY_RUN: '1' },
+        cwd: path.resolve(__dirname, '..', '..'),
+      });
+
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(result.stderr.includes(expected), result.stderr);
+      assert.ok(!result.stderr.includes('\uFFFD'), 'Preview must not contain a replacement character');
+      assert.ok(!result.stderr.includes('\\x...'), 'Preview must not contain a partial escape token');
+    }
+  });
+}
+
 function runTests() {
   console.log('\n=== Testing dry-run mode ===\n');
 
@@ -198,34 +229,7 @@ function runTests() {
     assert.strictEqual(result.stderr.trim().split('\n').length, 1, 'Preview must remain one line');
   })) passed++; else failed++;
 
-  if (test('dry-run preview preserves Unicode and escape-token truncation boundaries', () => {
-    const runWithFlags = path.resolve(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
-    const emojiBoundary = `${'x'.repeat(63)}😀`;
-    const escapeBoundary = `${'y'.repeat(62)}\0`;
-
-    for (const [tool, expected] of [
-      [emojiBoundary, `tool=${'x'.repeat(63)}...`],
-      [escapeBoundary, `tool=${'y'.repeat(62)}...`],
-    ]) {
-      const input = JSON.stringify({ tool, tool_input: {} });
-      const result = spawnSync(process.execPath, [
-        runWithFlags,
-        'pre:test',
-        'scripts/hooks/doc-file-warning.js',
-        'standard',
-      ], {
-        input,
-        encoding: 'utf8',
-        env: { ...process.env, ECC_DRY_RUN: '1' },
-        cwd: path.resolve(__dirname, '..', '..'),
-      });
-
-      assert.strictEqual(result.status, 0, result.stderr);
-      assert.ok(result.stderr.includes(expected), result.stderr);
-      assert.ok(!result.stderr.includes('\uFFFD'), 'Preview must not contain a replacement character');
-      assert.ok(!result.stderr.includes('\\x...'), 'Preview must not contain a partial escape token');
-    }
-  })) passed++; else failed++;
+  if (testDiagnosticTruncationBoundaries()) passed++; else failed++;
 
   if (test('dry-run preview handles non-JSON stdin gracefully', () => {
     const runWithFlags = path.resolve(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
@@ -358,6 +362,8 @@ function runTests() {
   })) passed++; else failed++;
 
   console.log(`\nResults: ${passed} passed, ${failed} failed`);
+  console.log(`Passed: ${passed}`);
+  console.log(`Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }
 

--- a/tests/lib/dry-run.test.js
+++ b/tests/lib/dry-run.test.js
@@ -91,13 +91,17 @@ function runTests() {
       `Expected stderr to contain tool name, got: ${result.stderr}`
     );
     assert.ok(
-      result.stderr.includes('target=/tmp/test.md'),
-      `Expected stderr to contain target file path, got: ${result.stderr}`
+      result.stderr.includes('target=[redacted]'),
+      `Expected stderr to redact the target file path, got: ${result.stderr}`
+    );
+    assert.ok(
+      !result.stderr.includes('/tmp/test.md'),
+      'Dry-run stderr must not expose file paths'
     );
     assert.strictEqual(result.stdout, '', 'Dry-run hook should not echo stdin');
   })) passed++; else failed++;
 
-  if (test('flushes a large dry-run preview when oversized stdout is suppressed', () => {
+  if (test('bounds dry-run diagnostics when oversized stdout is suppressed', () => {
     const runWithFlags = path.resolve(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
     const hookScript = 'scripts/hooks/block-no-verify.js';
     const command = 'x'.repeat(900 * 1024);
@@ -119,13 +123,18 @@ function runTests() {
 
     assert.strictEqual(result.status, 0, `Expected exit 0, got ${result.status}`);
     assert.strictEqual(result.stdout, '', 'Oversized dry-run input must keep stdout suppressed');
+    assert.ok(result.stderr.includes('command=[redacted]'), result.stderr);
     assert.ok(
-      result.stderr.endsWith(`command=${command}\n`),
-      `Expected the complete dry-run preview on stderr, got ${result.stderr.length} characters`
+      !result.stderr.includes(command.slice(0, 100)),
+      'Dry-run stderr must not expose commands'
+    );
+    assert.ok(
+      result.stderr.length < 1024,
+      `Dry-run stderr must stay bounded, got ${result.stderr.length} characters`
     );
   })) passed++; else failed++;
 
-  if (test('dry-run preview includes command for bash hooks', () => {
+  if (test('dry-run preview indicates a redacted command for bash hooks', () => {
     const runWithFlags = path.resolve(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
     const hookScript = 'scripts/hooks/block-no-verify.js';
     const input = JSON.stringify({ tool: 'Bash', tool_input: { command: 'git commit --no-verify -m "test"' } });
@@ -148,10 +157,45 @@ function runTests() {
       `Expected stderr to contain tool=Bash, got: ${result.stderr}`
     );
     assert.ok(
-      result.stderr.includes('command=git commit --no-verify'),
-      `Expected stderr to contain command, got: ${result.stderr}`
+      result.stderr.includes('command=[redacted]'),
+      `Expected stderr to indicate a redacted command, got: ${result.stderr}`
+    );
+    assert.ok(
+      !result.stderr.includes('git commit --no-verify'),
+      'Dry-run stderr must not expose commands'
     );
     assert.strictEqual(result.stdout, '', 'Dry-run hook should not echo stdin');
+  })) passed++; else failed++;
+
+  if (test('dry-run preview omits secrets and escapes multiline diagnostic fields', () => {
+    const runWithFlags = path.resolve(__dirname, '..', '..', 'scripts', 'hooks', 'run-with-flags.js');
+    const secret = 'preview-secret-value';
+    const input = JSON.stringify({
+      tool: 'Bash\nInjected',
+      tool_input: {
+        command: `echo ${secret}\nsecond line`,
+        file_path: `/tmp/${secret}`,
+      },
+    });
+
+    const result = spawnSync(process.execPath, [
+      runWithFlags,
+      'pre:bash:block-no-verify',
+      'scripts/hooks/block-no-verify.js',
+      'standard,strict',
+    ], {
+      input,
+      encoding: 'utf8',
+      env: { ...process.env, ECC_DRY_RUN: '1' },
+      cwd: path.resolve(__dirname, '..', '..'),
+    });
+
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.ok(!result.stderr.includes(secret), 'Dry-run stderr must not expose secret-bearing input');
+    assert.ok(result.stderr.includes('tool=Bash\\nInjected'), result.stderr);
+    assert.ok(result.stderr.includes('target=[redacted]'), result.stderr);
+    assert.ok(result.stderr.includes('command=[redacted]'), result.stderr);
+    assert.strictEqual(result.stderr.trim().split('\n').length, 1, 'Preview must remain one line');
   })) passed++; else failed++;
 
   if (test('dry-run preview handles non-JSON stdin gracefully', () => {


### PR DESCRIPTION
## What Changed

- stop `run-with-flags.js` from echoing raw hook input on silent-success, disabled, dry-run, missing-script, and fail-open paths
- keep explicit hook stdout, additional context, blocking exit codes, and oversized-input protection intact
- honor `ECC_HOOK_INPUT_MAX_BYTES` instead of overwriting it with the fixed default
- prevent the plugin and SessionStart bootstraps from reintroducing stdin when the runner is silent
- update affected contract tests and add end-to-end coverage through registered hook commands

## Why This Change

Silent hooks currently duplicate full `tool_input` and `tool_response` payloads into hook stdout. Empty stdout is the hook protocol's no-op result; echoing stdin adds transcript volume and makes disabling a hook ineffective as a mitigation.

Closes #2600

## Testing Done

- [x] Manual reproduction completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested

Focused validation passed:

- `node scripts/ci/validate-hooks.js`
- `node tests/hooks/run-with-flags-no-output.test.js` (13/13)
- `node tests/hooks/run-with-flags-truncation.test.js` (7/7)
- `node tests/hooks/config-protection.test.js` (9/9)
- `node tests/hooks/gateguard-fact-force.test.js` (144/144)
- Stop stdout, dry-run, and hook-flag focused suites also pass

The full local suite reached 3,716/3,736 before the final focused rerun; remaining failures were in Windows tests that require a working Bash/WSL runtime. Git Bash-specific behavior was exercised separately where applicable.

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [x] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [ ] Updated relevant documentation
- [x] Added comments for complex logic
- [ ] README updated (if needed)