### PR TITLE
fix(opencode): inherit user-selected models

### DIFF
--- a/.opencode/README.md
+++ b/.opencode/README.md
@@ -224,8 +224,6 @@ Full configuration in `opencode.json`:
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "anthropic/claude-sonnet-4-5",
-  "small_model": "anthropic/claude-haiku-4-5",
   "plugin": ["./plugins"],
   "instructions": [
     "skills/tdd-workflow/SKILL.md",
@@ -235,6 +233,10 @@ Full configuration in `opencode.json`:
   "command": { /* 24 commands */ }
 }
 ```
+
+The reference config intentionally leaves model selection to OpenCode. Connect a
+provider and select a model in OpenCode; ECC's primary agent uses that global
+selection, and its subagents inherit the invoking primary agent's model.
 
 ## License
 

--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,7 +1,5 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "model": "anthropic/claude-sonnet-4-5",
-  "small_model": "anthropic/claude-haiku-4-5",
   "default_agent": "build",
   "instructions": [
     "AGENTS.md",
@@ -31,7 +29,6 @@
     "build": {
       "description": "Primary coding agent for development work",
       "mode": "primary",
-      "model": "anthropic/claude-sonnet-4-5",
       "tools": {
         "write": true,
         "edit": true,
@@ -43,7 +40,6 @@
     "planner": {
       "description": "Expert planning specialist for complex features and refactoring. Use for implementation planning, architectural changes, or complex refactoring.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/planner.txt}",
       "tools": {
         "read": true,
@@ -55,7 +51,6 @@
     "architect": {
       "description": "Software architecture specialist for system design, scalability, and technical decision-making.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/architect.txt}",
       "tools": {
         "read": true,
@@ -67,7 +62,6 @@
     "code-reviewer": {
       "description": "Expert code review specialist. Reviews code for quality, security, and maintainability. Use immediately after writing or modifying code.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/code-reviewer.txt}",
       "tools": {
         "read": true,
@@ -79,7 +73,6 @@
     "security-reviewer": {
       "description": "Security vulnerability detection and remediation specialist. Use after writing code that handles user input, authentication, API endpoints, or sensitive data.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/security-reviewer.txt}",
       "tools": {
         "read": true,
@@ -91,7 +84,6 @@
     "tdd-guide": {
       "description": "Test-Driven Development specialist enforcing write-tests-first methodology. Use when writing new features, fixing bugs, or refactoring code. Ensures 80%+ test coverage.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/tdd-guide.txt}",
       "tools": {
         "read": true,
@@ -103,7 +95,6 @@
     "build-error-resolver": {
       "description": "Build and TypeScript error resolution specialist. Use when build fails or type errors occur. Fixes build/type errors only with minimal diffs.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/build-error-resolver.txt}",
       "tools": {
         "read": true,
@@ -115,7 +106,6 @@
     "e2e-runner": {
       "description": "End-to-end testing specialist using Playwright. Generates, maintains, and runs E2E tests for critical user flows.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/e2e-runner.txt}",
       "tools": {
         "read": true,
@@ -127,7 +117,6 @@
     "doc-updater": {
       "description": "Documentation and codemap specialist. Use for updating codemaps and documentation.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/doc-updater.txt}",
       "tools": {
         "read": true,
@@ -139,7 +128,6 @@
     "refactor-cleaner": {
       "description": "Dead code cleanup and consolidation specialist. Use for removing unused code, duplicates, and refactoring.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/refactor-cleaner.txt}",
       "tools": {
         "read": true,
@@ -151,7 +139,6 @@
     "go-reviewer": {
       "description": "Expert Go code reviewer specializing in idiomatic Go, concurrency patterns, error handling, and performance.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/go-reviewer.txt}",
       "tools": {
         "read": true,
@@ -163,7 +150,6 @@
     "go-build-resolver": {
       "description": "Go build, vet, and compilation error resolution specialist. Fixes Go build errors with minimal changes.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/go-build-resolver.txt}",
       "tools": {
         "read": true,
@@ -175,7 +161,6 @@
     "database-reviewer": {
       "description": "PostgreSQL database specialist for query optimization, schema design, security, and performance. Incorporates Supabase best practices.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/database-reviewer.txt}",
       "tools": {
         "read": true,
@@ -187,7 +172,6 @@
     "cpp-reviewer": {
       "description": "Expert C++ code reviewer specializing in memory safety, modern C++ idioms, concurrency, and performance. Use for all C++ code changes.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/cpp-reviewer.txt}",
       "tools": {
         "read": true,
@@ -199,7 +183,6 @@
     "cpp-build-resolver": {
       "description": "C++ build, CMake, and compilation error resolution specialist. Fixes build errors, linker issues, and template errors with minimal changes.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/cpp-build-resolver.txt}",
       "tools": {
         "read": true,
@@ -211,7 +194,6 @@
     "docs-lookup": {
       "description": "Documentation specialist using Context7 MCP to fetch current library and API documentation with code examples.",
       "mode": "subagent",
-      "model": "anthropic/claude-sonnet-4-5",
       "prompt": "{file:prompts/agents/docs-lookup.txt}",
       "tools": {
         "read": true,
@@ -223,7 +205,6 @@
     "harness-optimizer": {
       "description": "Analyze and improve the local agent harness configuration for reliability, cost, and throughput.",
       "mode": "subagent",
-      "model": "anthropic/claude-sonnet-4-5",
       "prompt": "{file:prompts/agents/harness-optimizer.txt}",
       "tools": {
         "read": true,
@@ -234,7 +215,6 @@
     "java-reviewer": {
       "description": "Expert Java and Spring Boot code reviewer specializing in layered architecture, JPA patterns, security, and concurrency.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/java-reviewer.txt}",
       "tools": {
         "read": true,
@@ -246,7 +226,6 @@
     "java-build-resolver": {
       "description": "Java/Maven/Gradle build, compilation, and dependency error resolution specialist. Fixes build errors with minimal changes.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/java-build-resolver.txt}",
       "tools": {
         "read": true,
@@ -258,7 +237,6 @@
     "kotlin-reviewer": {
       "description": "Kotlin and Android/KMP code reviewer. Reviews Kotlin code for idiomatic patterns, coroutine safety, Compose best practices.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/kotlin-reviewer.txt}",
       "tools": {
         "read": true,
@@ -270,7 +248,6 @@
     "kotlin-build-resolver": {
       "description": "Kotlin/Gradle build, compilation, and dependency error resolution specialist. Fixes Kotlin build errors with minimal changes.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/kotlin-build-resolver.txt}",
       "tools": {
         "read": true,
@@ -282,7 +259,6 @@
     "loop-operator": {
       "description": "Operate autonomous agent loops, monitor progress, and intervene safely when loops stall.",
       "mode": "subagent",
-      "model": "anthropic/claude-sonnet-4-5",
       "prompt": "{file:prompts/agents/loop-operator.txt}",
       "tools": {
         "read": true,
@@ -293,7 +269,6 @@
     "php-reviewer": {
       "description": "Expert PHP code reviewer specializing in PSR-12 compliance, PHP type system, Eloquent ORM patterns, security, and performance.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/php-reviewer.txt}",
       "tools": {
         "read": true,
@@ -305,7 +280,6 @@
     "python-reviewer": {
       "description": "Expert Python code reviewer specializing in PEP 8 compliance, Pythonic idioms, type hints, security, and performance.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/python-reviewer.txt}",
       "tools": {
         "read": true,
@@ -317,7 +291,6 @@
     "rust-reviewer": {
       "description": "Expert Rust code reviewer specializing in idiomatic Rust, ownership, lifetimes, concurrency, and performance.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/rust-reviewer.txt}",
       "tools": {
         "read": true,
@@ -329,7 +302,6 @@
     "rust-build-resolver": {
       "description": "Rust build, Cargo, and compilation error resolution specialist. Fixes Rust build errors with minimal changes.",
       "mode": "subagent",
-      "model": "anthropic/claude-opus-4-5",
       "prompt": "{file:prompts/agents/rust-build-resolver.txt}",
       "tools": {
         "read": true,

--- a/README.md
+++ b/README.md
@@ -1501,7 +1501,7 @@ See [affaan-m/ECC#2065](https://github.com/affaan-m/ECC/issues/2065).
 | Claude Code | Stable primary | Plugin or selective installer | The plugin advertises the installed catalog to the model; use a selective/manual profile when context footprint matters. Optional shell-backed skills are not portable to every OS. |
 | Codex | Supported sync; marketplace experimental | Repo config or `sync-ecc-to-codex.sh` | No ECC hook runtime. The marketplace package can omit shared repository content from Codex's cache; use sync for the reliable path. |
 | Cursor | Beta project adapter | Selective installer into `.cursor/` | Agent discovery varies by Cursor build, and ECC's installer paths do not yet expose identical hook sets ([#2419](https://github.com/affaan-m/ECC/issues/2419)). |
-| OpenCode | Beta built plugin | Build plugin, then selective installer | ECC ships a subset of the catalog and the reference config pins Anthropic models; select models available to your provider ([#2617](https://github.com/affaan-m/ECC/issues/2617)). |
+| OpenCode | Beta built plugin | Build plugin, then selective installer | ECC ships a subset of the catalog; connect a provider and select a model in OpenCode ([#2617](https://github.com/affaan-m/ECC/issues/2617)). |
 | GitHub Copilot | Instruction-only | Checked-in instructions and prompt files | No ECC hooks, runtime agents, delegation, or native skill discovery. |
 | Gemini, Zed, Antigravity, Qwen, Hermes, OpenClaw, Kimi, CodeBuddy, JoyCode | Experimental/minimal adapters | Harness-specific selective target | File placement and instruction portability are tested; full Claude feature parity is not claimed. |
 
@@ -1687,7 +1687,7 @@ The adapter writes ECC-managed files under `.zed/` and keeps BYOK/OpenRouter cre
 <details>
 <summary><strong>OpenCode support in depth</strong></summary>
 
-ECC provides a beta OpenCode plugin integration with instructions, a catalog subset, commands, custom tools, and hook events. It does not provide feature parity with Claude Code, and the reference model IDs must exist in the user's configured provider.
+ECC provides a beta OpenCode plugin integration with instructions, a catalog subset, commands, custom tools, and hook events. It does not provide feature parity with Claude Code. The reference config inherits the user's OpenCode model selection instead of pinning a provider-specific model.
 
 ```bash
 # Install OpenCode
