### PR TITLE
fix(install): surface actionable errors when runtime deps are missing

### DIFF
--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -195,7 +195,11 @@ async function main() {
       printHumanPlan(result, false);
     }
   } catch (error) {
-    process.stderr.write(`Error: ${error.message}${getHelpText()}`);
+    const { isMissing } = require('./lib/require-runtime');
+    const suffix = error.code === 'ECC_RUNTIME_DEPENDENCY_MISSING' || isMissing(error)
+      ? '\n'
+      : getHelpText();
+    process.stderr.write(`Error: ${error.message}${suffix}`);
     process.exit(1);
   }
 }

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -195,8 +195,7 @@ async function main() {
       printHumanPlan(result, false);
     }
   } catch (error) {
-    const { isMissing } = require('./lib/require-runtime');
-    const suffix = error.code === 'ECC_RUNTIME_DEPENDENCY_MISSING' || isMissing(error)
+    const suffix = error.code === 'ECC_RUNTIME_DEPENDENCY_MISSING'
       ? '\n'
       : getHelpText();
     process.stderr.write(`Error: ${error.message}${suffix}`);

--- a/scripts/install-plan.js
+++ b/scripts/install-plan.js
@@ -9,10 +9,6 @@ const {
   listInstallProfiles,
   resolveInstallPlan,
 } = require('./lib/install-manifests');
-const {
-  findDefaultInstallConfigPath,
-  loadInstallConfig,
-} = require('./lib/install/config');
 const { normalizeInstallRequest } = require('./lib/install/request');
 
 function showHelp() {
@@ -237,6 +233,10 @@ function main() {
       return;
     }
 
+    const {
+      findDefaultInstallConfigPath,
+      loadInstallConfig,
+    } = require('./lib/install/config');
     const defaultConfigPath = options.configPath
       ? null
       : findDefaultInstallConfigPath({ cwd: process.cwd() });

--- a/scripts/lib/control-pane/state.js
+++ b/scripts/lib/control-pane/state.js
@@ -4,8 +4,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-const initSqlJs = require('sql.js');
-const toml = require('@iarna/toml');
+const { requireRuntime } = require('../require-runtime');
 
 const { buildControlPaneActions } = require('./actions');
 
@@ -86,6 +85,7 @@ function normalizeConfig(rawConfig = {}, options = {}) {
 
 function readTomlConfig(configPath) {
   const raw = fs.readFileSync(configPath, 'utf8');
+  const toml = requireRuntime('@iarna/toml');
   return toml.parse(raw);
 }
 
@@ -113,6 +113,7 @@ function resolveControlPaneConfig(options = {}) {
 
 async function openSqlDatabase(dbPath) {
   if (!dbPath || !fs.existsSync(dbPath)) return null;
+  const initSqlJs = requireRuntime('sql.js');
   const SQL = await initSqlJs();
   const buffer = fs.readFileSync(dbPath);
   return new SQL.Database(buffer);

--- a/scripts/lib/install/antigravity-agent.js
+++ b/scripts/lib/install/antigravity-agent.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { requireRuntime } = require('../require-runtime');
+
 const TOOL_NAMES = Object.freeze({
   Read: 'view_file',
   Write: 'write_to_file',
@@ -26,7 +28,7 @@ function splitFrontmatter(source, label) {
   // Keep YAML loading behind the transform boundary. Public help commands load
   // the installer graph without executing a transform, including in hermetic
   // packed-artifact checks where runtime dependencies are intentionally absent.
-  const frontmatter = require('js-yaml').load(match[1]);
+  const frontmatter = requireRuntime('js-yaml').load(match[1]);
   if (!frontmatter || typeof frontmatter !== 'object' || Array.isArray(frontmatter)) {
     throw new Error(`Cannot adapt Antigravity agent ${label}: frontmatter must be an object`);
   }
@@ -57,7 +59,7 @@ function adaptAntigravityAgent(source, label = '<unknown>') {
       ? MODEL_NAMES[frontmatter.model]
       : frontmatter.model;
   }
-  const serialized = require('js-yaml')
+  const serialized = requireRuntime('js-yaml')
     .dump(adapted, { lineWidth: -1, noRefs: true })
     .trimEnd();
   return `---\n${serialized}\n---\n${body}`;

--- a/scripts/lib/install/config.js
+++ b/scripts/lib/install/config.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const Ajv = require('ajv');
+const { requireRuntime } = require('../require-runtime');
 
 const DEFAULT_INSTALL_CONFIG = 'ecc-install.json';
 const CONFIG_SCHEMA_PATH = path.join(__dirname, '..', '..', '..', 'schemas', 'ecc-install-config.schema.json');
@@ -23,6 +23,7 @@ function getValidator() {
   }
 
   const schema = readJson(CONFIG_SCHEMA_PATH, 'ecc-install-config.schema.json');
+  const Ajv = requireRuntime('ajv');
   const ajv = new Ajv({ allErrors: true });
   cachedValidator = ajv.compile(schema);
   return cachedValidator;

--- a/scripts/lib/require-runtime.js
+++ b/scripts/lib/require-runtime.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const path = require('path');
+
+const root = path.join(__dirname, '..', '..');
+
+function isMissing(error) {
+  return Boolean(error && error.code === 'MODULE_NOT_FOUND');
+}
+
+function pkg(error, fallback) {
+  const match = String(error?.message || '').match(/Cannot find module '([^']+)'/);
+  return match ? match[1] : fallback;
+}
+
+function format(name) {
+  return [
+    `Missing runtime dependency '${name}'.`,
+    'ECC plugin/marketplace installs are git clones without node_modules.',
+    'From the ECC repository root, run: npm install',
+    `ECC root: ${root}`,
+  ].join('\n');
+}
+
+function missing(name) {
+  const err = new Error(format(name));
+  err.code = 'ECC_RUNTIME_DEPENDENCY_MISSING';
+  err.packageName = name;
+  return err;
+}
+
+function requireRuntime(name) {
+  try {
+    return require(name);
+  } catch (error) {
+    if (!isMissing(error)) {
+      throw error;
+    }
+    throw missing(pkg(error, name));
+  }
+}
+
+module.exports = {
+  format,
+  isMissing,
+  missing,
+  requireRuntime,
+};

--- a/scripts/lib/state-store/index.js
+++ b/scripts/lib/state-store/index.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const crypto = require('crypto');
 const os = require('os');
 const path = require('path');
-const initSqlJs = require('sql.js');
+const { requireRuntime } = require('../require-runtime');
 
 const { applyMigrations, getAppliedMigrations } = require('./migrations');
 const { createQueryApi } = require('./queries');
@@ -333,6 +333,7 @@ async function openDatabase(SQL, dbPath) {
 
 async function createStateStore(options = {}) {
   const dbPath = resolveStateStorePath(options);
+  const initSqlJs = requireRuntime('sql.js');
   const SQL = await initSqlJs();
   const db = await openDatabase(SQL, dbPath);
   const appliedMigrations = applyMigrations(db);

--- a/scripts/lib/state-store/schema.js
+++ b/scripts/lib/state-store/schema.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const Ajv = require('ajv');
+const { requireRuntime } = require('../require-runtime');
 
 const SCHEMA_PATH = path.join(__dirname, '..', '..', '..', 'schemas', 'state-store.schema.json');
 
@@ -34,7 +34,7 @@ function getAjv() {
     return cachedAjv;
   }
 
-  cachedAjv = new Ajv({
+  cachedAjv = new (requireRuntime('ajv'))({
     allErrors: true,
     strict: false,
   });

--- a/tests/lib/antigravity-agent.test.js
+++ b/tests/lib/antigravity-agent.test.js
@@ -1,0 +1,96 @@
+/**
+ * Tests for scripts/lib/install/antigravity-agent.js
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { adaptAntigravityAgent } = require('../../scripts/lib/install/antigravity-agent');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \u2713 ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  \u2717 ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing antigravity-agent.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('reports actionable error when js-yaml is missing', () => {
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'antigravity-agent-no-yaml-'));
+    const scriptsDir = path.join(sandbox, 'scripts');
+    const libDir = path.join(scriptsDir, 'lib', 'install');
+
+    try {
+      fs.mkdirSync(libDir, { recursive: true });
+      fs.cpSync(
+        path.join(__dirname, '..', '..', 'scripts', 'lib', 'require-runtime.js'),
+        path.join(scriptsDir, 'lib', 'require-runtime.js'),
+      );
+      fs.cpSync(
+        path.join(__dirname, '..', '..', 'scripts', 'lib', 'install', 'antigravity-agent.js'),
+        path.join(libDir, 'antigravity-agent.js'),
+      );
+
+      const source = `---
+name: demo
+tools: Read
+---
+Body
+`;
+      const result = spawnInSandbox(sandbox, source);
+      assert.strictEqual(result.status, 1);
+      assert.ok(result.stderr.includes("Missing runtime dependency 'js-yaml'"));
+      assert.ok(result.stderr.includes('npm install'));
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('adapts agent frontmatter when js-yaml is available', () => {
+    const adapted = adaptAntigravityAgent(`---
+name: demo
+tools: Read, Bash
+model: sonnet
+---
+Body
+`, 'demo.md');
+    assert.ok(adapted.includes('view_file'));
+    assert.ok(adapted.includes('run_command'));
+    assert.ok(adapted.includes('pro'));
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+function spawnInSandbox(sandbox, source) {
+  const runner = path.join(sandbox, 'runner.js');
+  fs.writeFileSync(runner, `
+    const { adaptAntigravityAgent } = require('./scripts/lib/install/antigravity-agent');
+    try {
+      adaptAntigravityAgent(${JSON.stringify(source)}, 'demo.md');
+      process.exit(0);
+    } catch (error) {
+      process.stderr.write(String(error.message || error));
+      process.exit(1);
+    }
+  `);
+  return require('child_process').spawnSync(process.execPath, [runner], {
+    encoding: 'utf8',
+    cwd: sandbox,
+  });
+}
+
+runTests();

--- a/tests/lib/require-runtime.test.js
+++ b/tests/lib/require-runtime.test.js
@@ -1,0 +1,96 @@
+/**
+ * Tests for scripts/lib/require-runtime.js
+ */
+
+const assert = require('assert');
+const Module = require('module');
+const path = require('path');
+
+const {
+  format,
+  isMissing,
+  missing,
+  requireRuntime,
+} = require('../../scripts/lib/require-runtime');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \u2713 ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  \u2717 ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runTests() {
+  console.log('\n=== Testing require-runtime.js ===\n');
+
+  let passed = 0;
+  let failed = 0;
+
+  if (test('detects MODULE_NOT_FOUND errors', () => {
+    assert.strictEqual(isMissing({ code: 'MODULE_NOT_FOUND' }), true);
+    assert.strictEqual(isMissing({ code: 'ENOENT' }), false);
+  })) passed++; else failed++;
+
+  if (test('formats actionable missing dependency messages', () => {
+    const message = format('ajv');
+    assert.ok(message.includes("Missing runtime dependency 'ajv'"));
+    assert.ok(message.includes('npm install'));
+    assert.ok(message.includes('plugin/marketplace'));
+  })) passed++; else failed++;
+
+  if (test('creates tagged missing dependency errors', () => {
+    const err = missing('sql.js');
+    assert.strictEqual(err.code, 'ECC_RUNTIME_DEPENDENCY_MISSING');
+    assert.strictEqual(err.packageName, 'sql.js');
+    assert.ok(err.message.includes('sql.js'));
+  })) passed++; else failed++;
+
+  if (test('requireRuntime rethrows non-module errors', () => {
+  const original = Module._load;
+  Module._load = function fakeLoad(request, parent, isMain) {
+    if (request === 'ecc-test-broken-module') {
+      throw new Error('boom');
+    }
+    return original.call(this, request, parent, isMain);
+  };
+
+  try {
+    assert.throws(() => requireRuntime('ecc-test-broken-module'), /boom/);
+  } finally {
+    Module._load = original;
+  }
+  })) passed++; else failed++;
+
+  if (test('requireRuntime wraps MODULE_NOT_FOUND with actionable text', () => {
+    const original = Module._load;
+    Module._load = function fakeLoad(request, parent, isMain) {
+      if (request === 'ecc-test-missing-module') {
+        const err = new Error("Cannot find module 'ecc-test-missing-module'");
+        err.code = 'MODULE_NOT_FOUND';
+        throw err;
+      }
+      return original.call(this, request, parent, isMain);
+    };
+
+    try {
+      assert.throws(() => requireRuntime('ecc-test-missing-module'), error => {
+        assert.strictEqual(error.code, 'ECC_RUNTIME_DEPENDENCY_MISSING');
+        assert.ok(error.message.includes('ecc-test-missing-module'));
+        assert.ok(error.message.includes('npm install'));
+        return true;
+      });
+    } finally {
+      Module._load = original;
+    }
+  })) passed++; else failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();

--- a/tests/lib/require-runtime.test.js
+++ b/tests/lib/require-runtime.test.js
@@ -3,7 +3,8 @@
  */
 
 const assert = require('assert');
-const Module = require('module');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const {
@@ -51,42 +52,23 @@ function runTests() {
   })) passed++; else failed++;
 
   if (test('requireRuntime rethrows non-module errors', () => {
-  const original = Module._load;
-  Module._load = function fakeLoad(request, parent, isMain) {
-    if (request === 'ecc-test-broken-module') {
-      throw new Error('boom');
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'require-runtime-throws-'));
+    const modulePath = path.join(temp, 'throws.js');
+    fs.writeFileSync(modulePath, "throw new Error('boom');");
+    try {
+      assert.throws(() => requireRuntime(modulePath), /boom/);
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
     }
-    return original.call(this, request, parent, isMain);
-  };
-
-  try {
-    assert.throws(() => requireRuntime('ecc-test-broken-module'), /boom/);
-  } finally {
-    Module._load = original;
-  }
   })) passed++; else failed++;
 
   if (test('requireRuntime wraps MODULE_NOT_FOUND with actionable text', () => {
-    const original = Module._load;
-    Module._load = function fakeLoad(request, parent, isMain) {
-      if (request === 'ecc-test-missing-module') {
-        const err = new Error("Cannot find module 'ecc-test-missing-module'");
-        err.code = 'MODULE_NOT_FOUND';
-        throw err;
-      }
-      return original.call(this, request, parent, isMain);
-    };
-
-    try {
-      assert.throws(() => requireRuntime('ecc-test-missing-module'), error => {
-        assert.strictEqual(error.code, 'ECC_RUNTIME_DEPENDENCY_MISSING');
-        assert.ok(error.message.includes('ecc-test-missing-module'));
-        assert.ok(error.message.includes('npm install'));
-        return true;
-      });
-    } finally {
-      Module._load = original;
-    }
+    assert.throws(() => requireRuntime('ecc-test-missing-module-xyz'), error => {
+      assert.strictEqual(error.code, 'ECC_RUNTIME_DEPENDENCY_MISSING');
+      assert.ok(error.message.includes('ecc-test-missing-module-xyz'));
+      assert.ok(error.message.includes('npm install'));
+      return true;
+    });
   })) passed++; else failed++;
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -128,6 +128,35 @@ function runTests() {
     const result = run(['--profile', 'core', 'typescript']);
     assert.strictEqual(result.code, 1);
     assert.ok(result.stderr.includes('cannot be combined'));
+    assert.ok(result.stderr.includes('Usage:'));
+  })) passed++; else failed++;
+
+  if (test('omits usage text for missing runtime dependency errors', () => {
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'install-apply-missing-ajv-'));
+    const scriptsDir = path.join(sandbox, 'scripts');
+    const libDir = path.join(scriptsDir, 'lib');
+    const configPath = path.join(sandbox, 'ecc-install.json');
+
+    try {
+      fs.mkdirSync(libDir, { recursive: true });
+      fs.cpSync(SCRIPT, path.join(scriptsDir, 'install-apply.js'));
+      fs.cpSync(path.join(__dirname, '..', '..', 'scripts', 'lib'), libDir, { recursive: true });
+      fs.cpSync(path.join(__dirname, '..', '..', 'manifests'), path.join(sandbox, 'manifests'), { recursive: true });
+      fs.cpSync(path.join(__dirname, '..', '..', 'schemas'), path.join(sandbox, 'schemas'), { recursive: true });
+      fs.writeFileSync(configPath, JSON.stringify({ version: 1, profile: 'core' }, null, 2));
+
+      const result = spawnSync('node', [path.join(scriptsDir, 'install-apply.js'), '--config', configPath, '--dry-run'], {
+        encoding: 'utf8',
+        cwd: sandbox,
+      });
+
+      assert.strictEqual(result.status, 1);
+      assert.ok(result.stderr.includes("Missing runtime dependency 'ajv'"));
+      assert.ok(result.stderr.includes('npm install'));
+      assert.ok(!result.stderr.includes('Usage:'));
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
   })) passed++; else failed++;
 
   if (test('installs Claude rules and writes install-state', () => {

--- a/tests/scripts/install-plan.test.js
+++ b/tests/scripts/install-plan.test.js
@@ -3,8 +3,10 @@
  */
 
 const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
-const { execFileSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'install-plan.js');
 
@@ -185,6 +187,57 @@ function runTests() {
     const result = run(['--profile', 'core', '--target', 'not-a-target']);
     assert.strictEqual(result.code, 1);
     assert.ok(result.stderr.includes('Unknown install target'));
+  })) passed++; else failed++;
+
+  if (test('lists profiles without runtime dependencies installed', () => {
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'install-plan-no-deps-'));
+    const scriptsDir = path.join(sandbox, 'scripts');
+    const libDir = path.join(scriptsDir, 'lib');
+
+    try {
+      fs.mkdirSync(libDir, { recursive: true });
+      fs.cpSync(path.join(__dirname, '..', '..', 'scripts', 'install-plan.js'), path.join(scriptsDir, 'install-plan.js'));
+      fs.cpSync(path.join(__dirname, '..', '..', 'scripts', 'lib'), libDir, { recursive: true });
+      fs.cpSync(path.join(__dirname, '..', '..', 'manifests'), path.join(sandbox, 'manifests'), { recursive: true });
+
+      const result = spawnSync('node', [path.join(scriptsDir, 'install-plan.js'), '--list-profiles'], {
+        encoding: 'utf8',
+        cwd: sandbox,
+      });
+
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(result.stdout.includes('Install profiles'));
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('reports actionable error when config validation deps are missing', () => {
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'install-plan-missing-ajv-'));
+    const scriptsDir = path.join(sandbox, 'scripts');
+    const libDir = path.join(scriptsDir, 'lib');
+    const configPath = path.join(sandbox, 'ecc-install.json');
+
+    try {
+      fs.mkdirSync(libDir, { recursive: true });
+      fs.cpSync(path.join(__dirname, '..', '..', 'scripts', 'install-plan.js'), path.join(scriptsDir, 'install-plan.js'));
+      fs.cpSync(path.join(__dirname, '..', '..', 'scripts', 'lib'), libDir, { recursive: true });
+      fs.cpSync(path.join(__dirname, '..', '..', 'manifests'), path.join(sandbox, 'manifests'), { recursive: true });
+      fs.cpSync(path.join(__dirname, '..', '..', 'schemas'), path.join(sandbox, 'schemas'), { recursive: true });
+      fs.writeFileSync(configPath, JSON.stringify({ version: 1, profile: 'core' }, null, 2));
+
+      const result = spawnSync('node', [path.join(scriptsDir, 'install-plan.js'), '--config', configPath], {
+        encoding: 'utf8',
+        cwd: sandbox,
+      });
+
+      assert.strictEqual(result.status, 1);
+      assert.ok(result.stderr.includes("Missing runtime dependency 'ajv'"));
+      assert.ok(result.stderr.includes('npm install'));
+      assert.ok(!result.stderr.includes('Unknown argument'));
+    } finally {
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
   })) passed++; else failed++;
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);


### PR DESCRIPTION
## What Changed

- Added `scripts/lib/require-runtime.js` to turn `MODULE_NOT_FOUND` into an actionable message that tells plugin/marketplace users to run `npm install` from the ECC root.
- Lazy-loaded `ajv`/`sql.js`/`@iarna/toml` in install and control-pane code paths so listing commands do not require `node_modules`.
- Deferred `install-plan.js` config loading until a config-backed code path runs.
- Stopped `install-apply.js` from appending the usage banner when the failure is a missing runtime dependency.

## Why This Change

Fixes #2822. Claude Code plugin/marketplace installs are git clones without `node_modules`, so `install-plan.js`, `install-apply.js`, and `control-pane.js` crashed with raw `Cannot find module 'ajv'/'sql.js'` stack traces. `install-apply.js` also printed its usage banner after the stack trace, which looked like an argument error.

## Testing Done
- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/lib/require-runtime.test.js`, `node tests/scripts/install-plan.test.js`, `node tests/lib/install-config.test.js`)
- [x] Edge cases considered and tested

## Type of Change
- [x] `fix:` Bug fix

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## If you changed dependencies or `package.json` (`bin` / `files` / deps)
- [ ] Ran `yarn install --mode=update-lockfile` and committed the `yarn.lock` change. CI runs Yarn in hardened mode on public PRs and fails if the lockfile would be modified, so an out of date `yarn.lock` breaks the build even when nothing else is wrong.

## If you added a skill, command, agent, hook, or CLI tool
- [ ] Not applicable

## Documentation
- [ ] Updated relevant documentation
- [x] Added comments for complex logic
- [ ] README updated (if needed)