### PR TITLE
fix(install): add skills/skill-comply to workflow-quality module

### DIFF
--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -326,6 +326,7 @@
         "skills/plan-canvas",
         "skills/plankton-code-quality",
         "skills/production-audit",
+        "skills/skill-comply",
         "skills/skill-scout",
         "skills/skill-stocktake",
         "skills/strategic-compact",


### PR DESCRIPTION
## Summary

`skills/skill-comply/` was not referenced by any module in `manifests/install-modules.json`, so `install-apply.js --profile full` silently installed 284 of 285 skills. The gap was invisible from the install output and `npm run catalog:check` still passed because it compares documentation counts against the repository catalog, not manifest coverage.

This was the last remaining instance of #2431 ("install-modules.json is missing 79 curated skills"), which was closed as completed on 2026-08-04. That fix covered 78 of the 79; `skill-comply` slipped through.

## Fix

Added `"skills/skill-comply"` to the `workflow-quality` module in `manifests/install-modules.json`, alongside the other evaluation, audit, and compliance skills (`skill-scout`, `skill-stocktake`, `production-audit`, `delivery-gate`, etc.).

One-line change, alphabetically positioned.

## Verification

**Manifest coverage scan** — every skill directory is now referenced:

```
skill dirs: 285
referenced : 285
unreferenced: []
```

**Dry-run install plan** (`--profile full --dry-run --json`) now includes all 22 `skill-comply` files:

```
Total unique skills in plan: 286
skill-comply IS in plan
  skills/skill-comply/SKILL.md -> ~/.claude/skills/skill-comply/SKILL.md
  skills/skill-comply/scripts/runner.py -> ~/.claude/skills/skill-comply/scripts/runner.py
  ... (22 files total)
```

Before this fix, `skill-comply` was absent from the plan entirely.

## Environment

- ECC 2.2.0 (main @ 06c5e11)
- Node.js v22.x, npm 11.x
- Termux/Android (Linux ARM64)

Fixes #2789