### PR TITLE
fix(gateguard): deny dd whose input path is not word-initial

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -48,11 +48,13 @@ const ECC_ENABLE_VALUES = new Set(['1', 'true', 'on', 'enabled', 'enable', 'yes'
 // phrases without shell-flag ordering concerns. Quoted strings are
 // stripped before this regex runs so a commit message mentioning
 // "drop table" no longer triggers a false positive.
-// The trailing \b applies only to the arms that end in a word character.
-// `dd\s+if=` ends in `=`, so a shared \b demanded that the NEXT character be a
-// word character and the disk-wipe spellings slipped through: `dd if=/dev/zero`
-// and `dd if=./img` were allowed while `dd if=x` was denied (#2642).
-const DESTRUCTIVE_SQL_DD = /\b(?:drop\s+table|delete\s+from|truncate)\b|\bdd\s+if=/i;
+// `dd if=` used to be a fourth arm here. Matching it as text could not work:
+// the arm ended in `=`, so the shared trailing \b required the NEXT character
+// to be a word character and `dd if=/dev/zero` slipped through while
+// `echo dd if=x` — which runs no dd at all — was gated. The boundary decided
+// the verdict instead of the command position, so dd moved to isDestructiveDd()
+// alongside the other token-based detectors (#2642).
+const DESTRUCTIVE_SQL = /\b(drop\s+table|delete\s+from|truncate)\b/i;
 
 // Operator-supplied additional destructive patterns. Lazily compiled from
 // `GATEGUARD_BASH_EXTRA_DESTRUCTIVE` (regex source) on first use, then
@@ -352,6 +354,7 @@ function isDestructiveQuoteAware(raw, depth = 0) {
     if (tokens.length === 0) continue;
     if (isDestructiveRm(tokens)) return true;
     if (isDestructiveGit(tokens)) return true;
+    if (isDestructiveDd(tokens)) return true;
     if (isDestructiveFindExec(tokens.join(' '))) return true;
     const base = commandBasename(tokens[0]);
     if (SHELL_WRAPPERS.has(base)) {
@@ -377,6 +380,52 @@ function commandBasename(token) {
     .replace(/^.*[\\/]/, '')
     .replace(/\.exe$/i, '')
     .toLowerCase();
+}
+
+/**
+ * Detect a `dd` invocation carrying an `if=` operand.
+ *
+ * Token-based rather than a regex arm because the verdict has to depend on
+ * `dd` being the command, not on `dd if=` appearing anywhere in the line:
+ * `echo dd if=/dev/zero` executes nothing. dd operands are order-free, so
+ * `dd of=/dev/sda if=/dev/zero` counts too — a text pattern anchored on
+ * `dd\s+if=` missed that spelling entirely.
+ *
+ * Leading `sudo` / `doas` / `env`, their flags, and `VAR=value` assignment
+ * prefixes are skipped so `sudo dd if=/dev/zero` stays the dd invocation it is.
+ *
+ * @param {string[]} tokens
+ * @returns {boolean}
+ */
+function isDestructiveDd(tokens) {
+  let index = 0;
+  let sawWrapper = false;
+  while (index < tokens.length) {
+    const token = tokens[index];
+    const name = commandBasename(token);
+    if (name === 'sudo' || name === 'doas' || name === 'env') {
+      sawWrapper = true;
+      index += 1;
+      continue;
+    }
+    // `FOO=bar dd if=…` and `env FOO=bar dd if=…` both put assignments before
+    // the command word. `dd`'s own operands are never reached here: the loop
+    // stops at the first token that is neither a wrapper nor an assignment.
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) {
+      index += 1;
+      continue;
+    }
+    // Only skip flags once a wrapper has been seen, so this cannot walk past
+    // an unrelated command's arguments.
+    if (sawWrapper && token.startsWith('-')) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+
+  if (index >= tokens.length || commandBasename(tokens[index]) !== 'dd') return false;
+  return tokens.slice(index + 1).some(operand => /^if=/i.test(operand));
 }
 
 /**
@@ -677,7 +726,7 @@ function isDestructiveBash(command) {
   // inside `$(...)` or backticks are also caught.
   const raw = String(command || '');
   const flattened = explodeSubshells(stripQuotedStrings(raw));
-  if (DESTRUCTIVE_SQL_DD.test(flattened)) return true;
+  if (DESTRUCTIVE_SQL.test(flattened)) return true;
 
   // Operator-supplied additional destructive patterns. Same scope as the
   // built-in SQL/dd regex: matched against the quote-stripped, subshell-
@@ -704,7 +753,7 @@ function isDestructiveBash(command) {
   const segments = bodies.flatMap(splitCommandSegments);
   for (const segment of segments) {
     const stripped = stripQuotedStrings(segment);
-    if (DESTRUCTIVE_SQL_DD.test(stripped)) return true;
+    if (DESTRUCTIVE_SQL.test(stripped)) return true;
     if (extra && extra.test(stripped)) return true;
     const tokens = tokenize(segment);
     if (isDestructiveRm(tokens)) return true;

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -48,7 +48,11 @@ const ECC_ENABLE_VALUES = new Set(['1', 'true', 'on', 'enabled', 'enable', 'yes'
 // phrases without shell-flag ordering concerns. Quoted strings are
 // stripped before this regex runs so a commit message mentioning
 // "drop table" no longer triggers a false positive.
-const DESTRUCTIVE_SQL_DD = /\b(drop\s+table|delete\s+from|truncate|dd\s+if=)\b/i;
+// The trailing \b applies only to the arms that end in a word character.
+// `dd\s+if=` ends in `=`, so a shared \b demanded that the NEXT character be a
+// word character and the disk-wipe spellings slipped through: `dd if=/dev/zero`
+// and `dd if=./img` were allowed while `dd if=x` was denied (#2642).
+const DESTRUCTIVE_SQL_DD = /\b(?:drop\s+table|delete\s+from|truncate)\b|\bdd\s+if=/i;
 
 // Operator-supplied additional destructive patterns. Lazily compiled from
 // `GATEGUARD_BASH_EXTRA_DESTRUCTIVE` (regex source) on first use, then

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -53,7 +53,11 @@ const ECC_ENABLE_VALUES = new Set(['1', 'true', 'on', 'enabled', 'enable', 'yes'
 // phrases without shell-flag ordering concerns. Quoted strings are
 // stripped before this regex runs so a commit message mentioning
 // "drop table" no longer triggers a false positive.
-const DESTRUCTIVE_SQL_DD = /\b(drop\s+table|delete\s+from|truncate|dd\s+if=)\b/i;
+// The trailing \b applies only to the arms that end in a word character.
+// `dd\s+if=` ends in `=`, so a shared \b demanded that the NEXT character be a
+// word character and the disk-wipe spellings slipped through: `dd if=/dev/zero`
+// and `dd if=./img` were allowed while `dd if=x` was denied (#2642).
+const DESTRUCTIVE_SQL_DD = /\b(?:drop\s+table|delete\s+from|truncate)\b|\bdd\s+if=/i;
 
 // Operator-supplied additional destructive patterns. Lazily compiled from
 // `GATEGUARD_BASH_EXTRA_DESTRUCTIVE` (regex source) on first use, then

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -53,11 +53,13 @@ const ECC_ENABLE_VALUES = new Set(['1', 'true', 'on', 'enabled', 'enable', 'yes'
 // phrases without shell-flag ordering concerns. Quoted strings are
 // stripped before this regex runs so a commit message mentioning
 // "drop table" no longer triggers a false positive.
-// The trailing \b applies only to the arms that end in a word character.
-// `dd\s+if=` ends in `=`, so a shared \b demanded that the NEXT character be a
-// word character and the disk-wipe spellings slipped through: `dd if=/dev/zero`
-// and `dd if=./img` were allowed while `dd if=x` was denied (#2642).
-const DESTRUCTIVE_SQL_DD = /\b(?:drop\s+table|delete\s+from|truncate)\b|\bdd\s+if=/i;
+// `dd if=` used to be a fourth arm here. Matching it as text could not work:
+// the arm ended in `=`, so the shared trailing \b required the NEXT character
+// to be a word character and `dd if=/dev/zero` slipped through while
+// `echo dd if=x` — which runs no dd at all — was gated. The boundary decided
+// the verdict instead of the command position, so dd moved to isDestructiveDd()
+// alongside the other token-based detectors (#2642).
+const DESTRUCTIVE_SQL = /\b(drop\s+table|delete\s+from|truncate)\b/i;
 
 // Operator-supplied additional destructive patterns. Lazily compiled from
 // `GATEGUARD_BASH_EXTRA_DESTRUCTIVE` (regex source) on first use, then
@@ -357,6 +359,7 @@ function isDestructiveQuoteAware(raw, depth = 0) {
     if (tokens.length === 0) continue;
     if (isDestructiveRm(tokens)) return true;
     if (isDestructiveGit(tokens)) return true;
+    if (isDestructiveDd(tokens)) return true;
     if (isDestructiveFindExec(tokens.join(' '))) return true;
     const base = commandBasename(tokens[0]);
     if (SHELL_WRAPPERS.has(base)) {
@@ -382,6 +385,52 @@ function commandBasename(token) {
     .replace(/^.*[\\/]/, '')
     .replace(/\.exe$/i, '')
     .toLowerCase();
+}
+
+/**
+ * Detect a `dd` invocation carrying an `if=` operand.
+ *
+ * Token-based rather than a regex arm because the verdict has to depend on
+ * `dd` being the command, not on `dd if=` appearing anywhere in the line:
+ * `echo dd if=/dev/zero` executes nothing. dd operands are order-free, so
+ * `dd of=/dev/sda if=/dev/zero` counts too — a text pattern anchored on
+ * `dd\s+if=` missed that spelling entirely.
+ *
+ * Leading `sudo` / `doas` / `env`, their flags, and `VAR=value` assignment
+ * prefixes are skipped so `sudo dd if=/dev/zero` stays the dd invocation it is.
+ *
+ * @param {string[]} tokens
+ * @returns {boolean}
+ */
+function isDestructiveDd(tokens) {
+  let index = 0;
+  let sawWrapper = false;
+  while (index < tokens.length) {
+    const token = tokens[index];
+    const name = commandBasename(token);
+    if (name === 'sudo' || name === 'doas' || name === 'env') {
+      sawWrapper = true;
+      index += 1;
+      continue;
+    }
+    // `FOO=bar dd if=…` and `env FOO=bar dd if=…` both put assignments before
+    // the command word. `dd`'s own operands are never reached here: the loop
+    // stops at the first token that is neither a wrapper nor an assignment.
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) {
+      index += 1;
+      continue;
+    }
+    // Only skip flags once a wrapper has been seen, so this cannot walk past
+    // an unrelated command's arguments.
+    if (sawWrapper && token.startsWith('-')) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+
+  if (index >= tokens.length || commandBasename(tokens[index]) !== 'dd') return false;
+  return tokens.slice(index + 1).some(operand => /^if=/i.test(operand));
 }
 
 /**
@@ -681,9 +730,11 @@ function isDestructiveBash(command) {
   // after quoting AND subshell delimiters are normalized so phrases
   // inside `$(...)` or backticks are also caught.
   const raw = String(command || '');
+  // Keep main's heredoc stripping: a phrase inside a heredoc body is data, not a
+  // command. dd is no longer part of this regex — see DESTRUCTIVE_SQL.
   const executable = stripHeredocBodies(raw);
   const flattened = explodeSubshells(stripQuotedStrings(executable));
-  if (DESTRUCTIVE_SQL_DD.test(flattened)) return true;
+  if (DESTRUCTIVE_SQL.test(flattened)) return true;
 
   // Operator-supplied additional destructive patterns. Same scope as the
   // built-in SQL/dd regex: matched against the quote-stripped, subshell-
@@ -710,7 +761,7 @@ function isDestructiveBash(command) {
   const segments = bodies.flatMap(splitCommandSegments);
   for (const segment of segments) {
     const stripped = stripQuotedStrings(segment);
-    if (DESTRUCTIVE_SQL_DD.test(stripped)) return true;
+    if (DESTRUCTIVE_SQL.test(stripped)) return true;
     if (extra && extra.test(stripped)) return true;
     const tokens = tokenize(segment);
     if (isDestructiveRm(tokens)) return true;

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -268,8 +268,10 @@ function runTests() {
     'dd if="/dev/zero" of=/dev/sda',
     // Wrapped invocations must still resolve to the dd command word.
     'sudo dd if=/dev/zero of=/dev/sda',
-    // dd operands are order-free; a text pattern anchored on `dd if=` missed this.
-    'dd of=/dev/sda if=/dev/zero'
+    // dd operands are order-free; a text pattern anchored on `dd if=` missed
+    // both the reversed and the intervening-option spellings.
+    'dd of=/dev/sda if=/dev/zero',
+    'dd bs=1M if=/dev/zero of=/dev/sda'
   ]) {
     clearState();
     if (

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -253,6 +253,67 @@ function runTests() {
     passed++;
   else failed++;
 
+  // --- Test 4b: dd targets that do not start with a word character ---
+  /**
+   * #2642: DESTRUCTIVE_SQL_DD carried one trailing \b across every alternation
+   * arm. `dd\s+if=` ends in `=`, so that \b demanded the NEXT character be a
+   * word character: `dd if=x` was denied while the disk-wipe spelling
+   * `dd if=/dev/zero of=/dev/sda` and the relative `dd if=./img` were allowed.
+   * These run through the real hook, since the report is specifically that the
+   * published hook lets the slash-prefixed form through.
+   */
+  for (const command of [
+    'dd if=/dev/zero of=/dev/sda',
+    'dd if=./disk.img of=/dev/sdb',
+    'dd if="/dev/zero" of=/dev/sda'
+  ]) {
+    clearState();
+    if (
+      test(`denies dd whose input path is not word-initial: ${command}`, () => {
+        const result = runBashHook({ tool_name: 'Bash', tool_input: { command } });
+        const output = parseOutput(result.stdout);
+        assert.ok(output, 'hook should produce JSON output');
+        assert.ok(output.hookSpecificOutput, 'hook should return a permission decision');
+        assert.strictEqual(
+          output.hookSpecificOutput.permissionDecision,
+          'deny',
+          `${command} must be gated as destructive`
+        );
+        assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('Destructive'));
+      })
+    )
+      passed++;
+    else failed++;
+  }
+
+  // --- Test 4c: widening the dd arm must not gate ordinary commands ---
+  /**
+   * The fix drops the trailing \b only from the dd arm, so the arms that end in
+   * a word character keep theirs. Without that split, `truncated` would match
+   * `truncate`, and `add if=` would match `dd if=`.
+   */
+  for (const command of ['echo add if=1', 'echo truncated output', 'git status']) {
+    clearState();
+    if (
+      test(`does not gate as destructive: ${command}`, () => {
+        // Prime the session so the separate first-command routine gate cannot
+        // be mistaken for a destructive denial.
+        runBashHook({ tool_name: 'Bash', tool_input: { command: 'printf ready' } });
+        const result = runBashHook({ tool_name: 'Bash', tool_input: { command } });
+        const output = parseOutput(result.stdout);
+        if (output && output.hookSpecificOutput) {
+          const reason = output.hookSpecificOutput.permissionDecisionReason || '';
+          assert.ok(
+            output.hookSpecificOutput.permissionDecision !== 'deny' || !reason.includes('Destructive'),
+            `${command} must not be gated as destructive`
+          );
+        }
+      })
+    )
+      passed++;
+    else failed++;
+  }
+
   // --- Test 5: denies first routine Bash, allows second ---
   clearState();
   if (

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -313,13 +313,22 @@ function runTests() {
         // be mistaken for a destructive denial.
         runBashHook({ tool_name: 'Bash', tool_input: { command: 'printf ready' } });
         const result = runBashHook({ tool_name: 'Bash', tool_input: { command } });
+        // Assert the hook actually answered before reading the decision: a
+        // crashed or silent hook makes parseOutput return null, and a bare
+        // `if (output)` would let this case pass without testing anything.
+        assert.strictEqual(result.code, 0, `hook should exit 0 for ${command}`);
         const output = parseOutput(result.stdout);
-        if (output && output.hookSpecificOutput) {
-          const reason = output.hookSpecificOutput.permissionDecisionReason || '';
+        assert.ok(output, `hook should produce JSON output for ${command}`);
+        const decision = output.hookSpecificOutput;
+        if (decision) {
+          const reason = decision.permissionDecisionReason || '';
           assert.ok(
-            output.hookSpecificOutput.permissionDecision !== 'deny' || !reason.includes('Destructive'),
+            decision.permissionDecision !== 'deny' || !reason.includes('Destructive'),
             `${command} must not be gated as destructive`
           );
+        } else {
+          // Pass-through echoes the input back unchanged.
+          assert.strictEqual(output.tool_name, 'Bash', 'pass-through should preserve input');
         }
       })
     )

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -265,7 +265,11 @@ function runTests() {
   for (const command of [
     'dd if=/dev/zero of=/dev/sda',
     'dd if=./disk.img of=/dev/sdb',
-    'dd if="/dev/zero" of=/dev/sda'
+    'dd if="/dev/zero" of=/dev/sda',
+    // Wrapped invocations must still resolve to the dd command word.
+    'sudo dd if=/dev/zero of=/dev/sda',
+    // dd operands are order-free; a text pattern anchored on `dd if=` missed this.
+    'dd of=/dev/sda if=/dev/zero'
   ]) {
     clearState();
     if (
@@ -292,7 +296,16 @@ function runTests() {
    * a word character keep theirs. Without that split, `truncated` would match
    * `truncate`, and `add if=` would match `dd if=`.
    */
-  for (const command of ['echo add if=1', 'echo truncated output', 'git status']) {
+  for (const command of [
+    'echo add if=1',
+    'echo truncated output',
+    'git status',
+    // `dd if=` as another command's argument runs no dd at all. The old text
+    // match gated these; the command-word check is what keeps them out.
+    'echo dd if=/dev/zero',
+    'grep dd if=/dev/zero file',
+    'echo dd if=x'
+  ]) {
     clearState();
     if (
       test(`does not gate as destructive: ${command}`, () => {

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -267,7 +267,11 @@ function runTests() {
   for (const command of [
     'dd if=/dev/zero of=/dev/sda',
     'dd if=./disk.img of=/dev/sdb',
-    'dd if="/dev/zero" of=/dev/sda'
+    'dd if="/dev/zero" of=/dev/sda',
+    // Wrapped invocations must still resolve to the dd command word.
+    'sudo dd if=/dev/zero of=/dev/sda',
+    // dd operands are order-free; a text pattern anchored on `dd if=` missed this.
+    'dd of=/dev/sda if=/dev/zero'
   ]) {
     clearState();
     if (
@@ -294,7 +298,16 @@ function runTests() {
    * a word character keep theirs. Without that split, `truncated` would match
    * `truncate`, and `add if=` would match `dd if=`.
    */
-  for (const command of ['echo add if=1', 'echo truncated output', 'git status']) {
+  for (const command of [
+    'echo add if=1',
+    'echo truncated output',
+    'git status',
+    // `dd if=` as another command's argument runs no dd at all. The old text
+    // match gated these; the command-word check is what keeps them out.
+    'echo dd if=/dev/zero',
+    'grep dd if=/dev/zero file',
+    'echo dd if=x'
+  ]) {
     clearState();
     if (
       test(`does not gate as destructive: ${command}`, () => {

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -255,6 +255,67 @@ function runTests() {
     passed++;
   else failed++;
 
+  // --- Test 4b: dd targets that do not start with a word character ---
+  /**
+   * #2642: DESTRUCTIVE_SQL_DD carried one trailing \b across every alternation
+   * arm. `dd\s+if=` ends in `=`, so that \b demanded the NEXT character be a
+   * word character: `dd if=x` was denied while the disk-wipe spelling
+   * `dd if=/dev/zero of=/dev/sda` and the relative `dd if=./img` were allowed.
+   * These run through the real hook, since the report is specifically that the
+   * published hook lets the slash-prefixed form through.
+   */
+  for (const command of [
+    'dd if=/dev/zero of=/dev/sda',
+    'dd if=./disk.img of=/dev/sdb',
+    'dd if="/dev/zero" of=/dev/sda'
+  ]) {
+    clearState();
+    if (
+      test(`denies dd whose input path is not word-initial: ${command}`, () => {
+        const result = runBashHook({ tool_name: 'Bash', tool_input: { command } });
+        const output = parseOutput(result.stdout);
+        assert.ok(output, 'hook should produce JSON output');
+        assert.ok(output.hookSpecificOutput, 'hook should return a permission decision');
+        assert.strictEqual(
+          output.hookSpecificOutput.permissionDecision,
+          'deny',
+          `${command} must be gated as destructive`
+        );
+        assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('Destructive'));
+      })
+    )
+      passed++;
+    else failed++;
+  }
+
+  // --- Test 4c: widening the dd arm must not gate ordinary commands ---
+  /**
+   * The fix drops the trailing \b only from the dd arm, so the arms that end in
+   * a word character keep theirs. Without that split, `truncated` would match
+   * `truncate`, and `add if=` would match `dd if=`.
+   */
+  for (const command of ['echo add if=1', 'echo truncated output', 'git status']) {
+    clearState();
+    if (
+      test(`does not gate as destructive: ${command}`, () => {
+        // Prime the session so the separate first-command routine gate cannot
+        // be mistaken for a destructive denial.
+        runBashHook({ tool_name: 'Bash', tool_input: { command: 'printf ready' } });
+        const result = runBashHook({ tool_name: 'Bash', tool_input: { command } });
+        const output = parseOutput(result.stdout);
+        if (output && output.hookSpecificOutput) {
+          const reason = output.hookSpecificOutput.permissionDecisionReason || '';
+          assert.ok(
+            output.hookSpecificOutput.permissionDecision !== 'deny' || !reason.includes('Destructive'),
+            `${command} must not be gated as destructive`
+          );
+        }
+      })
+    )
+      passed++;
+    else failed++;
+  }
+
   // --- Test 5: denies first routine Bash, allows second ---
   clearState();
   if (

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -315,13 +315,22 @@ function runTests() {
         // be mistaken for a destructive denial.
         runBashHook({ tool_name: 'Bash', tool_input: { command: 'printf ready' } });
         const result = runBashHook({ tool_name: 'Bash', tool_input: { command } });
+        // Assert the hook actually answered before reading the decision: a
+        // crashed or silent hook makes parseOutput return null, and a bare
+        // `if (output)` would let this case pass without testing anything.
+        assert.strictEqual(result.code, 0, `hook should exit 0 for ${command}`);
         const output = parseOutput(result.stdout);
-        if (output && output.hookSpecificOutput) {
-          const reason = output.hookSpecificOutput.permissionDecisionReason || '';
+        assert.ok(output, `hook should produce JSON output for ${command}`);
+        const decision = output.hookSpecificOutput;
+        if (decision) {
+          const reason = decision.permissionDecisionReason || '';
           assert.ok(
-            output.hookSpecificOutput.permissionDecision !== 'deny' || !reason.includes('Destructive'),
+            decision.permissionDecision !== 'deny' || !reason.includes('Destructive'),
             `${command} must not be gated as destructive`
           );
+        } else {
+          // Pass-through echoes the input back unchanged.
+          assert.strictEqual(output.tool_name, 'Bash', 'pass-through should preserve input');
         }
       })
     )

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -270,8 +270,10 @@ function runTests() {
     'dd if="/dev/zero" of=/dev/sda',
     // Wrapped invocations must still resolve to the dd command word.
     'sudo dd if=/dev/zero of=/dev/sda',
-    // dd operands are order-free; a text pattern anchored on `dd if=` missed this.
-    'dd of=/dev/sda if=/dev/zero'
+    // dd operands are order-free; a text pattern anchored on `dd if=` missed
+    // both the reversed and the intervening-option spellings.
+    'dd of=/dev/sda if=/dev/zero',
+    'dd bs=1M if=/dev/zero of=/dev/sda'
   ]) {
     clearState();
     if (


### PR DESCRIPTION
## What Changed

`DESTRUCTIVE_SQL_DD` shared one trailing `\b` across every alternation arm:

```js
const DESTRUCTIVE_SQL_DD = /\b(drop\s+table|delete\s+from|truncate|dd\s+if=)\b/i;
```

`dd\s+if=` ends in `=`. A `\b` after a non-word character only holds when the **next** character is a word character, so the arm matched `dd if=x` and missed every path that starts with `/`, `.` or a quote. The word-boundary suffix now applies only to the arms that end in a word character:

```js
const DESTRUCTIVE_SQL_DD = /\b(?:drop\s+table|delete\s+from|truncate)\b|\bdd\s+if=/i;
```

This is the half of #2642 that @haelyra found still open on v2.1.0: the structural `findGitSubcommand()` parser already handles `git checkout -- .`, but the `dd` arm was untouched.

## Why This Change

Reproduced against current `main` (`d8409a4b`) — the classic disk-wipe spelling is allowed:

| command | before | after |
| --- | --- | --- |
| `dd if=/dev/zero of=/dev/sda` | **allowed** | denied |
| `dd if=./disk.img of=/dev/sdb` | **allowed** | denied |
| `dd if="/dev/zero" of=/dev/sda` | **allowed** | denied |
| `dd if=x` | denied | denied |
| `truncate table t` / `drop table users` / `delete from t` | denied | denied |
| `echo add if=1` | allowed | allowed |
| `echo truncated output` | allowed | allowed |

The change strictly widens the gate, and the split is what keeps the widening bounded: dropping the trailing `\b` outright would let `truncate` match `truncated`, and dropping the leading `\b` would let `dd if=` match inside `add if=`. Both spellings are in the tests.

## Testing Done

- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`) — **see the note below; I could not complete this runner here and did not want to tick it**
- [x] Edge cases considered and tested

`tests/hooks/gateguard-fact-force.test.js` — 6 new cases, driven end-to-end through `run-with-flags.js` rather than against the regex, because the report is specifically that *the published hook* lets the slash-prefixed form through.

Reverting only `scripts/hooks/gateguard-fact-force.js` and keeping the tests:

```
✗ denies dd whose input path is not word-initial: dd if=/dev/zero of=/dev/sda
✗ denies dd whose input path is not word-initial: dd if=./disk.img of=/dev/sdb
✗ denies dd whose input path is not word-initial: dd if="/dev/zero" of=/dev/sda
✓ does not gate as destructive: echo add if=1
✓ does not gate as destructive: echo truncated output
✓ does not gate as destructive: git status
147 passed, 3 failed
```

With the fix: **150 passed, 0 failed**. The three "does not gate" cases pass either way by design — they guard against over-widening, they are not evidence of the bug.

Also checked by hand: `sudo dd if=/dev/zero` denied; `ddrescue if=…` and `xdd if=…` correctly not matched; `dd  if=` (double space) and `DD IF=` denied.

**Why `run-all.js` is unchecked:** it stops in my environment at `tests/lib/claude-plugin-setup.test.js`, which performs real marketplace `git clone`s — they fail here with `fatal: fetch-pack: invalid index-pack output`. That is environmental and unrelated to this change. `tests/hooks/gateguard-fact-force.test.js` is the only test file in the repo that references gateguard (`grep -rl gateguard tests/`), so the suite I did run covers this change's blast radius. Happy to post the full runner output if someone can point me at a way around the clone step.

## Type of Change

- [x] `fix:` Bug fix

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly (no JSON touched)
- [x] Shell scripts pass shellcheck (no shell scripts touched)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## One gap this does NOT close

`dd of=/dev/sda if=/dev/zero` — operands reversed — is still allowed, before and after this change, because the pattern requires `if=` immediately after `dd`. That is a separate defect from the `\b` reported here, and I did not want to widen a P0 gate's regex beyond the reported failure without a maintainer's call: something like `\bdd(?:\s+[a-z]+=\S*)*\s+if=` would cover it, but it changes the shape of the pattern rather than just its boundary handling, and a gate that blocks users' commands is the wrong place for me to guess. Say the word and I will add it here with its own cases, or file it separately.

---

*Written with Claude Code. The tables and test counts above are measured on `main` at `d8409a4b`, not estimated.*
