### PR TITLE
fix(rules): stop prescribing JS casing for every language in common/

### DIFF
--- a/rules/common/coding-style.md
+++ b/rules/common/coding-style.md
@@ -59,18 +59,15 @@ ALWAYS validate at system boundaries:
 ## Naming Conventions
 
 > **Language note**: This rule may be overridden by language-specific rules for
-> languages where this pattern is not idiomatic. Casing in particular belongs to
-> the language file — e.g. PEP 8 for Python, `snake_case` for Rust, `camelCase`
-> for Java and Kotlin. React hook naming lives in
-> [react/coding-style.md](../react/coding-style.md).
+> languages where a pattern is not idiomatic. Casing and framework-specific
+> prefixes belong to the applicable language or package rule.
 
 Language-independent:
 
 - Descriptive names: the name says what the thing holds or does, without a comment.
 - Booleans read as a claim: prefix with `is`, `has`, `should` or `can`.
 - Where the language draws the distinction, constants and types are visually
-  distinct from ordinary values (`UPPER_SNAKE_CASE` and `PascalCase` in many
-  languages) — whether it draws it at all is for the language file to say.
+  distinct from ordinary values in the form its language or package rule defines.
 
 ## Code Smells to Avoid
 

--- a/rules/common/coding-style.md
+++ b/rules/common/coding-style.md
@@ -65,7 +65,8 @@ ALWAYS validate at system boundaries:
 Language-independent:
 
 - Descriptive names: the name says what the thing holds or does, without a comment.
-- Booleans read as a claim: prefix with `is`, `has`, `should` or `can`.
+- Boolean names read clearly as claims under the applicable language or package
+  convention.
 - Where the language draws the distinction, constants and types are visually
   distinct from ordinary values in the form its language or package rule defines.
 

--- a/rules/common/coding-style.md
+++ b/rules/common/coding-style.md
@@ -58,11 +58,19 @@ ALWAYS validate at system boundaries:
 
 ## Naming Conventions
 
-- Variables and functions: `camelCase` with descriptive names
-- Booleans: prefer `is`, `has`, `should`, or `can` prefixes
-- Interfaces, types, and components: `PascalCase`
-- Constants: `UPPER_SNAKE_CASE`
-- Custom hooks: `camelCase` with a `use` prefix
+> **Language note**: This rule may be overridden by language-specific rules for
+> languages where this pattern is not idiomatic. Casing in particular belongs to
+> the language file — e.g. PEP 8 for Python, `snake_case` for Rust, `camelCase`
+> for Java and Kotlin. React hook naming lives in
+> [react/coding-style.md](../react/coding-style.md).
+
+Language-independent:
+
+- Descriptive names: the name says what the thing holds or does, without a comment.
+- Booleans read as a claim: prefix with `is`, `has`, `should` or `can`.
+- Where the language draws the distinction, constants and types are visually
+  distinct from ordinary values (`UPPER_SNAKE_CASE` and `PascalCase` in many
+  languages) — whether it draws it at all is for the language file to say.
 
 ## Code Smells to Avoid
 


### PR DESCRIPTION
Closes #2830.

## Problem

`rules/common/coding-style.md` has no `paths:` frontmatter, so it is loaded for every source file regardless of language. Its Naming Conventions section nevertheless prescribed JavaScript/TypeScript casing:

```markdown
- Variables and functions: `camelCase` with descriptive names
...
- Custom hooks: `camelCase` with a `use` prefix
```

That is not idiomatic for several languages this package supports, and the language files say the opposite:

- `rules/python/coding-style.md` — "Follow **PEP 8** conventions" (`snake_case`)
- `rules/rust/coding-style.md` — "`snake_case` for functions, methods, variables, modules, crates"

Both carry `paths:` frontmatter, so for a `.py` or `.rs` file the agent is handed both files and two opposite naming rules in the same context.

`rules/README.md` does state that language-specific rules take precedence, so the precedence *is* defined — but it is defined in the README, not in the rule files the agent actually receives at inference time. From the model's point of view the two rules arrive side by side with nothing marking one as the override.

The "Custom hooks" line is also misplaced regardless of casing: it is a React concept in the language-agnostic file.

## Change

- The casing list is replaced by the canonical `> **Language note**:` marker documented in `rules/README.md`, which is the mechanism this package already prescribes for exactly this situation.
- `common/` keeps only what is genuinely language-independent: descriptive names, boolean prefixes, and constants and types being visually distinct from ordinary values — the last one qualified, since not every language draws that distinction.
- The per-language examples name only languages whose own `coding-style.md` actually states a casing standard: PEP 8 for Python, `snake_case` for Rust, `camelCase` for Java and Kotlin. (Python states the standard rather than the casing itself, hence the wording.)
- The "Custom hooks" line is dropped and linked to `react/coding-style.md`, which documents it as the `useCamelCase` symbol rule and again as the `eslint-plugin-react-hooks` enforcement note.

One file changed, +13 / −5.

## Two things worth your judgement

**1. React hook rule loses some path coverage.** `rules/react/coding-style.md` is scoped to `**/*.tsx`, `**/*.jsx`, `**/components/**/*.{ts,js}` and `**/hooks/**/*.{ts,js}`. A hook colocated outside those paths — say `src/features/foo/useFoo.ts` — previously picked up the rule from the always-loaded `common/` file and now matches neither React path. Removing a React rule from the language-agnostic file seems right to me either way, but the clean fix may be to widen the React `paths:` rather than to keep the line in `common/`. Happy to follow whichever you prefer.

**2. JavaScript/TypeScript has no naming section at all.** `rules/typescript/coding-style.md` covers types, immutability, error handling, input validation and console.log, but never states a casing rule — so after this change, generic JS/TS variable and function casing is not written down anywhere in the package. This PR deliberately does not add one, since inventing a rule for a language the maintainers have not documented felt out of scope. Say the word and I will add a `## Naming` section there in this same PR.