### PR TITLE
fix(strategic-compact): the task list may not exist — stop promising it survives compaction

### DIFF
--- a/.agents/skills/strategic-compact/SKILL.md
+++ b/.agents/skills/strategic-compact/SKILL.md
@@ -73,7 +73,7 @@ Use this table to decide when to compact:
 | Phase Transition | Compact? | Why |
 |-----------------|----------|-----|
 | Research → Planning | Yes | Research context is bulky; plan is the distilled output |
-| Planning → Implementation | Yes | Plan is in TodoWrite or a file; free up context for code |
+| Planning → Implementation | Yes | Plan is written down (a file, or the task list if you have one); free up context for code |
 | Implementation → Testing | Maybe | Keep if tests reference recent code; compact if switching focus |
 | Debugging → Next feature | Yes | Debug traces pollute context for unrelated work |
 | Mid-implementation | No | Losing variable names, file paths, and partial state is costly |
@@ -86,14 +86,28 @@ Understanding what persists helps you compact with confidence:
 | Persists | Lost |
 |----------|------|
 | CLAUDE.md instructions | Intermediate reasoning and analysis |
-| TodoWrite task list | File contents you previously read |
+| Files on disk | File contents you previously read |
 | Memory files (`~/.claude/memory/`) | Multi-step conversation context |
 | Git state (commits, branches) | Tool call history and counts |
-| Files on disk | Nuanced user preferences stated verbally |
+| The task list — **only if you have the todo tools** (see below) | Nuanced user preferences stated verbally |
+
+> ### Don't rely on the task list surviving — it may not exist
+>
+> Claude Code **2.1.233 removed the todo/task tools by default** on Opus 4.8, Sonnet 5,
+> Fable 5, Mythos 5 and newer models (`TodoWrite`, `TaskCreate/Get/Update/List`).
+> `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` brings them back, but that is a per-machine
+> environment setting — **it does not travel with this skill**, so you cannot assume the
+> reader has it.
+>
+> This matters because "my todo list survives compaction" is a reason people compact
+> *instead of* writing state down. If the tools are absent there is no list to survive,
+> and the plan is simply gone. **Write the plan to a file before compacting** — a file
+> persists on every version and every model. Treat the task list as a convenience that
+> may be missing, never as your durable record.
 
 ## Best Practices
 
-1. **Compact after planning** — Once plan is finalized in TodoWrite, compact to start fresh
+1. **Compact after planning** — Once the plan is finalized **and written to a file**, compact to start fresh
 2. **Compact after debugging** — Clear error-resolution context before continuing
 3. **Don't compact mid-implementation** — Preserve context for related changes
 4. **Read the suggestion** — The hook tells you *when*, you decide *if*

--- a/.kiro/skills/strategic-compact/SKILL.md
+++ b/.kiro/skills/strategic-compact/SKILL.md
@@ -71,7 +71,7 @@ Use this table to decide when to compact:
 | Phase Transition | Compact? | Why |
 |-----------------|----------|-----|
 | Research → Planning | Yes | Research context is bulky; plan is the distilled output |
-| Planning → Implementation | Yes | Plan is in TodoWrite or a file; free up context for code |
+| Planning → Implementation | Yes | Plan is written down (a file, or the task list if you have one); free up context for code |
 | Implementation → Testing | Maybe | Keep if tests reference recent code; compact if switching focus |
 | Debugging → Next feature | Yes | Debug traces pollute context for unrelated work |
 | Mid-implementation | No | Losing variable names, file paths, and partial state is costly |
@@ -84,14 +84,28 @@ Understanding what persists helps you compact with confidence:
 | Persists | Lost |
 |----------|------|
 | CLAUDE.md instructions | Intermediate reasoning and analysis |
-| TodoWrite task list | File contents you previously read |
+| Files on disk | File contents you previously read |
 | Memory files (`~/.claude/memory/`) | Multi-step conversation context |
 | Git state (commits, branches) | Tool call history and counts |
