### PR TITLE
fix(tests): support npm 12 pack output

### DIFF
--- a/tests/lib/npm-pack-output.js
+++ b/tests/lib/npm-pack-output.js
@@ -1,0 +1,21 @@
+function isPackEntry(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getNpmPackEntry(output, packageName) {
+  if (Array.isArray(output)) {
+    return output.find(isPackEntry);
+  }
+
+  if (!isPackEntry(output)) {
+    return undefined;
+  }
+
+  if (isPackEntry(output[packageName])) {
+    return output[packageName];
+  }
+
+  return Object.values(output).find(isPackEntry);
+}
+
+module.exports = { getNpmPackEntry };

--- a/tests/lib/npm-pack-output.js
+++ b/tests/lib/npm-pack-output.js
@@ -3,19 +3,23 @@ function isPackEntry(value) {
 }
 
 function getNpmPackEntry(output, packageName) {
+  const matchesPackage = value => (
+    isPackEntry(value) && value.name === packageName
+  );
+
   if (Array.isArray(output)) {
-    return output.find(isPackEntry);
+    return output.find(matchesPackage);
   }
 
   if (!isPackEntry(output)) {
     return undefined;
   }
 
-  if (isPackEntry(output[packageName])) {
+  if (matchesPackage(output[packageName])) {
     return output[packageName];
   }
 
-  return Object.values(output).find(isPackEntry);
+  return Object.values(output).find(matchesPackage);
 }
 
 module.exports = { getNpmPackEntry };

--- a/tests/lib/npm-pack-output.test.js
+++ b/tests/lib/npm-pack-output.test.js
@@ -1,0 +1,46 @@
+const assert = require('assert');
+const { getNpmPackEntry } = require('./npm-pack-output');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed += 1;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.error(`    ${error.message}`);
+    failed += 1;
+  }
+}
+
+test('reads the npm 11 array response', () => {
+  const entry = getNpmPackEntry([
+    { name: 'ecc-universal', filename: 'ecc-universal-2.2.0.tgz' },
+  ], 'ecc-universal');
+
+  assert.strictEqual(entry.filename, 'ecc-universal-2.2.0.tgz');
+});
+
+test('reads the npm 12 package-keyed response', () => {
+  const entry = getNpmPackEntry({
+    'ecc-universal': {
+      name: 'ecc-universal',
+      filename: 'ecc-universal-2.2.0.tgz',
+    },
+  }, 'ecc-universal');
+
+  assert.strictEqual(entry.filename, 'ecc-universal-2.2.0.tgz');
+});
+
+test('returns undefined for empty or malformed responses', () => {
+  assert.strictEqual(getNpmPackEntry([], 'ecc-universal'), undefined);
+  assert.strictEqual(getNpmPackEntry({}, 'ecc-universal'), undefined);
+  assert.strictEqual(getNpmPackEntry(null, 'ecc-universal'), undefined);
+});
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/lib/npm-pack-output.test.js
+++ b/tests/lib/npm-pack-output.test.js
@@ -18,6 +18,7 @@ function test(name, fn) {
 
 test('reads the npm 11 array response', () => {
   const entry = getNpmPackEntry([
+    { name: 'unrelated-package', filename: 'unrelated-package-1.0.0.tgz' },
     { name: 'ecc-universal', filename: 'ecc-universal-2.2.0.tgz' },
   ], 'ecc-universal');
 
@@ -35,10 +36,31 @@ test('reads the npm 12 package-keyed response', () => {
   assert.strictEqual(entry.filename, 'ecc-universal-2.2.0.tgz');
 });
 
+test('finds a requested package in a generic object response', () => {
+  const entry = getNpmPackEntry({
+    unrelated: { name: 'unrelated-package', filename: 'unrelated-package-1.0.0.tgz' },
+    target: { name: 'ecc-universal', filename: 'ecc-universal-2.2.0.tgz' },
+  }, 'ecc-universal');
+
+  assert.strictEqual(entry.filename, 'ecc-universal-2.2.0.tgz');
+});
+
 test('returns undefined for empty or malformed responses', () => {
   assert.strictEqual(getNpmPackEntry([], 'ecc-universal'), undefined);
   assert.strictEqual(getNpmPackEntry({}, 'ecc-universal'), undefined);
   assert.strictEqual(getNpmPackEntry(null, 'ecc-universal'), undefined);
+  assert.strictEqual(
+    getNpmPackEntry([
+      { name: 'unrelated-package', filename: 'unrelated-package-1.0.0.tgz' },
+    ], 'ecc-universal'),
+    undefined
+  );
+  assert.strictEqual(
+    getNpmPackEntry({
+      unrelated: { name: 'unrelated-package', filename: 'unrelated-package-1.0.0.tgz' },
+    }, 'ecc-universal'),
+    undefined
+  );
 });
 
 console.log(`\nPassed: ${passed}`);

--- a/tests/scripts/build-opencode.test.js
+++ b/tests/scripts/build-opencode.test.js
@@ -6,6 +6,7 @@ const assert = require("assert")
 const fs = require("fs")
 const path = require("path")
 const { spawnSync } = require("child_process")
+const { getNpmPackEntry } = require("../lib/npm-pack-output")
 
 function runTest(name, fn) {
   try {
@@ -54,7 +55,8 @@ function main() {
       assert.strictEqual(result.status, 0, result.error?.message || result.stderr)
 
       const packOutput = JSON.parse(result.stdout)
-      const packagedPaths = new Set(packOutput[0]?.files?.map((file) => file.path) ?? [])
+      const packEntry = getNpmPackEntry(packOutput, packageJson.name)
+      const packagedPaths = new Set(packEntry?.files?.map((file) => file.path) ?? [])
 
       assert.ok(
         packagedPaths.has(".opencode/dist/index.js"),

--- a/tests/scripts/ecc-universal-bin.test.js
+++ b/tests/scripts/ecc-universal-bin.test.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const { getNpmPackEntry } = require('../lib/npm-pack-output');
 
 const repoRoot = path.join(__dirname, '..', '..');
 const packageJson = JSON.parse(
@@ -123,14 +124,15 @@ function getPackedFixture() {
     ['pack', '--json', '--ignore-scripts', '--pack-destination', directory]
   );
   const packOutput = JSON.parse(packResult.stdout);
-  const filename = packOutput[0]?.filename;
+  const packEntry = getNpmPackEntry(packOutput, packageJson.name);
+  const filename = packEntry?.filename;
   assert.ok(filename, 'npm pack should report the archive filename');
 
   packedFixture = {
     archivePath: path.join(directory, filename),
     directory,
     publishedPaths: new Set(
-      packOutput[0]?.files?.map(file => file.path) || []
+      packEntry?.files?.map(file => file.path) || []
     ),
   };
   return packedFixture;

--- a/tests/scripts/npm-publish-surface.test.js
+++ b/tests/scripts/npm-publish-surface.test.js
@@ -6,6 +6,7 @@ const assert = require("assert")
 const fs = require("fs")
 const path = require("path")
 const { spawnSync } = require("child_process")
+const { getNpmPackEntry } = require("../lib/npm-pack-output")
 
 function runTest(name, fn) {
   try {
@@ -149,7 +150,8 @@ function main() {
       assert.strictEqual(result.status, 0, result.error?.message || result.stderr)
 
       const packOutput = JSON.parse(result.stdout)
-      const packagedPaths = new Set(packOutput[0]?.files?.map((file) => file.path) ?? [])
+      const packEntry = getNpmPackEntry(packOutput, packageJson.name)
+      const packagedPaths = new Set(packEntry?.files?.map((file) => file.path) ?? [])
 
       for (const requiredPath of [
         "scripts/catalog.js",


### PR DESCRIPTION
## What Changed
- add a shared parser for both npm <=11 array output and npm 12 package-keyed output from `npm pack --json`
- use the normalized entry in all three affected packaging suites
- add regression coverage for both response shapes and malformed empty output

## Why This Change
npm 12 changed `npm pack --json` from an array to an object keyed by package name. The existing tests indexed `[0]`, causing six false packaging failures even though the archive contents were correct.

Fixes #2816

## Testing Done
- [x] `node tests/lib/npm-pack-output.test.js`
- [x] `node tests/scripts/build-opencode.test.js`
- [x] `node tests/scripts/npm-publish-surface.test.js`
- [x] `node tests/scripts/ecc-universal-bin.test.js`
- [x] `npx eslint tests/lib/npm-pack-output.js tests/lib/npm-pack-output.test.js tests/scripts/build-opencode.test.js tests/scripts/npm-publish-surface.test.js tests/scripts/ecc-universal-bin.test.js`
- [ ] `npm test` completes with 3818/3843 passing on this Windows host; the remaining 25 failures are existing environment limitations where `/bin/bash` is unavailable or symlink creation returns EPERM, outside the changed pack tests

## Type of Change
- [x] `fix:` Bug fix
- [x] `test:` Tests

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format
- [x] `git diff --check` passes