### PR TITLE
fix(ci): add tool cache directories to check-unicode-safety ignore list

### DIFF
--- a/scripts/ci/check-unicode-safety.js
+++ b/scripts/ci/check-unicode-safety.js
@@ -15,6 +15,10 @@ const ignoredDirs = new Set([
   '.dmux',
   '.next',
   '.venv',
+  '.pytest_cache',
+  '.ruff_cache',
+  '.turbo',
+  '.cache',
   'coverage',
   'venv',
 ]);

--- a/tests/scripts/check-unicode-safety.test.js
+++ b/tests/scripts/check-unicode-safety.test.js
@@ -198,6 +198,24 @@ if (
   passed++;
 else failed++;
 
+if (
+  test('skips tool cache directories (.pytest_cache, .ruff_cache, .turbo, .cache)', () => {
+    const root = makeTempRoot('ecc-unicode-cache-');
+    for (const cacheDir of ['.pytest_cache', '.ruff_cache', '.turbo', '.cache']) {
+      fs.mkdirSync(path.join(root, cacheDir), { recursive: true });
+      fs.writeFileSync(
+        path.join(root, cacheDir, 'cache-data.json'),
+        `{"cached": "${rocketEmoji}"}\n`
+      );
+    }
+
+    const result = runCheck(root);
+    assert.strictEqual(result.status, 0, result.stdout + result.stderr);
+  })
+)
+  passed++;
+else failed++;
+
 console.log(`\nPassed: ${passed}`);
 console.log(`Failed: ${failed}`);
 process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
### Summary
- Adds `.pytest_cache`, `.ruff_cache`, `.turbo`, and `.cache` to `ignoredDirs` in `scripts/ci/check-unicode-safety.js` so local test and linter cache artifacts do not trigger false-positive unicode safety violations.
- Adds automated test coverage in `tests/scripts/check-unicode-safety.test.js`.