### PR TITLE
fix(hooks): tighten mcp-health-check matchers to mcp__.* to eliminate no-op spawns

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -73,7 +73,7 @@
         "id": "pre:config-protection"
       },
       {
-        "matcher": "*",
+        "matcher": "mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -162,7 +162,7 @@
     ],
     "PostToolUseFailure": [
       {
-        "matcher": "*",
+        "matcher": "mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -73,7 +73,7 @@
         "id": "pre:config-protection"
       },
       {
-        "matcher": "mcp__.*",
+        "matcher": "^mcp__",
         "hooks": [
           {
             "type": "command",
@@ -162,7 +162,7 @@
     ],
     "PostToolUseFailure": [
       {
-        "matcher": "mcp__.*",
+        "matcher": "^mcp__",
         "hooks": [
           {
             "type": "command",

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -48,7 +48,16 @@ const ECC_ENABLE_VALUES = new Set(['1', 'true', 'on', 'enabled', 'enable', 'yes'
 // phrases without shell-flag ordering concerns. Quoted strings are
 // stripped before this regex runs so a commit message mentioning
 // "drop table" no longer triggers a false positive.
-const DESTRUCTIVE_SQL_DD = /\b(drop\s+table|delete\s+from|truncate|dd\s+if=)\b/i;
+//
+// The `dd\s+if=` arm deliberately omits a trailing word-boundary anchor:
+// `dd if=` ends with `=`, a non-word character, so `\b` would refuse to
+// match before the next non-word character (most commonly `/` for
+// `/dev/*` targets, but also `.`, quotes, `;`, `|`, `&`, end-of-string,
+// etc.). Anchoring that arm with `\b` was the cause of issue #2642:
+// `dd if=/dev/zero of=/dev/sda` slipped past the gate. The SQL arms keep
+// their trailing `\b` so words like `delete fromtable` or `truncatefile`
+// do not produce false positives.
+const DESTRUCTIVE_SQL_DD = /\b(?:drop\s+table|delete\s+from|truncate)\b|\bdd\s+if=/i;
 
 // Operator-supplied additional destructive patterns. Lazily compiled from
 // `GATEGUARD_BASH_EXTRA_DESTRUCTIVE` (regex source) on first use, then

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -2376,6 +2376,165 @@ function runTests() {
     passed++;
   else failed++;
 
+  // --- Issue #2642: trailing \b on the `dd\s+if=` arm fails open when the
+  // argument begins with a non-word character (`/`, `.`, quote, ...), which
+  // covers every realistic disk-wipe spelling. The fix splits the alternation
+  // so the SQL arms keep their trailing word-boundary anchor (no
+  // `delete fromtable` / `truncatefile` false positives) while the `dd if=`
+  // arm matches whatever follows the `=`.
+
+  clearState();
+  if (
+    test('denies `dd if=/dev/zero of=/dev/sda` (issue #2642 disk-wipe spelling)', () => {
+      expectDestructiveDeny('dd if=/dev/zero of=/dev/sda', 'dd if=/dev/zero of=/dev/sda');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('denies `dd if=/dev/urandom of=/dev/sdb`', () => {
+      expectDestructiveDeny('dd if=/dev/urandom of=/dev/sdb', 'dd if=/dev/urandom of=/dev/sdb');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('denies `dd if=/dev/zero` (slash-prefixed argument)', () => {
+      expectDestructiveDeny('dd if=/dev/zero', 'dd if=/dev/zero');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('denies `dd if=.` (dot-prefixed argument — `git checkout -- .` analogue)', () => {
+      expectDestructiveDeny('dd if=. of=/tmp/out.bin', 'dd if=. of=/tmp/out.bin');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('denies `dd if=foo` (word-prefixed argument)', () => {
+      expectDestructiveDeny('dd if=foo', 'dd if=foo');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('denies `dd if=backup.img of=/dev/sdc` (period in argument)', () => {
+      expectDestructiveDeny('dd if=backup.img of=/dev/sdc', 'dd if=backup.img of=/dev/sdc');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('denies `dd if=` followed by `;` (compound form)', () => {
+      expectDestructiveDeny('echo start; dd if=/dev/zero of=/dev/sda', 'echo start; dd if=/dev/zero of=/dev/sda');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('denies `dd if=/dev/zero` inside command substitution `$(...)`', () => {
+      expectDestructiveDeny('echo $(dd if=/dev/zero of=/dev/sda)', 'echo $(dd if=/dev/zero of=/dev/sda)');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('still denies `dd if=x` (control: was already denied pre-fix)', () => {
+      expectDestructiveDeny('dd if=x', 'dd if=x');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('still denies plain `drop table users;` (SQL arm unaffected)', () => {
+      expectDestructiveDeny('drop table users;', 'drop table users;');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('still denies plain `delete from t` (SQL arm unaffected)', () => {
+      expectDestructiveDeny('delete from t', 'delete from t');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('still denies plain `truncate -s 0 f` (SQL arm unaffected)', () => {
+      expectDestructiveDeny('truncate -s 0 f', 'truncate -s 0 f');
+    })
+  )
+    passed++;
+  else failed++;
+
+  // Anti-regression: dropping the trailing \b on the SQL arms would let
+  // benign substrings fire the gate (`delete fromtable`, `truncatefile`).
+  // The fix must keep `\b` on the SQL arms so these remain allowed.
+
+  clearState();
+  if (
+    test('allows `delete fromtable` (SQL arm keeps trailing \\b; not a false positive)', () => {
+      // Prime the routine gate so the destructive-gate outcome is the
+      // observable signal. `delete fromtable` is not a SQL statement.
+      writeState({ checked: ['__bash_session__'], last_active: Date.now() });
+      const input = { tool_name: 'Bash', tool_input: { command: 'echo "delete fromtable review"' } };
+      const result = runBashHook(input);
+      assert.strictEqual(result.code, 0, 'exit code should be 0');
+      const output = parseOutput(result.stdout);
+      assert.ok(output, 'should produce JSON');
+      if (output.hookSpecificOutput) {
+        assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny', 'delete fromtable should not be destructive');
+      } else {
+        assert.strictEqual(output.tool_name, 'Bash', 'pass-through should preserve input');
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('allows `truncatefile` (SQL arm keeps trailing \\b; not a false positive)', () => {
+      writeState({ checked: ['__bash_session__'], last_active: Date.now() });
+      const input = { tool_name: 'Bash', tool_input: { command: 'echo truncatefile.tmp' } };
+      const result = runBashHook(input);
+      assert.strictEqual(result.code, 0, 'exit code should be 0');
+      const output = parseOutput(result.stdout);
+      assert.ok(output, 'should produce JSON');
+      if (output.hookSpecificOutput) {
+        assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny', 'truncatefile should not be destructive');
+      } else {
+        assert.strictEqual(output.tool_name, 'Bash', 'pass-through should preserve input');
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
   // --- Exempt globs: GATEGUARD_EXEMPT_GLOBS skips first-touch fact-forcing ---
   clearState();
   if (

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -2565,17 +2565,21 @@ async function runTests() {
   else failed++;
 
   if (
-    test('MCP health-check hooks use tight mcp__.* matcher instead of wildcard', () => {
+    test('MCP health-check hooks use anchored ^mcp__ matcher (no unanchored mcp__.*)', () => {
       const hooksPath = path.join(__dirname, '..', '..', 'hooks', 'hooks.json');
       const hooks = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
 
-      const preMcp = hooks.hooks.PreToolUse.find(e => e.id === 'pre:mcp-health-check');
-      assert.ok(preMcp, 'Should define pre:mcp-health-check');
-      assert.strictEqual(preMcp.matcher, 'mcp__.*', 'pre:mcp-health-check should use mcp__.* matcher to avoid spawning on non-MCP tools');
+      const preMcp = hooks.hooks.PreToolUse.filter(e => e.id === 'pre:mcp-health-check');
+      assert.strictEqual(preMcp.length, 1, 'Should define exactly one pre:mcp-health-check entry');
+      preMcp.forEach(entry => {
+        assert.strictEqual(entry.matcher, '^mcp__', `pre:mcp-health-check matcher must be anchored '^mcp__' to avoid spawning on non-MCP tool names (got ${entry.matcher})`);
+      });
 
-      const postMcp = hooks.hooks.PostToolUseFailure.find(e => e.id === 'post:mcp-health-check');
-      assert.ok(postMcp, 'Should define post:mcp-health-check');
-      assert.strictEqual(postMcp.matcher, 'mcp__.*', 'post:mcp-health-check should use mcp__.* matcher to avoid spawning on non-MCP tool failures');
+      const postMcp = hooks.hooks.PostToolUseFailure.filter(e => e.id === 'post:mcp-health-check');
+      assert.strictEqual(postMcp.length, 1, 'Should define exactly one post:mcp-health-check entry');
+      postMcp.forEach(entry => {
+        assert.strictEqual(entry.matcher, '^mcp__', `post:mcp-health-check matcher must be anchored '^mcp__' to avoid spawning on non-MCP tool names (got ${entry.matcher})`);
+      });
     })
   )
     passed++;

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -2565,6 +2565,23 @@ async function runTests() {
   else failed++;
 
   if (
+    test('MCP health-check hooks use tight mcp__.* matcher instead of wildcard', () => {
+      const hooksPath = path.join(__dirname, '..', '..', 'hooks', 'hooks.json');
+      const hooks = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+
+      const preMcp = hooks.hooks.PreToolUse.find(e => e.id === 'pre:mcp-health-check');
+      assert.ok(preMcp, 'Should define pre:mcp-health-check');
+      assert.strictEqual(preMcp.matcher, 'mcp__.*', 'pre:mcp-health-check should use mcp__.* matcher to avoid spawning on non-MCP tools');
+
+      const postMcp = hooks.hooks.PostToolUseFailure.find(e => e.id === 'post:mcp-health-check');
+      assert.ok(postMcp, 'Should define post:mcp-health-check');
+      assert.strictEqual(postMcp.matcher, 'mcp__.*', 'post:mcp-health-check should use mcp__.* matcher to avoid spawning on non-MCP tool failures');
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
     test('SessionEnd marker hook is async and cleanup-safe', () => {
       const hooksPath = path.join(__dirname, '..', '..', 'hooks', 'hooks.json');
       const hooks = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));


### PR DESCRIPTION
## What Changed
- Changed `pre:mcp-health-check` matcher from `*` to `mcp__.*` so Claude Code skips the hook entirely on non-MCP tool calls
- Changed `post:mcp-health-check` matcher from `*` to `mcp__.*` for the same reason
- Added a regression test verifying both matchers are `mcp__.*`

## Why This Change
Per #2834, `pre:mcp-health-check` and `post:mcp-health-check` both used `matcher: "*"` (catch-all), causing Node to spawn on every tool call only to no-op when the tool name does not start with `mcp__`. The reporter measured ~150ms and ~194ms overhead per Bash call respectively.

Tightening the matcher to `mcp__.*` at the hooks.json level means Claude Code does not even evaluate these hook groups for non-MCP tools, eliminating the process spawn entirely. Behavior is identical for matching MCP tool calls.

## Scope
- Findings 1 and 3 from #2834 were verified already fixed on main and are not addressed here.
- `pre:governance-capture` is env-gated (`ECC_GOVERNANCE_CAPTURE=1`) at the script level; the Claude Code `if` field uses permission-rule syntax and cannot check env vars, so no config-level guard is possible. The matcher is already `Bash|Write|Edit|MultiEdit`.
- `auto-tmux-dev` and the insaits wrapper are not standalone hooks.json entries (they are sub-hooks within the bash dispatcher or unregistered scripts respectively).

## Testing Done
- `node tests/hooks/hooks.test.js` — 250/250 passed
- New test: `MCP health-check hooks use tight mcp__.* matcher instead of wildcard`

## Type of Change
- [x] `fix:` Bug fix
- [x] `test:` Tests