### PR TITLE
fix: accept standard tools/list request metadata

### DIFF
--- a/scripts/memory-mcp.mjs
+++ b/scripts/memory-mcp.mjs
@@ -423,8 +423,16 @@ function createMemoryMcpService(options = {}) {
         return jsonRpcResult(message.id, {});
       }
       if (message.method === 'tools/list') {
-        if (message.params && Object.keys(message.params).length > 0) {
-          return jsonRpcError(message.id, -32602, 'tools/list does not accept parameters.');
+        const params = message.params || {};
+        if (
+          (Object.prototype.hasOwnProperty.call(params, '_meta') && !isRecord(params._meta))
+          || (
+            Object.prototype.hasOwnProperty.call(params, 'cursor')
+            && typeof params.cursor !== 'string'
+          )
+          || Object.keys(params).some(key => !['cursor', '_meta'].includes(key))
+        ) {
+          return jsonRpcError(message.id, -32602, 'Invalid tools/list parameters.');
         }
         return jsonRpcResult(message.id, {
           tools: TOOL_DEFINITIONS.map(tool => ({ ...tool })),

--- a/tests/scripts/memory-mcp.test.js
+++ b/tests/scripts/memory-mcp.test.js
@@ -132,6 +132,7 @@ async function withClient(fn, options = {}) {
 
   const client = {
     listTools: () => request('tools/list'),
+    listToolsRaw: params => request('tools/list', params),
     callTool: ({ name, arguments: toolArguments }) => request(
       'tools/call',
       { name, arguments: toolArguments }
@@ -178,6 +179,51 @@ async function main() {
       assert.ok(!JSON.stringify(save.inputSchema).includes('sourceHarness'));
       assert.ok(!JSON.stringify(search.inputSchema).includes('targetHarness'));
       assert.strictEqual(save.inputSchema.properties.body.minLength, 1);
+    });
+  });
+
+  await test('accepts reserved tools/list params and rejects malformed values', async () => {
+    await withClient(async client => {
+      const withMeta = await client.listToolsRaw({
+        _meta: { progressToken: 'progress-123' },
+      });
+      assert.strictEqual(withMeta.tools.length, 4);
+
+      const withCursor = await client.listToolsRaw({ cursor: 'next-page' });
+      assert.strictEqual(withCursor.tools.length, 4);
+
+      const withCursorAndMeta = await client.listToolsRaw({
+        cursor: 'next-page',
+        _meta: { progressToken: 'progress-456' },
+      });
+      assert.strictEqual(withCursorAndMeta.tools.length, 4);
+
+      const withoutMeta = await client.listTools();
+      assert.deepStrictEqual(
+        withoutMeta.tools.map(tool => tool.name).sort(),
+        ['memory_doctor', 'memory_read', 'memory_save', 'memory_search']
+      );
+
+      for (const badMeta of [null, ['not', 'an', 'object'], 'string', 42, true]) {
+        await assert.rejects(
+          client.listToolsRaw({ _meta: badMeta }),
+          /-32602/,
+          `expected _meta=${JSON.stringify(badMeta)} to be rejected`
+        );
+      }
+
+      for (const badCursor of [null, {}, [], 42, true]) {
+        await assert.rejects(
+          client.listToolsRaw({ cursor: badCursor }),
+          /-32602/,
+          `expected cursor=${JSON.stringify(badCursor)} to be rejected`
+        );
+      }
+
+      await assert.rejects(
+        client.listToolsRaw({ unexpected: true }),
+        /-32602/
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- accept MCP-reserved `_meta` on `tools/list`
- accept and validate the standard optional `cursor` field
- keep rejecting malformed metadata, malformed cursors, and unknown top-level parameters
- add regression coverage for Codex-compatible list requests

## Root cause

Recent Codex clients attach an MCP `_meta` object to `tools/list`. The memory MCP server rejected every non-empty parameter object, so initialization stopped with `-32602` before `memory_search`, `memory_save`, and the other tools could be exposed.

## Validation

```text
NODE_PATH=/usr/local/lib/node_modules/ecc-universal/node_modules node tests/scripts/memory-mcp.test.js
Results: Passed: 13, Failed: 0
```

Also verified:

- `node --check scripts/memory-mcp.mjs`
- `node --check tests/scripts/memory-mcp.test.js`
- `git diff --check`

Fixes #2810