-| Files on disk | Nuanced user preferences stated verbally |
+| The task list — **only if you have the todo tools** (see below) | Nuanced user preferences stated verbally |
+
+> ### Don't rely on the task list surviving — it may not exist
+>
+> Claude Code **2.1.233 removed the todo/task tools by default** on Opus 4.8, Sonnet 5,
+> Fable 5, Mythos 5 and newer models (`TodoWrite`, `TaskCreate/Get/Update/List`).
+> `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` brings them back, but that is a per-machine
+> environment setting — **it does not travel with this skill**, so you cannot assume the
+> reader has it.
+>
+> This matters because "my todo list survives compaction" is a reason people compact
+> *instead of* writing state down. If the tools are absent there is no list to survive,
+> and the plan is simply gone. **Write the plan to a file before compacting** — a file
+> persists on every version and every model. Treat the task list as a convenience that
+> may be missing, never as your durable record.
 
 ## Best Practices
 
-1. **Compact after planning** — Once plan is finalized in TodoWrite, compact to start fresh
+1. **Compact after planning** — Once the plan is finalized **and written to a file**, compact to start fresh
 2. **Compact after debugging** — Clear error-resolution context before continuing
 3. **Don't compact mid-implementation** — Preserve context for related changes
 4. **Read the suggestion** — The hook tells you *when*, you decide *if*

--- a/skills/strategic-compact/SKILL.md
+++ b/skills/strategic-compact/SKILL.md
@@ -80,7 +80,7 @@ Use this table to decide when to compact:
 | Phase Transition | Compact? | Why |
 |-----------------|----------|-----|
 | Research → Planning | Yes | Research context is bulky; plan is the distilled output |
-| Planning → Implementation | Yes | Plan is in TodoWrite or a file; free up context for code |
+| Planning → Implementation | Yes | Plan is written down (a file, or the task list if you have one); free up context for code |
 | Implementation → Testing | Maybe | Keep if tests reference recent code; compact if switching focus |
 | Debugging → Next feature | Yes | Debug traces pollute context for unrelated work |
 | Mid-implementation | No | Losing variable names, file paths, and partial state is costly |
@@ -93,14 +93,28 @@ Understanding what persists helps you compact with confidence:
 | Persists | Lost |
 |----------|------|
 | CLAUDE.md instructions | Intermediate reasoning and analysis |
-| TodoWrite task list | File contents you previously read |
+| Files on disk | File contents you previously read |
 | Memory files (`~/.claude/memory/`) | Multi-step conversation context |
 | Git state (commits, branches) | Tool call history and counts |
-| Files on disk | Nuanced user preferences stated verbally |
+| The task list — **only if you have the todo tools** (see below) | Nuanced user preferences stated verbally |
+
+> ### Don't rely on the task list surviving — it may not exist
+>
+> Claude Code **2.1.233 removed the todo/task tools by default** on Opus 4.8, Sonnet 5,
+> Fable 5, Mythos 5 and newer models (`TodoWrite`, `TaskCreate/Get/Update/List`).
+> `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` brings them back, but that is a per-machine
+> environment setting — **it does not travel with this skill**, so you cannot assume the
+> reader has it.
+>
+> This matters because "my todo list survives compaction" is a reason people compact
+> *instead of* writing state down. If the tools are absent there is no list to survive,
+> and the plan is simply gone. **Write the plan to a file before compacting** — a file
+> persists on every version and every model. Treat the task list as a convenience that
+> may be missing, never as your durable record.
 
 ## Best Practices
 
-1. **Compact after planning** — Once plan is finalized in TodoWrite, compact to start fresh
+1. **Compact after planning** — Once the plan is finalized **and written to a file**, compact to start fresh
 2. **Compact after debugging** — Clear error-resolution context before continuing
 3. **Don't compact mid-implementation** — Preserve context for related changes
 4. **Read the suggestion** — The hook tells you *when*, you decide *if*


### PR DESCRIPTION
## What Changed

`strategic-compact` tells readers their todo list survives compaction. Three claims are wrong for most readers on a current Claude Code:

| Location | Claim |
|---|---|
| *What Survives Compaction* table | `TodoWrite task list` listed **unconditionally** |
| *Compaction Decision Guide* | "Plan is in TodoWrite or a file" as the reason to compact at Planning→Implementation |
| *Best Practices* #1 | "Once plan is finalized in TodoWrite, compact to start fresh" |

Fixes:
- Promote **`Files on disk`** into the survives table — the claim that holds on every version and model.
- Make the task-list row **conditional**, with a short caveat naming the version, the env var, and the fact that it does not travel with the skill.
- Point readers at **a file** as the durable record before compacting.
- Reword the Decision Guide and Best Practices lines so neither depends on the tool existing.

Applied identically to the Codex (`.agents/`) and Kiro (`.kiro/`) mirrors so all three copies agree.

## Why This Change

Claude Code **2.1.233** removed the todo/task tools by default on Opus 4.8, Sonnet 5, Fable 5, Mythos 5 and newer — `TodoWrite`, `TaskCreate/Get/Update/List`. From the changelog:

> Todo/task-tracking tools (TaskCreate/Get/Update/List, TodoWrite) are no longer available on Opus 4.8, Sonnet 5, Fable 5, Mythos 5, and newer models; set `CLAUDE_CODE_ENABLE_TODO_TOOLS=1` to bring them back.

`CLAUDE_CODE_ENABLE_TODO_TOOLS=1` restores them, but it is a **per-machine environment setting that does not travel with a skill** — so this skill cannot assume its reader has a task list at all.

This is load-bearing advice, not a cosmetic detail. *"My todo list survives compaction"* is a reason to compact **instead of** writing state down. If the tools are absent there is no list to survive, so the reader follows the advice, compacts, and the plan is simply gone. That is the one failure this skill exists to prevent.

Found while auditing a downstream consumer for the 2.1.233 change: 3 of 6 affected files were prose making promises the harness no longer keeps, and this was the load-bearing one.

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally — see the note below on scope
- [x] Edge cases considered and tested

All eight `scripts/ci/` validators pass with `node_modules` installed:

```
check-unicode-safety           PASS
validate-skills                PASS   (285 skill directories)
validate-agents                PASS
validate-commands              PASS
validate-rules                 PASS   (122 rule files)
validate-hooks                 PASS
validate-install-manifests     PASS
validate-no-personal-paths     PASS
```

Plus `npm run catalog:check` (counts match), `npm run command-registry:check` (up to date), and `node scripts/harness-adapter-compliance.js` (**PASS**, 12 adapters — relevant here since this touches two harness mirrors).

**Scope note, stated plainly:** `check-unicode-safety` initially failed on my added block because I used a `⚠️` heading (`U+26A0` + `U+FE0F`, flagged `dangerous-invisible`). Removed — the added text is emoji-free. Separately, `node tests/run-all.js` is long-running and had not finished when I opened this; I am not claiming a full `npm test` pass. Every gate that bears on a docs-only skill change is listed above and green. Happy to report the full suite result in a comment.

`yarn.lock` is byte-identical to `main` — my local `npm ci` rewrote it and I reverted that before committing, per the lockfile warning in the PR template.

## Type of Change
- [x] `fix:` Bug fix
- [x] `docs:` Documentation

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] JSON files validate cleanly (no JSON touched)
- [x] Shell scripts pass shellcheck (N/A — no shell scripts touched)
- [x] Pre-commit hooks pass locally
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## If you changed dependencies or `package.json`
N/A — no dependency or manifest changes. `yarn.lock` confirmed unchanged.

## If you added a skill, command, agent, hook, or CLI tool
N/A — no new components. This edits three existing copies of one skill; catalog and command-registry checks confirm counts are unchanged, and harness-adapter-compliance passes.

## Note on the mirrors

The `.agents/` and `.kiro/` copies already carry **pre-existing drift** from `skills/strategic-compact/SKILL.md` (the Kiro copy predates the context-size signal entirely). This change deliberately does **not** reconcile that drift — it applies only the same three claim fixes to each, so the diff stays reviewable. Reconciling the mirrors looks worth a separate PR if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)