@@ -2011,7 +2011,7 @@ Each component is fully independent.
 Yes. ECC is cross-platform:
 - **Cursor**: Pre-translated configs in `.cursor/`. See [Platform Support](#platform-support).
 - **Gemini CLI**: Experimental project-local support via `.gemini/GEMINI.md` and shared installer plumbing.
-- **OpenCode**: Beta plugin integration in `.opencode/`; provider model selection and catalog parity remain limited.
+- **OpenCode**: Beta plugin integration in `.opencode/`; models follow the user's OpenCode selection, while catalog parity remains limited.
 - **Codex**: Supported repo/sync path for macOS app and CLI; ECC's marketplace package remains experimental.
 - **GitHub Copilot (VS Code)**: Instruction and prompt layer via `.github/copilot-instructions.md`, `.vscode/settings.json`, and `.github/prompts/`.
 - **Antigravity**: Tightly integrated setup for workflows, skills, and flattened rules in `.agent/`. See [Antigravity Guide](docs/ANTIGRAVITY-GUIDE.md).

--- a/tests/opencode-config.test.js
+++ b/tests/opencode-config.test.js
@@ -33,7 +33,15 @@ if (
     assert.ok(!Object.hasOwn(config, 'model'), 'Root config must not pin a provider-specific model');
     assert.ok(!Object.hasOwn(config, 'small_model'), 'Root config must not pin a provider-specific small model');
 
-    for (const [agentId, agent] of Object.entries(config.agent || {})) {
+    assert.ok(
+      config.agent &&
+        typeof config.agent === 'object' &&
+        !Array.isArray(config.agent) &&
+        Object.keys(config.agent).length > 0,
+      'Reference config must define registered agents'
+    );
+
+    for (const [agentId, agent] of Object.entries(config.agent)) {
       assert.ok(!Object.hasOwn(agent, 'model'), `Agent "${agentId}" must inherit the selected OpenCode model`);
     }
   })

--- a/tests/opencode-config.test.js
+++ b/tests/opencode-config.test.js
@@ -29,6 +29,19 @@ let passed = 0;
 let failed = 0;
 
 if (
+  test('model selection inherits the user configured OpenCode provider', () => {
+    assert.ok(!Object.hasOwn(config, 'model'), 'Root config must not pin a provider-specific model');
+    assert.ok(!Object.hasOwn(config, 'small_model'), 'Root config must not pin a provider-specific small model');
+
+    for (const [agentId, agent] of Object.entries(config.agent || {})) {
+      assert.ok(!Object.hasOwn(agent, 'model'), `Agent "${agentId}" must inherit the selected OpenCode model`);
+    }
+  })
+)
+  passed++;
+else failed++;
+
+if (
   test('plugin paths do not duplicate the .opencode directory', () => {
     const plugins = config.plugin || [];
     for (const pluginPath of plugins) {


### PR DESCRIPTION
## What Changed

- Removed provider-specific `model` and `small_model` pins from the reference OpenCode config.
- Removed per-agent model overrides so primary agents use OpenCode's global model selection and subagents inherit the invoking primary agent's model.
- Added a regression test covering the root config and every registered agent.
- Updated the OpenCode documentation and support matrix to describe the inherited model behavior.

## Why This Change

Context: #2617

The checked-in reference config currently requires Anthropic model IDs even when a user has connected a different OpenCode provider. That makes agents such as `code-reviewer` fail before they can run.

This Draft takes the smallest reversible approach supported by OpenCode's model-selection semantics: omit model overrides and let OpenCode use the user's configured selection.

### Assumptions and boundaries

- Assumes the user has connected a provider and selected a usable model in OpenCode.
- Applies one selected model across ECC agents through OpenCode inheritance. It intentionally gives up the current fixed Opus/Sonnet/Haiku tiering in exchange for provider neutrality.
- Does not inspect credentials, probe provider APIs, add dependencies, or expand the guided installer.
- Does not attempt feature parity with Claude Code.

### Alternative for review

If explicit quality/cost tiering is required, the follow-up alternative is to add provider/model inputs to the installer and generate validated root and per-agent mappings. That is a larger interface and configuration change; this Draft keeps that option open without requiring it for provider-neutral defaults.

OpenCode documents configured model selection and per-agent model inheritance here:
- https://opencode.ai/docs/models
- https://opencode.ai/docs/agents/

## Testing Done

- [ ] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested

Focused validation:
- `node tests/opencode-config.test.js` — 4 passed, 0 failed
- JSON parse validation — passed
- `git diff --check` — passed
- `node tests/run-all.js` — 3716 passed, 20 failed. The failures are confined to Windows environment constraints (missing `/bin/bash`/WSL, unavailable symlink privileges, and unrelated local temp/server assumptions); the OpenCode config, plugin, tools, and build tests pass.

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [x] `docs:` Documentation
- [x] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## If you changed dependencies or `package.json` (`bin` / `files` / deps)

Not applicable.

## If you added a skill, command, agent, hook, or CLI tool

Not applicable.

## Documentation

- [x] Updated relevant documentation
- [ ] Added comments for complex logic
- [x] README updated (if needed)