### PR TITLE
fix(gateguard): look past sudo/doas/env when classifying destructive commands

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -333,9 +333,11 @@ function quoteAwareSegments(input) {
 
 const SHELL_WRAPPERS = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh']);
 
-// Short shell options that take a value. Reaching one inside a cluster means
-// the rest of the token is that value, so a `c` behind it is not `-c`.
+// Shell options that take a value. A `c` behind one of these inside the same
+// token is that value, not `-c` — but the option only swallows one value, so
+// the scan has to resume after it rather than give up.
 const SHELL_SHORT_OPTIONS_WITH_VALUE = new Set(['o', 'O']);
+const SHELL_LONG_OPTIONS_WITH_VALUE = new Set(['--rcfile', '--init-file']);
 
 /**
  * Return the command string a shell would run for `-c`, or null.
@@ -346,9 +348,12 @@ const SHELL_SHORT_OPTIONS_WITH_VALUE = new Set(['o', 'O']);
  * what `sh -c '<cmd>'` runs. Matching only a bare `-c` token left every
  * clustered spelling unclassified.
  *
- * `-o`/`-O` take a value, so `c` behind one of them is that value rather
- * than a flag; the shell rejects those forms instead of running the payload
- * (`sh -oc 'cmd'` → "invalid option name"), so stopping there loses nothing.
+ * `-o`/`-O` and `--rcfile`/`--init-file` take a value. That only rules out a
+ * `c` sitting inside the same token as its value (`sh -oc 'cmd'`, which the
+ * shell rejects with "invalid option name" rather than running it) — the
+ * option consumes exactly one value, so the scan skips it and keeps looking.
+ * `sh -o errexit -c '<cmd>'` and `bash --init-file /dev/null -c '<cmd>'` both
+ * run the payload.
  *
  * @param {string[]} tokens command words, wrappers already stripped
  * @returns {string|null}
@@ -362,15 +367,35 @@ function shellDashCPayload(tokens) {
     // `--` ends the options, and a bare operand is the script name — after
     // either one there is no `-c` left to find.
     if (token === '--' || token === '-' || !token.startsWith('-')) return null;
-    if (token.startsWith('--')) continue;
-
-    for (const flag of token.slice(1)) {
-      if (flag === 'c') {
-        const payload = tokens[i + 1];
-        return typeof payload === 'string' ? payload : null;
-      }
-      if (SHELL_SHORT_OPTIONS_WITH_VALUE.has(flag)) return null;
+    if (token.startsWith('--')) {
+      // `--rcfile FILE` holds its value in the next token; `--rcfile=FILE`
+      // holds it in this one and needs no skip.
+      if (SHELL_LONG_OPTIONS_WITH_VALUE.has(token)) i += 1;
+      continue;
     }
+
+    const body = token.slice(1);
+    let consumesNextToken = false;
+    let carriesCommand = false;
+    for (let j = 0; j < body.length; j++) {
+      const flag = body[j];
+      if (flag === 'c') {
+        carriesCommand = true;
+        break;
+      }
+      if (SHELL_SHORT_OPTIONS_WITH_VALUE.has(flag)) {
+        // Its value is the rest of this token, or the next token when the
+        // option ends the cluster. Either way there is no `-c` in here.
+        consumesNextToken = j === body.length - 1;
+        break;
+      }
+    }
+
+    if (carriesCommand) {
+      const payload = tokens[i + 1];
+      return typeof payload === 'string' ? payload : null;
+    }
+    if (consumesNextToken) i += 1;
   }
   return null;
 }
@@ -455,9 +480,6 @@ const COMMAND_WRAPPERS = new Map([
   ],
 ]);
 
-// Bound `env -S` expansion so a self-referential split string cannot spin.
-const MAX_WRAPPER_EXPANSIONS = 8;
-
 // `env`'s short options that take an argument. Needed to read a cluster the way
 // getopt does: in `-uS` the `S` is `-u`'s value, not a split-string flag.
 const ENV_SHORT_OPTIONS_WITH_VALUE = new Set(['u', 'C']);
@@ -527,6 +549,15 @@ function stripCommandWrappers(tokens) {
   let valueFlags = null;
   let wrapper = null;
   let expansions = 0;
+  // Every expansion replaces `-S<string>` with the words of that string, which
+  // is a strict substring of the token it came from, so the character count of
+  // what is left strictly decreases and the walk terminates on its own.
+  // Bounding the loop by that count keeps the guarantee without the bound
+  // being reachable. A fixed cap was reachable: past it the split string went
+  // back to being an opaque option value, so the command it runs was hidden
+  // again — `env -Senv -Senv ... -S "rm -rf /x"` is a valid spelling of that
+  // and executes, and it flipped from denied to allowed at exactly the cap.
+  const maxExpansions = tokens.reduce((total, token) => total + String(token).length, 0);
   while (index < rest.length) {
     const token = rest[index];
     const base = commandBasename(token);
@@ -547,14 +578,16 @@ function stripCommandWrappers(tokens) {
       // `env -S "rm -rf /"` RUNS that string. Consuming it as an opaque option
       // value hid the whole command behind the option, so expand it and keep
       // walking. Bounded so a self-referential string cannot spin.
-      if (wrapper === 'env' && expansions < MAX_WRAPPER_EXPANSIONS) {
+      if (wrapper === 'env') {
         const split = envSplitString(token, rest[index + 1]);
         if (split) {
           // Quote-aware, because the split string carries its own quoting:
           // `env -S '"rm" -rf /'` must yield `rm`, not `"rm"`, or the command
           // word never matches. Falls back to a plain split if parsing fails.
           const words = tokenizeAllowlistedShellWords(split.value) || tokenize(split.value);
-          rest = words.concat(rest.slice(index + split.consumed));
+          const expanded = words.concat(rest.slice(index + split.consumed));
+          if (expansions >= maxExpansions) return expanded;
+          rest = expanded;
           index = 0;
           valueFlags = null;
           wrapper = null;

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -418,6 +418,43 @@ const COMMAND_WRAPPERS = new Map([
   ],
 ]);
 
+// Bound `env -S` expansion so a self-referential split string cannot spin.
+const MAX_WRAPPER_EXPANSIONS = 8;
+
+/**
+ * `env -S "<command>"`, `env --split-string=<command>`, and the attached
+ * `-S<command>` form all RUN the string. Return it so the caller can expand it
+ * into tokens instead of consuming it as an opaque option value.
+ *
+ * @param {string} token
+ * @param {string | undefined} next
+ * @returns {{ value: string, consumed: number } | null}
+ */
+function envSplitString(token, next) {
+  if (token === '-S' || token === '--split-string') {
+    return typeof next === 'string' ? { value: next, consumed: 2 } : null;
+  }
+  if (token.startsWith('--split-string=')) {
+    return { value: token.slice('--split-string='.length), consumed: 1 };
+  }
+  if (token.startsWith('-S') && token.length > 2) {
+    return { value: token.slice(2), consumed: 1 };
+  }
+  return null;
+}
+
+/**
+ * `command -v` / `-V`, including combined forms like `-pv`, only report where a
+ * name resolves — the operand never runs. Every other `command` option still
+ * executes its operand, so `-p` alone is not a lookup.
+ *
+ * @param {string} token
+ * @returns {boolean}
+ */
+function isCommandLookupOnly(token) {
+  return /^-[pvV]*[vV][pvV]*$/.test(token);
+}
+
 /**
  * Return `tokens` with any leading wrapper commands, their options, and
  * `VAR=value` assignment prefixes removed, so the caller sees the command that
@@ -433,13 +470,18 @@ const COMMAND_WRAPPERS = new Map([
  */
 function stripCommandWrappers(tokens) {
   if (!Array.isArray(tokens) || tokens.length === 0) return tokens;
+  let rest = tokens;
   let index = 0;
   let valueFlags = null;
-  while (index < tokens.length) {
-    const token = tokens[index];
-    const wrapperFlags = COMMAND_WRAPPERS.get(commandBasename(token));
+  let wrapper = null;
+  let expansions = 0;
+  while (index < rest.length) {
+    const token = rest[index];
+    const base = commandBasename(token);
+    const wrapperFlags = COMMAND_WRAPPERS.get(base);
     if (wrapperFlags) {
       valueFlags = wrapperFlags;
+      wrapper = base;
       index += 1;
       continue;
     }
@@ -450,13 +492,32 @@ function stripCommandWrappers(tokens) {
       continue;
     }
     if (valueFlags && token.startsWith('-')) {
+      // `env -S "rm -rf /"` RUNS that string. Consuming it as an opaque option
+      // value hid the whole command behind the option, so expand it and keep
+      // walking. Bounded so a self-referential string cannot spin.
+      if (wrapper === 'env' && expansions < MAX_WRAPPER_EXPANSIONS) {
+        const split = envSplitString(token, rest[index + 1]);
+        if (split) {
+          rest = tokenize(split.value).concat(rest.slice(index + split.consumed));
+          index = 0;
+          valueFlags = null;
+          wrapper = null;
+          expansions += 1;
+          continue;
+        }
+      }
+      // `command -v git reset --hard` only reports where `git` resolves —
+      // nothing runs, so there is no command to classify. Returning the operand
+      // here denied a lookup.
+      if (wrapper === 'command' && isCommandLookupOnly(token)) return [];
       if (valueFlags.has(token)) index += 1;
       index += 1;
       continue;
     }
     break;
   }
-  return index === 0 ? tokens : tokens.slice(index);
+  if (rest === tokens) return index === 0 ? tokens : tokens.slice(index);
+  return rest.slice(index);
 }
 
 /**

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -333,6 +333,48 @@ function quoteAwareSegments(input) {
 
 const SHELL_WRAPPERS = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh']);
 
+// Short shell options that take a value. Reaching one inside a cluster means
+// the rest of the token is that value, so a `c` behind it is not `-c`.
+const SHELL_SHORT_OPTIONS_WITH_VALUE = new Set(['o', 'O']);
+
+/**
+ * Return the command string a shell would run for `-c`, or null.
+ *
+ * `-c` reads its payload from the FOLLOWING argument (`sh -c'cmd'` is an
+ * invalid option, not an attached value), and short options cluster — so
+ * `sh -ec '<cmd>'`, `sh -xc '<cmd>'`, and `sh -ce '<cmd>'` all run exactly
+ * what `sh -c '<cmd>'` runs. Matching only a bare `-c` token left every
+ * clustered spelling unclassified.
+ *
+ * `-o`/`-O` take a value, so `c` behind one of them is that value rather
+ * than a flag; the shell rejects those forms instead of running the payload
+ * (`sh -oc 'cmd'` → "invalid option name"), so stopping there loses nothing.
+ *
+ * @param {string[]} tokens command words, wrappers already stripped
+ * @returns {string|null}
+ */
+function shellDashCPayload(tokens) {
+  if (tokens.length === 0) return null;
+  if (!SHELL_WRAPPERS.has(commandBasename(tokens[0]))) return null;
+
+  for (let i = 1; i < tokens.length; i++) {
+    const token = tokens[i];
+    // `--` ends the options, and a bare operand is the script name — after
+    // either one there is no `-c` left to find.
+    if (token === '--' || token === '-' || !token.startsWith('-')) return null;
+    if (token.startsWith('--')) continue;
+
+    for (const flag of token.slice(1)) {
+      if (flag === 'c') {
+        const payload = tokens[i + 1];
+        return typeof payload === 'string' ? payload : null;
+      }
+      if (SHELL_SHORT_OPTIONS_WITH_VALUE.has(flag)) return null;
+    }
+  }
+  return null;
+}
+
 /**
  * Quote-aware destructive check: catches quoted command words, newline
  * separators, quoted `find -exec`, and `sh -c`/`bash -c` wrappers that evade
@@ -352,14 +394,9 @@ function isDestructiveQuoteAware(raw, depth = 0) {
     if (tokens.length === 0) continue;
     if (isDestructiveRm(tokens)) return true;
     if (isDestructiveGit(tokens)) return true;
-    if (isDestructiveFindExec(tokens.join(' '))) return true;
-    const base = commandBasename(tokens[0]);
-    if (SHELL_WRAPPERS.has(base)) {
-      const ci = tokens.indexOf('-c');
-      if (ci !== -1 && tokens[ci + 1] && isDestructiveQuoteAware(tokens[ci + 1], depth + 1)) {
-        return true;
-      }
-    }
+    if (isDestructiveFindExecTokens(tokens, depth)) return true;
+    const payload = shellDashCPayload(tokens);
+    if (payload && isDestructiveQuoteAware(payload, depth + 1)) return true;
   }
   return false;
 }
@@ -767,17 +804,33 @@ function collectExecutableBodies(raw) {
  * `-exec unlink {} \;`, `-exec git reset --hard {} \;`.
  *
  * @param {string} command
+ * @param {number} [depth] recursion guard shared with isDestructiveQuoteAware
  * @returns {boolean}
  */
-function isDestructiveFindExec(command) {
+function isDestructiveFindExec(command, depth = 0) {
   const raw = String(command || '');
   const trimmed = raw.trim();
   if (!trimmed) {
     return false;
   }
 
-  // Tokenize the whole command line
-  const tokens = stripCommandWrappers(tokenize(trimmed));
+  return isDestructiveFindExecTokens(tokenize(trimmed), depth);
+}
+
+/**
+ * Token-taking half of `isDestructiveFindExec`.
+ *
+ * The quote-aware pass already holds correctly split tokens. Joining them
+ * back into one string so this check could re-tokenize it flattened a quoted
+ * `-exec sh -c '<cmd>'` payload into separate words, which is precisely the
+ * command that needed classifying.
+ *
+ * @param {string[]} rawTokens
+ * @param {number} [depth] recursion guard shared with isDestructiveQuoteAware
+ * @returns {boolean}
+ */
+function isDestructiveFindExecTokens(rawTokens, depth = 0) {
+  const tokens = stripCommandWrappers(rawTokens);
   if (!tokens || tokens.length === 0) {
     return false;
   }
@@ -812,6 +865,15 @@ function isDestructiveFindExec(command) {
   const execCommand = stripCommandWrappers(execTokens);
   if (execCommand.length === 0) {
     return false;
+  }
+
+  // `-exec sh -c '<cmd>' \;` runs <cmd> just as a bare `sh -c '<cmd>'` does.
+  // Classifying only the `sh` executable stopped at the wrapper, so the
+  // deletion inside it was never seen — the quote-aware pass already looks
+  // through the same wrapper, and this is the sibling that did not.
+  const execPayload = shellDashCPayload(execCommand);
+  if (execPayload) {
+    return isDestructiveQuoteAware(execPayload, depth + 1);
   }
 
   const baseCmd = commandBasename(execCommand[0]);

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -421,6 +421,10 @@ const COMMAND_WRAPPERS = new Map([
 // Bound `env -S` expansion so a self-referential split string cannot spin.
 const MAX_WRAPPER_EXPANSIONS = 8;
 
+// `env`'s short options that take an argument. Needed to read a cluster the way
+// getopt does: in `-uS` the `S` is `-u`'s value, not a split-string flag.
+const ENV_SHORT_OPTIONS_WITH_VALUE = new Set(['u', 'C']);
+
 /**
  * `env -S "<command>"`, `env --split-string=<command>`, and the attached
  * `-S<command>` form all RUN the string. Return it so the caller can expand it
@@ -431,14 +435,25 @@ const MAX_WRAPPER_EXPANSIONS = 8;
  * @returns {{ value: string, consumed: number } | null}
  */
 function envSplitString(token, next) {
-  if (token === '-S' || token === '--split-string') {
+  if (token === '--split-string') {
     return typeof next === 'string' ? { value: next, consumed: 2 } : null;
   }
   if (token.startsWith('--split-string=')) {
     return { value: token.slice('--split-string='.length), consumed: 1 };
   }
-  if (token.startsWith('-S') && token.length > 2) {
-    return { value: token.slice(2), consumed: 1 };
+  if (!token.startsWith('-') || token.startsWith('--') || token.length < 2) return null;
+  // Walk the short-option cluster the way getopt does: the first option that
+  // takes an argument claims the rest of the token, or the next word when the
+  // rest is empty. So `-vS "rm -rf /"` and `-vS"rm -rf /"` both reach `-S`,
+  // while `-uS` is `-u` unsetting a variable named `S` and carries no command.
+  for (let i = 1; i < token.length; i += 1) {
+    const flag = token[i];
+    if (flag === 'S') {
+      const attached = token.slice(i + 1);
+      if (attached) return { value: attached, consumed: 1 };
+      return typeof next === 'string' ? { value: next, consumed: 2 } : null;
+    }
+    if (ENV_SHORT_OPTIONS_WITH_VALUE.has(flag)) return null;
   }
   return null;
 }
@@ -498,7 +513,11 @@ function stripCommandWrappers(tokens) {
       if (wrapper === 'env' && expansions < MAX_WRAPPER_EXPANSIONS) {
         const split = envSplitString(token, rest[index + 1]);
         if (split) {
-          rest = tokenize(split.value).concat(rest.slice(index + split.consumed));
+          // Quote-aware, because the split string carries its own quoting:
+          // `env -S '"rm" -rf /'` must yield `rm`, not `"rm"`, or the command
+          // word never matches. Falls back to a plain split if parsing fails.
+          const words = tokenizeAllowlistedShellWords(split.value) || tokenize(split.value);
+          rest = words.concat(rest.slice(index + split.consumed));
           index = 0;
           valueFlags = null;
           wrapper = null;

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -376,6 +376,86 @@ function commandBasename(token) {
 }
 
 /**
+ * Command words that run ANOTHER command: the destructive check has to look
+ * past them, or the most dangerous spellings are the ones that slip through.
+ * Every token-based detector keys on `tokens[0]`, so `sudo rm -rf /` reads as
+ * an invocation of `sudo` and is allowed while the bare `rm -rf /` is denied.
+ */
+const COMMAND_WRAPPERS = new Set([
+  'sudo',
+  'doas',
+  'env',
+  'command',
+  'nohup',
+  'setsid',
+  'stdbuf',
+  'nice',
+  'ionice',
+]);
+
+/**
+ * Wrapper flags that consume the FOLLOWING token as their value, so the value
+ * is not mistaken for the wrapped command word (`sudo -u root rm -rf /`).
+ * Long `--flag=value` forms need no entry: they are a single token.
+ */
+const WRAPPER_FLAGS_WITH_VALUE = new Set([
+  '-u',
+  '-g',
+  '-p',
+  '-C',
+  '-h',
+  '-r',
+  '-t',
+  '-U',
+  '--user',
+  '--group',
+  '--prompt',
+  '--host',
+  '--role',
+  '--type',
+  '--chdir',
+]);
+
+/**
+ * Return `tokens` with any leading wrapper commands, their flags, and
+ * `VAR=value` assignment prefixes removed, so the caller sees the command that
+ * actually runs.
+ *
+ * Flags are only skipped once a wrapper has been seen, so this can never walk
+ * into an unwrapped command's own arguments. Returns the input array when
+ * there is nothing to strip.
+ *
+ * @param {string[]} tokens
+ * @returns {string[]}
+ */
+function stripCommandWrappers(tokens) {
+  if (!Array.isArray(tokens) || tokens.length === 0) return tokens;
+  let index = 0;
+  let sawWrapper = false;
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (COMMAND_WRAPPERS.has(commandBasename(token))) {
+      sawWrapper = true;
+      index += 1;
+      continue;
+    }
+    // `FOO=bar rm -rf /` and `env FOO=bar rm -rf /` both put assignments before
+    // the command word.
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) {
+      index += 1;
+      continue;
+    }
+    if (sawWrapper && token.startsWith('-')) {
+      if (WRAPPER_FLAGS_WITH_VALUE.has(token)) index += 1;
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  return index === 0 ? tokens : tokens.slice(index);
+}
+
+/**
  * Detect `rm` invocations that recursively force-delete files. Handles
  * combined (`-rf`, `-fr`, `-Rf`) and split (`-r -f`) flag forms.
  *
@@ -613,12 +693,12 @@ function isDestructiveFindExec(command) {
   }
 
   // Tokenize the whole command line
-  const tokens = tokenize(trimmed);
+  const tokens = stripCommandWrappers(tokenize(trimmed));
   if (!tokens || tokens.length === 0) {
     return false;
   }
 
-  // Must start with `find`
+  // Must start with `find` — after any wrapper prefix (`sudo find . -exec rm`).
   if (commandBasename(tokens[0]) !== 'find') {
     return false;
   }
@@ -702,7 +782,9 @@ function isDestructiveBash(command) {
     const stripped = stripQuotedStrings(segment);
     if (DESTRUCTIVE_SQL_DD.test(stripped)) return true;
     if (extra && extra.test(stripped)) return true;
-    const tokens = tokenize(segment);
+    // Look past sudo/doas/env/... so a privileged spelling is not the one that
+    // gets through (the gate matters MORE for those, not less).
+    const tokens = stripCommandWrappers(tokenize(segment));
     if (isDestructiveRm(tokens)) return true;
     if (isDestructiveGit(tokens)) return true;
   }

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -344,7 +344,11 @@ const SHELL_WRAPPERS = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh']);
  */
 function isDestructiveQuoteAware(raw, depth = 0) {
   if (depth > 4) return false;
-  for (const tokens of quoteAwareSegments(raw)) {
+  for (const segment of quoteAwareSegments(raw)) {
+    if (segment.length === 0) continue;
+    // A quoted command word survives this path as a plain token, so the
+    // wrapper prefix has to be normalized here too (`sudo "rm" -rf /`).
+    const tokens = stripCommandWrappers(segment);
     if (tokens.length === 0) continue;
     if (isDestructiveRm(tokens)) return true;
     if (isDestructiveGit(tokens)) return true;
@@ -380,50 +384,49 @@ function commandBasename(token) {
  * past them, or the most dangerous spellings are the ones that slip through.
  * Every token-based detector keys on `tokens[0]`, so `sudo rm -rf /` reads as
  * an invocation of `sudo` and is allowed while the bare `rm -rf /` is denied.
+ *
+ * The value is the set of that wrapper's OWN options which consume the
+ * following token, so the value is not mistaken for the wrapped command word.
+ * Arity is per wrapper because the same letter differs between them: `sudo -p`
+ * takes a prompt string, while `command -p` is a boolean that must leave `rm`
+ * as the next token. Long `--flag=value` forms need no entry (single token),
+ * and so do attached short forms (`stdbuf -oL`) — the flag token is skipped
+ * either way.
+ *
+ * @type {Map<string, Set<string>>}
  */
-const COMMAND_WRAPPERS = new Set([
-  'sudo',
-  'doas',
-  'env',
-  'command',
-  'nohup',
-  'setsid',
-  'stdbuf',
-  'nice',
-  'ionice',
+const COMMAND_WRAPPERS = new Map([
+  [
+    'sudo',
+    new Set([
+      '-a', '-C', '-c', '-D', '-g', '-h', '-p', '-R', '-r', '-T', '-t', '-U', '-u',
+      '--auth-type', '--close-from', '--login-class', '--chdir', '--group',
+      '--host', '--prompt', '--chroot', '--role', '--command-timeout', '--type',
+      '--other-user', '--user',
+    ]),
+  ],
+  ['doas', new Set(['-a', '-C', '-u'])],
+  ['env', new Set(['-u', '-C', '-S', '--unset', '--chdir', '--split-string'])],
+  ['command', new Set()],
+  ['nohup', new Set()],
+  ['setsid', new Set()],
+  ['stdbuf', new Set(['-i', '-o', '-e', '--input', '--output', '--error'])],
+  ['nice', new Set(['-n', '--adjustment'])],
+  [
+    'ionice',
+    new Set(['-c', '-n', '-p', '-P', '-u', '--class', '--classdata', '--pid', '--pgid', '--uid']),
+  ],
 ]);
 
 /**
- * Wrapper flags that consume the FOLLOWING token as their value, so the value
- * is not mistaken for the wrapped command word (`sudo -u root rm -rf /`).
- * Long `--flag=value` forms need no entry: they are a single token.
- */
-const WRAPPER_FLAGS_WITH_VALUE = new Set([
-  '-u',
-  '-g',
-  '-p',
-  '-C',
-  '-h',
-  '-r',
-  '-t',
-  '-U',
-  '--user',
-  '--group',
-  '--prompt',
-  '--host',
-  '--role',
-  '--type',
-  '--chdir',
-]);
-
-/**
- * Return `tokens` with any leading wrapper commands, their flags, and
+ * Return `tokens` with any leading wrapper commands, their options, and
  * `VAR=value` assignment prefixes removed, so the caller sees the command that
  * actually runs.
  *
- * Flags are only skipped once a wrapper has been seen, so this can never walk
- * into an unwrapped command's own arguments. Returns the input array when
- * there is nothing to strip.
+ * Options are only skipped once a wrapper has been seen, so this can never walk
+ * into an unwrapped command's own arguments, and an option's value is only
+ * consumed when the wrapper it belongs to declares that arity. Returns the
+ * input array when there is nothing to strip.
  *
  * @param {string[]} tokens
  * @returns {string[]}
@@ -431,11 +434,12 @@ const WRAPPER_FLAGS_WITH_VALUE = new Set([
 function stripCommandWrappers(tokens) {
   if (!Array.isArray(tokens) || tokens.length === 0) return tokens;
   let index = 0;
-  let sawWrapper = false;
+  let valueFlags = null;
   while (index < tokens.length) {
     const token = tokens[index];
-    if (COMMAND_WRAPPERS.has(commandBasename(token))) {
-      sawWrapper = true;
+    const wrapperFlags = COMMAND_WRAPPERS.get(commandBasename(token));
+    if (wrapperFlags) {
+      valueFlags = wrapperFlags;
       index += 1;
       continue;
     }
@@ -445,8 +449,8 @@ function stripCommandWrappers(tokens) {
       index += 1;
       continue;
     }
-    if (sawWrapper && token.startsWith('-')) {
-      if (WRAPPER_FLAGS_WITH_VALUE.has(token)) index += 1;
+    if (valueFlags && token.startsWith('-')) {
+      if (valueFlags.has(token)) index += 1;
       index += 1;
       continue;
     }
@@ -723,7 +727,14 @@ function isDestructiveFindExec(command) {
     return false;
   }
 
-  const baseCmd = commandBasename(execTokens[0]);
+  // `find . -exec sudo rm {} \;` runs the same deletion as `-exec rm`, so the
+  // executed command needs the same wrapper normalization as a top-level one.
+  const execCommand = stripCommandWrappers(execTokens);
+  if (execCommand.length === 0) {
+    return false;
+  }
+
+  const baseCmd = commandBasename(execCommand[0]);
 
   // Directly destructive commands inside -exec
   if (baseCmd === 'rmdir' || baseCmd === 'unlink') {
@@ -737,7 +748,7 @@ function isDestructiveFindExec(command) {
 
   // `git reset --hard` inside -exec
   if (baseCmd === 'git') {
-    const sub = findGitSubcommand(execTokens);
+    const sub = findGitSubcommand(execCommand);
     if (sub && sub.command === 'reset' && sub.rest.includes('--hard')) {
       return true;
     }

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -292,7 +292,16 @@ function runTests() {
     "sudo 'rm' -rf /important/data",
     'env "rm" -rf /important/data',
     'doas "rm" -rf /important/data',
-    'sudo bash -c "rm -rf /important/data"'
+    'sudo bash -c "rm -rf /important/data"',
+    // `env -S "<cmd>"` RUNS the string. Consuming it as an opaque option value
+    // let the whole command hide behind the option, in all three spellings.
+    'env -S "rm -rf /important/data"',
+    'env --split-string="rm -rf /important/data"',
+    'env -S"rm -rf /important/data"',
+    'env -S "sudo rm -rf /important/data"',
+    'env -S "git reset --hard"',
+    // `-p` is not a lookup mode, so the operand still runs.
+    'command -p rm -rf /important/data'
   ]) {
     clearState();
     if (
@@ -330,7 +339,14 @@ function runTests() {
     'nice -n 10 npm run build',
     'ionice -c 3 npm test',
     'stdbuf -o L npm test',
-    'find . -exec sudo chmod 644 {} ;'
+    'find . -exec sudo chmod 644 {} ;',
+    // `command -v`/`-V` only report where a name resolves; the operand never
+    // runs, so gating it denied a lookup that changes nothing.
+    'command -v git reset --hard',
+    'command -V git reset --hard',
+    'command -pv git reset --hard',
+    // A benign split string must stay benign.
+    'env -S "npm run build"'
   ]) {
     clearState();
     if (

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -334,7 +334,22 @@ function runTests() {
     'sh -xc "rm -rf /important/data"',
     'sh -ce "rm -rf /important/data"',
     'bash -ec "rm -rf /important/data"',
-    'find . -exec sh -ec "rm -rf {}" ;'
+    'find . -exec sh -ec "rm -rf {}" ;',
+    // A value-taking option consumes exactly one value and the scan continues
+    // past it. Stopping at one instead cost the plain `-c` that follows, which
+    // is a spelling the shell does run.
+    'sh -o errexit -c "rm -rf /important/data"',
+    'bash --init-file /dev/null -c "rm -rf /important/data"',
+    'bash --rcfile /dev/null -ic "rm -rf /important/data"',
+    'find . -exec sh -o errexit -c "rm -rf {}" ;',
+    // `-Senv` is env's attached split-string form, so these nest for real and
+    // run. Expansion used to stop after a fixed number of layers and hand the
+    // split string back as an opaque option value, which is exactly the thing
+    // expansion exists to prevent: the verdict flipped from denied to allowed
+    // at the cap, and one more wrapper bought a pass.
+    `env ${'-Senv '.repeat(8)}-S "rm -rf /important/data"`,
+    `env ${'-Senv '.repeat(9)}-S "rm -rf /important/data"`,
+    `env ${'-Senv '.repeat(40)}-S "rm -rf /important/data"`
   ]) {
     clearState();
     if (
@@ -395,7 +410,11 @@ function runTests() {
     // behind it is that value ("invalid option name"), and after `--` the next
     // word is the script name — neither shell runs the string as a command.
     'sh -oc "rm -rf /important/data"',
-    'sh -- -c "rm -rf /important/data"'
+    'sh -- -c "rm -rf /important/data"',
+    // Deep nesting is not destructive by itself; only what it ends up running
+    // is. A bound that gave up and denied would gate this.
+    `env ${'-Senv '.repeat(40)}-S "npm test"`,
+    'sh -o errexit -c "npm test"'
   ]) {
     clearState();
     if (

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -315,7 +315,26 @@ function runTests() {
     'env -uSHELL rm -rf /important/data',
     'env -uS rm -rf /important/data',
     // `-p` is not a lookup mode, so the operand still runs.
-    'command -p rm -rf /important/data'
+    'command -p rm -rf /important/data',
+    // `-exec sh -c '<cmd>'` runs <cmd>. Classifying only the `sh` executable
+    // stopped at the wrapper, so every deletion behind one was allowed while
+    // the bare `-exec rm` spelling was denied.
+    'find . -exec sh -c "rm -rf {}" ;',
+    "find . -exec sh -c 'rm -rf {}' ;",
+    'find . -exec bash -c "rm -rf /important/data" ;',
+    'find . -exec zsh -c "rm -rf /important/data" ;',
+    'find /tmp -type f -exec sh -c "rm -rf {}" ;',
+    // `+` terminates -exec too, and the payload keeps its own wrappers.
+    'find . -exec sh -c "rm -rf {}" +',
+    'find . -exec sh -c "git reset --hard" ;',
+    'find . -exec sh -c "sudo rm -rf /important/data" ;',
+    // Short options cluster, so `-c` is reached through `-e`/`-x` as well —
+    // attached or not, and whether or not `c` comes first.
+    'sh -ec "rm -rf /important/data"',
+    'sh -xc "rm -rf /important/data"',
+    'sh -ce "rm -rf /important/data"',
+    'bash -ec "rm -rf /important/data"',
+    'find . -exec sh -ec "rm -rf {}" ;'
   ]) {
     clearState();
     if (
@@ -364,7 +383,19 @@ function runTests() {
     'env -vS "npm test"',
     // `-uS` is `-u` unsetting a variable named S, not a split string.
     'env -uS FOO',
-    'env -C /tmp npm run build'
+    'env -C /tmp npm run build',
+    // Looking inside `-c` must classify the payload, not assume the worst of
+    // every shell wrapper.
+    'find . -exec sh -c "echo hello" ;',
+    'sh -c "npm test"',
+    'sh -ec "npm run build"',
+    'bash --norc -c "npm test"',
+    // These two carry a destructive payload on purpose: with a benign one the
+    // assertion passes either way and pins nothing. `-o` takes a value, so `c`
+    // behind it is that value ("invalid option name"), and after `--` the next
+    // word is the script name — neither shell runs the string as a command.
+    'sh -oc "rm -rf /important/data"',
+    'sh -- -c "rm -rf /important/data"'
   ]) {
     clearState();
     if (

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -253,6 +253,84 @@ function runTests() {
     passed++;
   else failed++;
 
+  // --- Test 4d: wrapper-prefixed destructive commands ---
+  /**
+   * Every token-based detector keys on `tokens[0]`, so `sudo rm -rf /` read as
+   * an invocation of `sudo` and was ALLOWED while the bare `rm -rf /` was
+   * denied — the gate missed exactly the privileged spellings it matters most
+   * for. Same for doas/env/command/nohup, `VAR=value` prefixes, sudo's own
+   * flags, and a wrapper appearing after a compound separator.
+   */
+  for (const command of [
+    'sudo rm -rf /important/data',
+    'sudo -u root rm -rf /important/data',
+    'sudo --user=root rm -rf /important/data',
+    'doas rm -rf /important/data',
+    'env rm -rf /important/data',
+    'FOO=bar rm -rf /important/data',
+    'command rm -rf /important/data',
+    'nohup rm -rf /important/data',
+    'sudo git reset --hard',
+    'sudo git clean -fd',
+    'sudo git push --force',
+    'sudo find . -exec rm {} ;',
+    'echo hello && sudo rm -rf /important/data'
+  ]) {
+    clearState();
+    if (
+      test(`denies a wrapper-prefixed destructive command: ${command}`, () => {
+        // Prime the session so the separate first-command routine gate cannot
+        // be mistaken for a destructive denial.
+        runBashHook({ tool_name: 'Bash', tool_input: { command: 'printf ready' } });
+        const result = runBashHook({ tool_name: 'Bash', tool_input: { command } });
+        assert.strictEqual(result.code, 0, `hook should exit 0 for ${command}`);
+        const output = parseOutput(result.stdout);
+        assert.ok(output, `hook should produce JSON output for ${command}`);
+        assert.ok(output.hookSpecificOutput, `${command} should carry a permission decision`);
+        assert.strictEqual(
+          output.hookSpecificOutput.permissionDecision,
+          'deny',
+          `${command} must be gated as destructive`
+        );
+        assert.ok(output.hookSpecificOutput.permissionDecisionReason.includes('Destructive'));
+      })
+    )
+      passed++;
+    else failed++;
+  }
+
+  // --- Test 4e: looking past wrappers must not gate ordinary privileged work ---
+  for (const command of [
+    'sudo apt-get update',
+    'sudo systemctl restart nginx',
+    'sudo ls -la /etc',
+    'env NODE_ENV=production npm run build',
+    'command ls'
+  ]) {
+    clearState();
+    if (
+      test(`does not gate an ordinary wrapped command: ${command}`, () => {
+        runBashHook({ tool_name: 'Bash', tool_input: { command: 'printf ready' } });
+        const result = runBashHook({ tool_name: 'Bash', tool_input: { command } });
+        assert.strictEqual(result.code, 0, `hook should exit 0 for ${command}`);
+        const output = parseOutput(result.stdout);
+        assert.ok(output, `hook should produce JSON output for ${command}`);
+        const decision = output.hookSpecificOutput;
+        if (decision) {
+          const reason = decision.permissionDecisionReason || '';
+          assert.ok(
+            decision.permissionDecision !== 'deny' || !reason.includes('Destructive'),
+            `${command} must not be gated as destructive`
+          );
+        } else {
+          assert.strictEqual(output.tool_name, 'Bash', 'pass-through should preserve input');
+        }
+      })
+    )
+      passed++;
+    else failed++;
+  }
+
   // --- Test 5: denies first routine Bash, allows second ---
   clearState();
   if (

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -300,6 +300,20 @@ function runTests() {
     'env -S"rm -rf /important/data"',
     'env -S "sudo rm -rf /important/data"',
     'env -S "git reset --hard"',
+    // getopt gives the first argument-taking option in a cluster the rest of
+    // the token, so `-S` is reached through `-v`/`-i` too, attached or not.
+    'env -vS"rm -rf /important/data"',
+    'env -vS "rm -rf /important/data"',
+    'env -iS "rm -rf /important/data"',
+    // The split string carries its own quoting; a whitespace-only split left
+    // the command word as `"rm"`, which matched nothing.
+    `env -S '"rm" -rf /important/data'`,
+    `env -S 'env -S "rm" -rf /important/data'`,
+    // `-uSHELL` is `-u` unsetting SHELL, so `rm` is still the command. Reading
+    // the cluster left to right is what keeps `HELL` from being taken as a
+    // split string and hiding the deletion.
+    'env -uSHELL rm -rf /important/data',
+    'env -uS rm -rf /important/data',
     // `-p` is not a lookup mode, so the operand still runs.
     'command -p rm -rf /important/data'
   ]) {
@@ -346,7 +360,11 @@ function runTests() {
     'command -V git reset --hard',
     'command -pv git reset --hard',
     // A benign split string must stay benign.
-    'env -S "npm run build"'
+    'env -S "npm run build"',
+    'env -vS "npm test"',
+    // `-uS` is `-u` unsetting a variable named S, not a split string.
+    'env -uS FOO',
+    'env -C /tmp npm run build'
   ]) {
     clearState();
     if (

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -274,7 +274,25 @@ function runTests() {
     'sudo git clean -fd',
     'sudo git push --force',
     'sudo find . -exec rm {} ;',
-    'echo hello && sudo rm -rf /important/data'
+    'echo hello && sudo rm -rf /important/data',
+    // A wrapper INSIDE `-exec` runs the same deletion as a bare one.
+    'find . -exec sudo rm {} ;',
+    'find . -exec doas rm {} ;',
+    'find . -exec sudo git reset --hard {} ;',
+    // Option arity is per wrapper: `command -p` is boolean and must leave `rm`
+    // in place, while `nice -n`, `stdbuf -o`, and `ionice -c` consume a value.
+    'command -p rm -rf /important/data',
+    'nice -n 10 rm -rf /important/data',
+    'stdbuf -o L rm -rf /important/data',
+    'stdbuf -oL rm -rf /important/data',
+    'ionice -c 3 rm -rf /important/data',
+    // Quoting the command word routes the check through the quote-aware pass,
+    // which needs the same wrapper normalization.
+    'sudo "rm" -rf /important/data',
+    "sudo 'rm' -rf /important/data",
+    'env "rm" -rf /important/data',
+    'doas "rm" -rf /important/data',
+    'sudo bash -c "rm -rf /important/data"'
   ]) {
     clearState();
     if (
@@ -304,8 +322,15 @@ function runTests() {
     'sudo apt-get update',
     'sudo systemctl restart nginx',
     'sudo ls -la /etc',
+    'sudo -u root ls -la /etc',
     'env NODE_ENV=production npm run build',
-    'command ls'
+    'command ls',
+    'command -p ls',
+    'command -v rm',
+    'nice -n 10 npm run build',
+    'ionice -c 3 npm test',
+    'stdbuf -o L npm test',
+    'find . -exec sudo chmod 644 {} ;'
   ]) {
     clearState();
     if (


### PR DESCRIPTION
## What Changed

Every token-based detector in `gateguard-fact-force.js` keys on `tokens[0]`, so a privilege or environment wrapper hides the command being run. `stripCommandWrappers()` now removes leading wrapper commands, their flags, and `VAR=value` assignment prefixes before the detectors see the tokens — applied in the per-segment loop (`isDestructiveRm`, `isDestructiveGit`) and in `isDestructiveFindExec`.

I found this while fixing #2642; it is a separate defect from the `dd` one, so it is a separate PR.

## Why This Change

Measured against `main` with a **primed session** (the first Bash command of a session trips a separate routine gate that otherwise masks this), driven through the published hook runner:

| command | main | this PR |
| --- | --- | --- |
| `rm -rf /important/data` | denied | denied |
| `sudo rm -rf /important/data` | **allowed** | denied |
| `sudo -u root rm -rf /data` | **allowed** | denied |
| `sudo --user=root rm -rf /data` | **allowed** | denied |
| `doas rm -rf /data` | **allowed** | denied |
| `env rm -rf /data` | **allowed** | denied |
| `FOO=bar rm -rf /data` | **allowed** | denied |
| `command rm -rf /data` | **allowed** | denied |
| `nohup rm -rf /data` | **allowed** | denied |
| `sudo git reset --hard` | **allowed** | denied |
| `sudo git clean -fd` | **allowed** | denied |
| `sudo git push --force` | **allowed** | denied |
| `sudo find . -exec rm {} ;` | **allowed** | denied |
| `echo a && sudo rm -rf /data` | **allowed** | denied |

The gate missed exactly the spellings it matters most for: the privileged ones. Adding four characters to a command was enough to turn a hard deny into a pass.

`sudo truncate table t` was already denied — the SQL arm is a text match and never looked at a command word at all, which is why the gap only shows up in the token-based detectors.

## How it is bounded

Widening a *deny* gate risks blocking legitimate work, so two limits are deliberate:

- **Flags are skipped only after a wrapper has been seen.** Without that, the scan could walk into an unwrapped command's own arguments.
- **Wrapper flags that consume a following token are listed** (`-u`, `-g`, `-p`, `-C`, `-h`, `-r`, `-t`, `-U`, and long forms), so `sudo -u root rm -rf /` resolves to `rm` and not to `root`. `--flag=value` needs no entry — it is one token.

Verified still **allowed**: `sudo apt-get update`, `sudo systemctl restart nginx`, `sudo ls -la /etc`, `command ls`, `env NODE_ENV=production npm run build`.

## Testing Done

- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`) — see the note below
- [x] Edge cases considered and tested

13 new deny cases and 5 new allow cases in `tests/hooks/gateguard-fact-force.test.js`, driven end-to-end through `run-with-flags.js`.

Reverting only `scripts/hooks/gateguard-fact-force.js`:

```
✗ denies a wrapper-prefixed destructive command: sudo rm -rf /important/data
✗ … sudo -u root rm -rf /important/data
✗ … sudo --user=root rm -rf /important/data
✗ … doas rm -rf /important/data
✗ … env rm -rf /important/data
✗ … FOO=bar rm -rf /important/data
✗ … command rm -rf /important/data
✗ … nohup rm -rf /important/data
✗ … sudo git reset --hard
✗ … sudo git clean -fd
✗ … sudo git push --force
✗ … sudo find . -exec rm {} ;
✗ … echo hello && sudo rm -rf /important/data
149 passed, 13 failed
```

With the change: **162 passed, 0 failed**. The 5 must-allow cases pass either way by design — they are the over-blocking guard, not evidence of the bug.

**Why `run-all.js` is unchecked:** it stops in my environment at `tests/lib/claude-plugin-setup.test.js`, which performs real marketplace `git clone`s (`fatal: fetch-pack: invalid index-pack output`). That is environmental and unrelated. `tests/hooks/gateguard-fact-force.test.js` is the only test file that references gateguard (`grep -rl gateguard tests/`), so the suite I did run covers this change's blast radius.

## Type of Change

- [x] `fix:` Bug fix

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly (none touched)
- [x] Shell scripts pass shellcheck (none touched)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Relationship to #2829

Independent — this branches from `main` and touches different functions, so the two can merge in either order.

There is one small overlap to reconcile afterwards: #2829 adds `isDestructiveDd`, which carries its own inline wrapper-skipping loop. Once both are in, that loop should call `stripCommandWrappers()` instead. I will send that one-line follow-up, or fold it in here if you prefer to take this one first — your call. As a side effect it would also fix `sudo -u root dd if=…`, which #2829's inline loop does not handle (it stops at `root`).
