### PR TITLE
fix(install): merge state across selective installs

### DIFF
--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -337,8 +337,12 @@ function previewInstallPlan(plan) {
 
 function applyInstallPlan(plan, dependencies = {}) {
   const persistInstallState = dependencies.writeInstallState || writeInstallState;
+  const beforeInstallStateRead = dependencies.beforeInstallStateRead;
   const beforeOperationWrite = dependencies.beforeOperationWrite;
   const beforeInstallStateWrite = dependencies.beforeInstallStateWrite;
+  if (typeof beforeInstallStateRead === 'function') {
+    beforeInstallStateRead({ plan });
+  }
   const migration = prepareClaudeSkillMigration(plan);
   const appliedPlan = {
     ...plan,

--- a/scripts/lib/install/claude-skill-migration.js
+++ b/scripts/lib/install/claude-skill-migration.js
@@ -133,19 +133,13 @@ function isManagedOperation(operation) {
 }
 
 function uniqueOperations(operations) {
-  const seen = new Set();
-  return operations.filter(operation => {
-    const key = [
-      operation.kind,
-      normalizeSourceRelativePath(operation.sourceRelativePath) || operation.sourceRelativePath,
-      comparablePath(operation.destinationPath),
-    ].join('\0');
-    if (seen.has(key)) {
-      return false;
-    }
-    seen.add(key);
-    return true;
-  });
+  const byDestination = new Map();
+  for (const operation of operations) {
+    // A target path has one current owner. Later operations come from the
+    // newest plan and replace stale metadata for the same destination.
+    byDestination.set(comparablePath(operation.destinationPath), operation);
+  }
+  return [...byDestination.values()];
 }
 
 function buildState(statePreview, operations) {
@@ -236,14 +230,18 @@ function createFileConflictWarning(destinationPath, retainsLegacy) {
   return `Skipped user-owned Claude skill file ${destinationPath}: the existing file is not recorded in ECC install-state.${legacySuffix}`;
 }
 
-function createDisabledMigration(plan) {
+function createDisabledMigration(plan, previousState) {
+  const finalState = buildState(plan.statePreview, [
+    ...((previousState && previousState.operations) || []),
+    ...plan.statePreview.operations,
+  ]);
   return {
     enabled: false,
     appliedOperations: [...plan.operations],
     skippedOperations: [],
     warnings: [],
-    bridgeState: plan.statePreview,
-    finalState: plan.statePreview,
+    bridgeState: finalState,
+    finalState,
     legacyOperationsToRemove: [],
     requiresBridgeState: false,
   };
@@ -331,11 +329,16 @@ function buildMigrationStates(plan, previousState, previous, classification) {
   const legacyOperationsToRemove = legacyOperations.filter(operation => (
     !retainedLegacyOperations.has(operation)
   ));
+  const removedLegacyDestinations = new Set(
+    legacyOperationsToRemove.map(operation => comparablePath(operation.destinationPath))
+  );
   const finalOperations = [
+    ...((previousState && previousState.operations) || []).filter(operation => (
+      !removedLegacyDestinations.has(comparablePath(operation.destinationPath))
+    )),
     ...plan.statePreview.operations.filter(operation => (
       !skippedDestinations.has(comparablePath(operation.destinationPath))
     )),
-    ...retainedLegacyOperations,
   ];
   const bridgeOperations = [
     ...((previousState && previousState.operations) || []),
@@ -352,14 +355,13 @@ function buildMigrationStates(plan, previousState, previous, classification) {
 }
 
 function prepareClaudeSkillMigration(plan) {
-  const target = plan && plan.adapter && plan.adapter.target;
-  if (!CLAUDE_TARGETS.has(target)) {
-    return createDisabledMigration(plan);
-  }
-
   const previousState = pathExists(plan.installStatePath)
     ? readInstallState(plan.installStatePath)
     : null;
+  const target = plan && plan.adapter && plan.adapter.target;
+  if (!CLAUDE_TARGETS.has(target)) {
+    return createDisabledMigration(plan, previousState);
+  }
   const currentGroups = groupCurrentSkillOperations(plan);
   const previous = classifyPreviousOperations(plan, previousState);
   const classification = classifySkillConflicts(currentGroups, previous);

--- a/scripts/lib/multi-harness-setup.js
+++ b/scripts/lib/multi-harness-setup.js
@@ -327,6 +327,7 @@ async function applyPreflightedManagedPlan(entry) {
   );
 
   const result = require('./install-executor').applyInstallPlan(preview.plan, {
+    beforeInstallStateRead: assertStateUnchanged,
     beforeOperationWrite({ operation }) {
       assertStateUnchanged();
       const expected = preview.operations[operationIndex];

--- a/scripts/lib/multi-harness-setup.js
+++ b/scripts/lib/multi-harness-setup.js
@@ -295,6 +295,9 @@ function preflightManagedPlan(plan, dependencies = {}) {
   if (!plan || !Array.isArray(plan.operations)) {
     throw new Error('A managed install plan with operations is required.');
   }
+  if (typeof plan.installStatePath !== 'string' || plan.installStatePath.trim() === '') {
+    throw new Error('A managed install plan with an install-state path is required.');
+  }
   const ownership = readOwnedDestinations(plan, dependencies);
   const operations = plan.operations.map(operation => {
     assertSafeInstallOperation(plan, operation);

--- a/tests/lib/install-claude-skill-migration.test.js
+++ b/tests/lib/install-claude-skill-migration.test.js
@@ -433,6 +433,72 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('merges managed operations across selective installs for the same target', () => {
+    const fixture = createFixture();
+    try {
+      applyInstallPlan(fixture.plan);
+
+      const extraSourceRelativePath = path.join('skills', 'extra-skill', 'SKILL.md');
+      const extraSourcePath = path.join(fixture.sourceRoot, extraSourceRelativePath);
+      const extraDestinationPath = path.join(
+        fixture.targetRoot,
+        'skills',
+        'extra-skill',
+        'SKILL.md'
+      );
+      fs.mkdirSync(path.dirname(extraSourcePath), { recursive: true });
+      fs.writeFileSync(extraSourcePath, '# Extra ECC skill\n');
+      const extraOperation = createOperation(
+        'skill-extra',
+        fixture.sourceRoot,
+        extraSourceRelativePath,
+        extraDestinationPath
+      );
+      const extraPlan = {
+        ...fixture.plan,
+        operations: [extraOperation],
+        statePreview: {
+          ...fixture.plan.statePreview,
+          request: {
+            ...fixture.plan.statePreview.request,
+            modules: [],
+            includeComponents: ['skill-extra'],
+          },
+          resolution: {
+            selectedModules: [],
+            skippedModules: [],
+          },
+          operations: [extraOperation],
+        },
+      };
+
+      applyInstallPlan(extraPlan);
+      const stateAfterExtraInstall = readInstallState(fixture.installStatePath);
+      assert.ok(fixture.operations.every(operation => (
+        stateAfterExtraInstall.operations.some(recorded => (
+          recorded.destinationPath === operation.destinationPath
+        ))
+      )));
+      assert.ok(stateAfterExtraInstall.operations.some(operation => (
+        operation.destinationPath === extraDestinationPath
+      )));
+
+      const retry = applyInstallPlan(fixture.plan);
+      assert.deepStrictEqual(retry.skippedOperations, []);
+      const stateAfterRetry = readInstallState(fixture.installStatePath);
+      assert.ok(stateAfterRetry.operations.some(operation => (
+        operation.destinationPath === extraDestinationPath
+      )));
+
+      const uninstall = runUninstall(fixture);
+      assert.strictEqual(uninstall.summary.errorCount, 0);
+      assert.ok(fixture.operations.every(operation => !fs.existsSync(operation.destinationPath)));
+      assert.ok(!fs.existsSync(extraDestinationPath));
+    } finally {
+      cleanup(fixture.tempDir);
+    }
+  })) passed++; else failed++;
+
   if (test('tracks a partial migration so retry and uninstall remain safe', () => {
     const fixture = createFixture();
     try {

--- a/tests/lib/install-claude-skill-migration.test.js
+++ b/tests/lib/install-claude-skill-migration.test.js
@@ -38,8 +38,14 @@ function createFixture(options = {}) {
   const target = options.target || 'claude';
   const targetRoot = target === 'claude'
     ? path.join(homeDir, '.claude')
-    : path.join(projectRoot, '.claude');
-  const installStatePath = path.join(targetRoot, 'ecc', 'install-state.json');
+    : path.join(projectRoot, target === 'cursor' ? '.cursor' : '.claude');
+  const installStatePath = target === 'cursor'
+    ? path.join(targetRoot, 'ecc-install-state.json')
+    : path.join(targetRoot, 'ecc', 'install-state.json');
+  const adapterId = target === 'claude'
+    ? 'claude-home'
+    : target === 'cursor' ? 'cursor-project' : 'claude-project';
+  const adapterKind = target === 'claude' ? 'home' : 'project';
   const skillFiles = options.skillFiles || {
     'SKILL.md': '# Current ECC skill\n',
     'references/guide.md': '# Current ECC guide\n',
@@ -61,9 +67,9 @@ function createFixture(options = {}) {
     schemaVersion: 'ecc.install.v1',
     installedAt: new Date().toISOString(),
     target: {
-      id: target === 'claude' ? 'claude-home' : 'claude-project',
+      id: adapterId,
       target,
-      kind: target === 'claude' ? 'home' : 'project',
+      kind: adapterKind,
       root: targetRoot,
       installStatePath,
     },
@@ -100,9 +106,9 @@ function createFixture(options = {}) {
       mode: 'manifest',
       target,
       adapter: {
-        id: target === 'claude' ? 'claude-home' : 'claude-project',
+        id: adapterId,
         target,
-        kind: target === 'claude' ? 'home' : 'project',
+        kind: adapterKind,
       },
       targetRoot,
       installRoot: targetRoot,
@@ -433,69 +439,71 @@ function runTests() {
     }
   })) passed++; else failed++;
 
-  if (test('merges managed operations across selective installs for the same target', () => {
-    const fixture = createFixture();
-    try {
-      applyInstallPlan(fixture.plan);
+  if (test('merges managed operations across selective installs for enabled and disabled migrations', () => {
+    for (const target of ['claude', 'cursor']) {
+      const fixture = createFixture({ target });
+      try {
+        applyInstallPlan(fixture.plan);
 
-      const extraSourceRelativePath = path.join('skills', 'extra-skill', 'SKILL.md');
-      const extraSourcePath = path.join(fixture.sourceRoot, extraSourceRelativePath);
-      const extraDestinationPath = path.join(
-        fixture.targetRoot,
-        'skills',
-        'extra-skill',
-        'SKILL.md'
-      );
-      fs.mkdirSync(path.dirname(extraSourcePath), { recursive: true });
-      fs.writeFileSync(extraSourcePath, '# Extra ECC skill\n');
-      const extraOperation = createOperation(
-        'skill-extra',
-        fixture.sourceRoot,
-        extraSourceRelativePath,
-        extraDestinationPath
-      );
-      const extraPlan = {
-        ...fixture.plan,
-        operations: [extraOperation],
-        statePreview: {
-          ...fixture.plan.statePreview,
-          request: {
-            ...fixture.plan.statePreview.request,
-            modules: [],
-            includeComponents: ['skill-extra'],
-          },
-          resolution: {
-            selectedModules: [],
-            skippedModules: [],
-          },
+        const extraSourceRelativePath = path.join('skills', 'extra-skill', 'SKILL.md');
+        const extraSourcePath = path.join(fixture.sourceRoot, extraSourceRelativePath);
+        const extraDestinationPath = path.join(
+          fixture.targetRoot,
+          'skills',
+          'extra-skill',
+          'SKILL.md'
+        );
+        fs.mkdirSync(path.dirname(extraSourcePath), { recursive: true });
+        fs.writeFileSync(extraSourcePath, '# Extra ECC skill\n');
+        const extraOperation = createOperation(
+          'skill-extra',
+          fixture.sourceRoot,
+          extraSourceRelativePath,
+          extraDestinationPath
+        );
+        const extraPlan = {
+          ...fixture.plan,
           operations: [extraOperation],
-        },
-      };
+          statePreview: {
+            ...fixture.plan.statePreview,
+            request: {
+              ...fixture.plan.statePreview.request,
+              modules: [],
+              includeComponents: ['skill-extra'],
+            },
+            resolution: {
+              selectedModules: [],
+              skippedModules: [],
+            },
+            operations: [extraOperation],
+          },
+        };
 
-      applyInstallPlan(extraPlan);
-      const stateAfterExtraInstall = readInstallState(fixture.installStatePath);
-      assert.ok(fixture.operations.every(operation => (
-        stateAfterExtraInstall.operations.some(recorded => (
-          recorded.destinationPath === operation.destinationPath
-        ))
-      )));
-      assert.ok(stateAfterExtraInstall.operations.some(operation => (
-        operation.destinationPath === extraDestinationPath
-      )));
+        applyInstallPlan(extraPlan);
+        const stateAfterExtraInstall = readInstallState(fixture.installStatePath);
+        assert.ok(fixture.operations.every(operation => (
+          stateAfterExtraInstall.operations.some(recorded => (
+            recorded.destinationPath === operation.destinationPath
+          ))
+        )));
+        assert.ok(stateAfterExtraInstall.operations.some(operation => (
+          operation.destinationPath === extraDestinationPath
+        )));
 
-      const retry = applyInstallPlan(fixture.plan);
-      assert.deepStrictEqual(retry.skippedOperations, []);
-      const stateAfterRetry = readInstallState(fixture.installStatePath);
-      assert.ok(stateAfterRetry.operations.some(operation => (
-        operation.destinationPath === extraDestinationPath
-      )));
+        const retry = applyInstallPlan(fixture.plan);
+        assert.deepStrictEqual(retry.skippedOperations, []);
+        const stateAfterRetry = readInstallState(fixture.installStatePath);
+        assert.ok(stateAfterRetry.operations.some(operation => (
+          operation.destinationPath === extraDestinationPath
+        )));
 
-      const uninstall = runUninstall(fixture);
-      assert.strictEqual(uninstall.summary.errorCount, 0);
-      assert.ok(fixture.operations.every(operation => !fs.existsSync(operation.destinationPath)));
-      assert.ok(!fs.existsSync(extraDestinationPath));
-    } finally {
-      cleanup(fixture.tempDir);
+        const uninstall = runUninstall(fixture);
+        assert.strictEqual(uninstall.summary.errorCount, 0);
+        assert.ok(fixture.operations.every(operation => !fs.existsSync(operation.destinationPath)));
+        assert.ok(!fs.existsSync(extraDestinationPath));
+      } finally {
+        cleanup(fixture.tempDir);
+      }
     }
   })) passed++; else failed++;
 

--- a/tests/lib/install-claude-skill-migration.test.js
+++ b/tests/lib/install-claude-skill-migration.test.js
@@ -490,12 +490,33 @@ function runTests() {
           operation.destinationPath === extraDestinationPath
         )));
 
+        const updatedExtraOperation = {
+          ...extraOperation,
+          moduleId: 'skill-extra-updated',
+        };
+        applyInstallPlan({
+          ...extraPlan,
+          operations: [updatedExtraOperation],
+          statePreview: {
+            ...extraPlan.statePreview,
+            operations: [updatedExtraOperation],
+          },
+        });
+        const stateAfterMetadataUpdate = readInstallState(fixture.installStatePath);
+        const updatedExtraRecords = stateAfterMetadataUpdate.operations.filter(operation => (
+          operation.destinationPath === extraDestinationPath
+        ));
+        assert.strictEqual(updatedExtraRecords.length, 1);
+        assert.strictEqual(updatedExtraRecords[0].moduleId, 'skill-extra-updated');
+
         const retry = applyInstallPlan(fixture.plan);
         assert.deepStrictEqual(retry.skippedOperations, []);
         const stateAfterRetry = readInstallState(fixture.installStatePath);
-        assert.ok(stateAfterRetry.operations.some(operation => (
+        const retainedExtraRecords = stateAfterRetry.operations.filter(operation => (
           operation.destinationPath === extraDestinationPath
-        )));
+        ));
+        assert.strictEqual(retainedExtraRecords.length, 1);
+        assert.strictEqual(retainedExtraRecords[0].moduleId, 'skill-extra-updated');
 
         const uninstall = runUninstall(fixture);
         assert.strictEqual(uninstall.summary.errorCount, 0);

--- a/tests/lib/install-claude-skill-migration.test.js
+++ b/tests/lib/install-claude-skill-migration.test.js
@@ -512,6 +512,11 @@ function runTests() {
         const retry = applyInstallPlan(fixture.plan);
         assert.deepStrictEqual(retry.skippedOperations, []);
         const stateAfterRetry = readInstallState(fixture.installStatePath);
+        assert.ok(fixture.operations.every(operation => (
+          stateAfterRetry.operations.filter(recorded => (
+            recorded.destinationPath === operation.destinationPath
+          )).length === 1
+        )));
         const retainedExtraRecords = stateAfterRetry.operations.filter(operation => (
           operation.destinationPath === extraDestinationPath
         ));

--- a/tests/lib/multi-harness-setup.test.js
+++ b/tests/lib/multi-harness-setup.test.js
@@ -143,6 +143,24 @@ function writeManagedState(plan, overrides = {}) {
     );
   });
 
+  await test('rejects managed plans without an install-state path', () => {
+    const root = tempDir('ecc-guided-missing-state-path-');
+    try {
+      const source = path.join(root, 'source.md');
+      const destination = path.join(root, '.kimi-code', 'rules', 'security.md');
+      writeFile(source, 'ecc\n');
+      const plan = managedPlan(root, [stateOperation(destination, { sourcePath: source })]);
+      const invalidPlan = { ...plan, installStatePath: undefined };
+
+      assert.throws(
+        () => preflightManagedPlan(invalidPlan),
+        /managed install plan.*install-state path/i
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   await test('classifies missing, identical, managed, and JSON merge destinations', () => {
     const root = tempDir('ecc-guided-preflight-');
     try {


### PR DESCRIPTION
## Summary

- merge previously recorded install operations when a later selective install targets the same destination root
- deduplicate by destination path so the newest operation metadata wins
- preserve retained legacy Claude skill ownership while excluding legacy paths that migration removes
- add a two-pass selective-install regression that verifies retry and uninstall behavior

## Validation

- `node tests/lib/install-claude-skill-migration.test.js` (17 passed)
- `node tests/scripts/install-apply.test.js` (36 passed)
- `node tests/scripts/uninstall.test.js` (4 passed)
- `npm exec eslint -- scripts/lib/install/claude-skill-migration.js tests/lib/install-claude-skill-migration.test.js`
- `git diff --check`
- `npm test` was exercised across the repository; changed install suites passed. The Windows run also hit existing environment-only failures where `/bin/bash`/WSL is unavailable and symlink creation returns EPERM.

## Scope

This addresses the state replacement reported in #2790 without adopting skipped user-owned files. It intentionally does not add a doctor/re-adoption path.