### PR TITLE
fix(scripts): detect and remove legacy sync-ecc-to-codex.sh installs

### DIFF
--- a/scripts/lib/codex-legacy-sync.js
+++ b/scripts/lib/codex-legacy-sync.js
@@ -475,6 +475,26 @@ function listLegacyCandidates(codexHome) {
   return candidates;
 }
 
+function hasMarkerBlock(codexHome) {
+  const agentsPath = path.join(codexHome, 'AGENTS.md');
+  try {
+    const snapshot = readRegularFileNoFollow(agentsPath, 'utf8');
+    if (snapshot) {
+      const stripped = stripMarkerBlock(snapshot.content);
+      return stripped !== snapshot.content;
+    }
+  } catch (_error) {
+    // Non-regular or unreadable AGENTS.md is not a clean marker signal.
+  }
+  return false;
+}
+
+function detectLegacyCodexSync(codexHome) {
+  const resolvedCodexHome = path.resolve(codexHome || process.env.CODEX_HOME || path.join(process.env.HOME || os.homedir(), '.codex'));
+  if (readStateIfPresent(getStatePath(resolvedCodexHome))) return true;
+  return hasMarkerBlock(resolvedCodexHome);
+}
+
 function uninstallLegacyCodexSync(options = {}) {
   const codexHome = path.resolve(options.codexHome || process.env.CODEX_HOME || path.join(process.env.HOME || os.homedir(), '.codex'));
   const statePath = getStatePath(codexHome);
@@ -498,13 +518,17 @@ function uninstallLegacyCodexSync(options = {}) {
         }
       }
     } catch (_error) {
-      retainedPaths.push(agentsPath);
+      if (_error.code !== 'ENOENT') retainedPaths.push(agentsPath);
     } finally {
       if (openedAgents) fs.closeSync(openedAgents.descriptor);
     }
     retainedPaths.push(...listLegacyCandidates(codexHome));
+    const hasWork = plannedRemovals.length > 0 || removedPaths.length > 0;
+    const status = dryRun
+      ? (hasWork || retainedPaths.length > 0 ? 'planned' : 'not-found')
+      : (retainedPaths.length > 0 ? 'partial' : (hasWork ? 'uninstalled' : 'not-found'));
     return {
-      status: dryRun ? 'planned' : retainedPaths.length > 0 ? 'partial' : plannedRemovals.length > 0 ? 'uninstalled' : 'not-found',
+      status,
       statePath: null,
       plannedRemovals,
       removedPaths,
@@ -594,6 +618,7 @@ module.exports = {
   END_MARKER,
   SCHEMA,
   beginLegacySyncState,
+  detectLegacyCodexSync,
   finalizeLegacySyncState,
   getStatePath,
   recordLegacySyncPath,

--- a/scripts/lib/codex-legacy-sync.js
+++ b/scripts/lib/codex-legacy-sync.js
@@ -483,8 +483,15 @@ function hasMarkerBlock(codexHome) {
       const stripped = stripMarkerBlock(snapshot.content);
       return stripped !== snapshot.content;
     }
-  } catch (_error) {
-    // Non-regular or unreadable AGENTS.md is not a clean marker signal.
+  } catch (error) {
+    // Only ENOENT means "no AGENTS.md" → no marker. Any other error
+    // (EACCES, EMFILE, EISDIR, symlink-ELOOP, ...) is an indeterminate
+    // inspection result and must propagate so callers do not read it as
+    // "clean home". Throwing here is intentional per the repo coding
+    // guideline: "Always handle errors explicitly at every level and never
+    // silently swallow errors."
+    if (error && error.code === 'ENOENT') return false;
+    throw error;
   }
   return false;
 }

--- a/scripts/lib/codex-legacy-sync.js
+++ b/scripts/lib/codex-legacy-sync.js
@@ -489,8 +489,17 @@ function hasMarkerBlock(codexHome) {
   return false;
 }
 
+function resolveCodexHome(codexHome) {
+  return path.resolve(codexHome || process.env.CODEX_HOME || path.join(process.env.HOME || os.homedir(), '.codex'));
+}
+
+function legacyCodexSyncStateExists(codexHome) {
+  const resolvedCodexHome = resolveCodexHome(codexHome);
+  return readStateIfPresent(getStatePath(resolvedCodexHome)) !== null;
+}
+
 function detectLegacyCodexSync(codexHome) {
-  const resolvedCodexHome = path.resolve(codexHome || process.env.CODEX_HOME || path.join(process.env.HOME || os.homedir(), '.codex'));
+  const resolvedCodexHome = resolveCodexHome(codexHome);
   if (readStateIfPresent(getStatePath(resolvedCodexHome))) return true;
   return hasMarkerBlock(resolvedCodexHome);
 }
@@ -514,7 +523,10 @@ function uninstallLegacyCodexSync(options = {}) {
         const stripped = stripMarkerBlock(content);
         if (stripped !== content) {
           plannedRemovals.push(`${agentsPath}#ecc-marker-block`);
-          if (!dryRun) replaceOpenedRegularFile(openedAgents, stripped, openedAgents.stat.mode & 0o777);
+          if (!dryRun) {
+            replaceOpenedRegularFile(openedAgents, stripped, openedAgents.stat.mode & 0o777);
+            removedPaths.push(agentsPath);
+          }
         }
       }
     } catch (_error) {
@@ -621,6 +633,7 @@ module.exports = {
   detectLegacyCodexSync,
   finalizeLegacySyncState,
   getStatePath,
+  legacyCodexSyncStateExists,
   recordLegacySyncPath,
   rollbackLegacyCodexSync,
   stripMarkerBlock,

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -5,7 +5,10 @@ const path = require('path');
 const { uninstallInstalledStates } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 const { exitFeedbackLines } = require('./lib/feedback-links');
-const { uninstallLegacyCodexSync } = require('./lib/codex-legacy-sync');
+const {
+  detectLegacyCodexSync,
+  uninstallLegacyCodexSync,
+} = require('./lib/codex-legacy-sync');
 
 function showHelp(exitCode = 0) {
   console.log(`
@@ -90,12 +93,8 @@ function printHuman(result) {
   }
 }
 
-function detectLegacyCodexSync(codexHome) {
-  const probe = uninstallLegacyCodexSync({
-    codexHome,
-    dryRun: true,
-  });
-  return probe.status !== 'not-found';
+function legacyCodexSyncDetected(codexHome) {
+  return detectLegacyCodexSync(codexHome);
 }
 
 function printLegacy(result, dryRun) {
@@ -149,7 +148,7 @@ async function main() {
       if (
         result.results.length === 0
         && includesCodexTarget(options.targets)
-        && detectLegacyCodexSync(codexHomePath())
+        && legacyCodexSyncDetected(codexHomePath())
       ) {
         result = uninstallLegacyCodexSync({
           codexHome: codexHomePath(),

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const os = require('os');
+const path = require('path');
 const { uninstallInstalledStates } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 const { exitFeedbackLines } = require('./lib/feedback-links');
@@ -11,7 +12,9 @@ function showHelp(exitCode = 0) {
 Usage: node scripts/uninstall.js [--target <${SUPPORTED_INSTALL_TARGETS.join('|')}>] [--legacy-codex-sync] [--dry-run] [--json]
 
 Remove ECC-managed files recorded in install-state for the current context.
-Use --legacy-codex-sync explicitly for the older sync-ecc-to-codex.sh installation.
+When no install-state is found, the uninstaller also detects and removes
+artifacts left by the older scripts/sync-ecc-to-codex.sh installer.
+Use --legacy-codex-sync to force the legacy path explicitly.
 `);
   process.exit(exitCode);
 }
@@ -87,6 +90,34 @@ function printHuman(result) {
   }
 }
 
+function detectLegacyCodexSync(codexHome) {
+  const probe = uninstallLegacyCodexSync({
+    codexHome,
+    dryRun: true,
+  });
+  return probe.status !== 'not-found';
+}
+
+function printLegacy(result, dryRun) {
+  console.log('Legacy Codex sync cleanup summary:\n');
+  console.log(`Status: ${result.status.toUpperCase()}`);
+  const paths = dryRun ? result.plannedRemovals : result.removedPaths;
+  console.log(`${dryRun ? 'Planned changes' : 'Removed paths'}: ${paths.length}`);
+  if (result.retainedPaths.length > 0) {
+    console.log(`Retained paths: ${result.retainedPaths.length}`);
+    for (const retainedPath of result.retainedPaths) console.log(`  - ${retainedPath}`);
+  }
+  for (const warning of result.warnings) console.log(`Warning: ${warning}`);
+}
+
+function codexHomePath() {
+  return process.env.CODEX_HOME || path.join(process.env.HOME || os.homedir(), '.codex');
+}
+
+function includesCodexTarget(targets) {
+  return targets.length === 0 || targets.includes('codex');
+}
+
 async function main() {
   try {
     const options = parseArgs(process.argv);
@@ -97,41 +128,54 @@ async function main() {
     if (options.legacyCodexSync && options.targets.length > 0) {
       throw new Error('--legacy-codex-sync cannot be combined with --target');
     }
-    const result = options.legacyCodexSync
-      ? uninstallLegacyCodexSync({
-          codexHome: process.env.CODEX_HOME,
-          dryRun: options.dryRun,
-        })
-      : uninstallInstalledStates({
-          homeDir: process.env.HOME || os.homedir(),
-          projectRoot: process.cwd(),
-          targets: options.targets,
-          dryRun: options.dryRun,
-        });
-    if (!options.dryRun && !options.legacyCodexSync) {
-      const { reconcileCanonicalInstallStates } = require('./lib/install-state-store-sync');
-      result.installStateProjection = await reconcileCanonicalInstallStates({
+
+    let result;
+    let mode = 'install-state';
+
+    if (options.legacyCodexSync) {
+      result = uninstallLegacyCodexSync({
+        codexHome: codexHomePath(),
+        dryRun: options.dryRun,
+      });
+      mode = 'legacy-codex-sync';
+    } else {
+      result = uninstallInstalledStates({
         homeDir: process.env.HOME || os.homedir(),
         projectRoot: process.cwd(),
         targets: options.targets,
+        dryRun: options.dryRun,
       });
+
+      if (
+        result.results.length === 0
+        && includesCodexTarget(options.targets)
+        && detectLegacyCodexSync(codexHomePath())
+      ) {
+        result = uninstallLegacyCodexSync({
+          codexHome: codexHomePath(),
+          dryRun: options.dryRun,
+        });
+        mode = 'legacy-codex-sync';
+      }
+
+      if (mode === 'install-state' && !options.dryRun) {
+        const { reconcileCanonicalInstallStates } = require('./lib/install-state-store-sync');
+        result.installStateProjection = await reconcileCanonicalInstallStates({
+          homeDir: process.env.HOME || os.homedir(),
+          projectRoot: process.cwd(),
+          targets: options.targets,
+        });
+      }
     }
-    const hasErrors = options.legacyCodexSync
+
+    const hasErrors = mode === 'legacy-codex-sync'
       ? result.status === 'partial'
       : result.summary.errorCount > 0 || result.summary.partialCount > 0;
 
     if (options.json) {
       console.log(JSON.stringify(result, null, 2));
-    } else if (options.legacyCodexSync) {
-      console.log('Legacy Codex sync cleanup summary:\n');
-      console.log(`Status: ${result.status.toUpperCase()}`);
-      const paths = options.dryRun ? result.plannedRemovals : result.removedPaths;
-      console.log(`${options.dryRun ? 'Planned changes' : 'Removed paths'}: ${paths.length}`);
-      if (result.retainedPaths.length > 0) {
-        console.log(`Retained paths: ${result.retainedPaths.length}`);
-        for (const retainedPath of result.retainedPaths) console.log(`  - ${retainedPath}`);
-      }
-      for (const warning of result.warnings) console.log(`Warning: ${warning}`);
+    } else if (mode === 'legacy-codex-sync') {
+      printLegacy(result, options.dryRun);
     } else {
       printHuman(result);
     }

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -6,7 +6,7 @@ const { uninstallInstalledStates } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 const { exitFeedbackLines } = require('./lib/feedback-links');
 const {
-  detectLegacyCodexSync,
+  legacyCodexSyncStateExists,
   uninstallLegacyCodexSync,
 } = require('./lib/codex-legacy-sync');
 
@@ -16,8 +16,9 @@ Usage: node scripts/uninstall.js [--target <${SUPPORTED_INSTALL_TARGETS.join('|'
 
 Remove ECC-managed files recorded in install-state for the current context.
 When no install-state is found, the uninstaller also detects and removes
-artifacts left by the older scripts/sync-ecc-to-codex.sh installer.
-Use --legacy-codex-sync to force the legacy path explicitly.
+legacy sync-ecc-to-codex.sh artifacts, but only when a legacy ownership
+manifest is present. Use --legacy-codex-sync to force the legacy path
+explicitly, including marker-only AGENTS.md cleanup.
 `);
   process.exit(exitCode);
 }
@@ -93,8 +94,8 @@ function printHuman(result) {
   }
 }
 
-function legacyCodexSyncDetected(codexHome) {
-  return detectLegacyCodexSync(codexHome);
+function legacyCodexSyncStateDetected(codexHome) {
+  return legacyCodexSyncStateExists(codexHome);
 }
 
 function printLegacy(result, dryRun) {
@@ -148,7 +149,7 @@ async function main() {
       if (
         result.results.length === 0
         && includesCodexTarget(options.targets)
-        && legacyCodexSyncDetected(codexHomePath())
+        && legacyCodexSyncStateDetected(codexHomePath())
       ) {
         result = uninstallLegacyCodexSync({
           codexHome: codexHomePath(),

--- a/tests/lib/codex-legacy-sync.test.js
+++ b/tests/lib/codex-legacy-sync.test.js
@@ -7,6 +7,7 @@ const path = require('path');
 
 const {
   beginLegacySyncState,
+  detectLegacyCodexSync,
   finalizeLegacySyncState,
   recordLegacySyncPath,
   rollbackLegacyCodexSync,
@@ -518,6 +519,53 @@ function runTests() {
     const uninstall = uninstallLegacyCodexSync({ codexHome });
     assert.strictEqual(uninstall.status, 'uninstalled');
     assert.strictEqual(fs.readFileSync(promptPath, 'utf8'), '# Original user prompt\n');
+    fs.rmSync(homeDir, { recursive: true, force: true });
+  })) passed += 1; else failed += 1;
+
+  if (test('detectLegacyCodexSync surfaces unreadable AGENTS.md instead of reporting clean', () => {
+    // hasMarkerBlock previously swallowed every read/open error and returned false,
+    // which made detectLegacyCodexSync claim a clean home even when AGENTS.md was
+    // unreadable (EACCES, EMFILE, ...). The fix is to rethrow every error except
+    // ENOENT (a missing file is a legitimate "no marker" signal).
+    const homeDir = tempDir('legacy-codex-home-');
+    const codexHome = path.join(homeDir, '.codex');
+    const agentsPath = path.join(codexHome, 'AGENTS.md');
+    fs.mkdirSync(codexHome, { recursive: true });
+    fs.writeFileSync(agentsPath, '# User instructions\n<!-- BEGIN ECC -->\n<!-- END ECC -->\n');
+
+    // chmod 000 to make AGENTS.md unreadable. Skip when running as root because
+    // root bypasses mode bits and the test would not exercise the error path.
+    if (typeof process.getuid === 'function' && process.getuid() !== 0) {
+      fs.chmodSync(agentsPath, 0o000);
+      let threw = null;
+      try {
+        detectLegacyCodexSync(codexHome);
+      } catch (error) {
+        threw = error;
+      }
+      assert.ok(threw, 'detectLegacyCodexSync must propagate the read error');
+      assert.notStrictEqual(threw && threw.code, 'ENOENT');
+      fs.chmodSync(agentsPath, 0o600);
+    } else {
+      // Root path: simulate the same failure by replacing AGENTS.md with a
+      // directory — openRegularFileNoFollow then throws EACCES-on-open on
+      // Linux when the path resolves to a non-regular file.
+      fs.rmSync(agentsPath);
+      fs.mkdirSync(agentsPath);
+      let threw = null;
+      try {
+        detectLegacyCodexSync(codexHome);
+      } catch (error) {
+        threw = error;
+      }
+      assert.ok(threw, 'detectLegacyCodexSync must propagate the inspection error');
+      fs.rmSync(agentsPath, { recursive: true });
+    }
+
+    // Sanity check: a missing AGENTS.md is still treated as no-marker (not an error).
+    fs.rmSync(agentsPath, { force: true });
+    assert.strictEqual(detectLegacyCodexSync(codexHome), false);
+
     fs.rmSync(homeDir, { recursive: true, force: true });
   })) passed += 1; else failed += 1;
 

--- a/tests/scripts/uninstall.test.js
+++ b/tests/scripts/uninstall.test.js
@@ -44,15 +44,9 @@ function writeState(filePath, options) {
 }
 
 function run(args = [], options = {}) {
-  const env = {
-    ...process.env,
-    HOME: options.homeDir || process.env.HOME,
-  };
-  if (options.homeDir) {
-    env.CODEX_HOME = path.join(options.homeDir, '.codex');
-  } else {
-    delete env.CODEX_HOME;
-  }
+  const env = options.homeDir
+    ? { ...process.env, HOME: options.homeDir, CODEX_HOME: path.join(options.homeDir, '.codex') }
+    : Object.fromEntries(Object.entries(process.env).filter(([key]) => key !== 'CODEX_HOME'))
 
   try {
     const stdout = execFileSync('node', [SCRIPT, ...args], {
@@ -462,6 +456,63 @@ function runTests() {
       assert.deepStrictEqual(parsed.plannedRemovals, []);
       assert.deepStrictEqual(parsed.retainedPaths, []);
       assert.strictEqual(fs.readFileSync(configPath, 'utf8'), 'model = "user"\n');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('does not auto-fallback to a marker-only AGENTS.md without a legacy ownership manifest', () => {
+    const homeDir = createTempDir('uninstall-marker-only-codex-home-');
+    const projectRoot = createTempDir('uninstall-marker-only-codex-project-');
+
+    try {
+      const codexHome = path.join(homeDir, '.codex');
+      const configPath = path.join(codexHome, 'config.toml');
+      const agentsPath = path.join(codexHome, 'AGENTS.md');
+      const conversationPath = path.join(codexHome, 'conversations', 'keep-me.md');
+
+      fs.mkdirSync(codexHome, { recursive: true });
+      fs.writeFileSync(configPath, 'model = "user"\n');
+      fs.writeFileSync(
+        agentsPath,
+        '# User instructions\n\n<!-- BEGIN ECC -->\n# ECC managed\n<!-- END ECC -->\n'
+      );
+      fs.mkdirSync(path.dirname(conversationPath), { recursive: true });
+      fs.writeFileSync(conversationPath, 'conversation history');
+
+      const uninstallResult = run([], { cwd: projectRoot, homeDir });
+      assert.strictEqual(uninstallResult.code, 0, uninstallResult.stderr);
+      assert.ok(uninstallResult.stdout.includes('No ECC install-state files found'), uninstallResult.stdout);
+      assert.ok(!uninstallResult.stdout.includes('Legacy Codex sync cleanup summary'), uninstallResult.stdout);
+      assert.strictEqual(fs.readFileSync(agentsPath, 'utf8'), '# User instructions\n\n<!-- BEGIN ECC -->\n# ECC managed\n<!-- END ECC -->\n');
+      assert.strictEqual(fs.readFileSync(configPath, 'utf8'), 'model = "user"\n');
+      assert.strictEqual(fs.readFileSync(conversationPath, 'utf8'), 'conversation history');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('explicit --legacy-codex-sync removes a marker-only AGENTS.md block', () => {
+    const homeDir = createTempDir('uninstall-explicit-marker-codex-home-');
+    const projectRoot = createTempDir('uninstall-explicit-marker-codex-project-');
+
+    try {
+      const codexHome = path.join(homeDir, '.codex');
+      const agentsPath = path.join(codexHome, 'AGENTS.md');
+
+      fs.mkdirSync(codexHome, { recursive: true });
+      fs.writeFileSync(
+        agentsPath,
+        '# User instructions\n\n<!-- BEGIN ECC -->\n# ECC managed\n<!-- END ECC -->\n'
+      );
+
+      const uninstallResult = run(['--legacy-codex-sync'], { cwd: projectRoot, homeDir });
+      assert.strictEqual(uninstallResult.code, 0, uninstallResult.stderr);
+      assert.ok(uninstallResult.stdout.includes('Legacy Codex sync cleanup summary'), uninstallResult.stdout);
+      assert.ok(uninstallResult.stdout.includes('Status: UNINSTALLED'), uninstallResult.stdout);
+      assert.strictEqual(fs.readFileSync(agentsPath, 'utf8'), '# User instructions\n\n');
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);

--- a/tests/scripts/uninstall.test.js
+++ b/tests/scripts/uninstall.test.js
@@ -23,6 +23,11 @@ const {
   createInstallState,
   writeInstallState,
 } = require('../../scripts/lib/install-state');
+const {
+  beginLegacySyncState,
+  recordLegacySyncPath,
+  finalizeLegacySyncState,
+} = require('../../scripts/lib/codex-legacy-sync');
 
 function createTempDir(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -43,6 +48,11 @@ function run(args = [], options = {}) {
     ...process.env,
     HOME: options.homeDir || process.env.HOME,
   };
+  if (options.homeDir) {
+    env.CODEX_HOME = path.join(options.homeDir, '.codex');
+  } else {
+    delete env.CODEX_HOME;
+  }
 
   try {
     const stdout = execFileSync('node', [SCRIPT, ...args], {
@@ -349,6 +359,59 @@ function runTests() {
       assert.ok(applied.stdout.includes(editedPath));
       assert.ok(fs.existsSync(editedPath));
       assert.ok(fs.existsSync(statePath));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('auto-detects legacy sync-ecc-to-codex.sh install and removes artifacts without touching conversations or unrelated config keys', () => {
+    const homeDir = createTempDir('uninstall-legacy-codex-home-');
+    const projectRoot = createTempDir('uninstall-legacy-codex-project-');
+
+    try {
+      const codexHome = path.join(homeDir, '.codex');
+      const configPath = path.join(codexHome, 'config.toml');
+      const agentsPath = path.join(codexHome, 'AGENTS.md');
+      const promptPath = path.join(codexHome, 'prompts', 'ecc-plan.md');
+      const conversationPath = path.join(codexHome, 'conversations', 'keep-me.md');
+      const userFilePath = path.join(codexHome, 'user-owned.txt');
+
+      fs.mkdirSync(codexHome, { recursive: true });
+      fs.writeFileSync(configPath, 'model = "user"\n');
+      fs.writeFileSync(agentsPath, '# User instructions\n');
+      fs.mkdirSync(path.dirname(promptPath), { recursive: true });
+
+      const statePath = beginLegacySyncState({
+        codexHome,
+        backupDir: path.join(codexHome, 'backups', 'ecc-test'),
+      });
+      recordLegacySyncPath({ statePath, filePath: configPath });
+      recordLegacySyncPath({ statePath, filePath: agentsPath });
+      recordLegacySyncPath({ statePath, filePath: promptPath });
+
+      fs.writeFileSync(configPath, 'model = "user"\napproval_policy = "on-request"\n');
+      fs.writeFileSync(
+        agentsPath,
+        '# User instructions\n\n<!-- BEGIN ECC -->\n# ECC managed\n<!-- END ECC -->\n'
+      );
+      fs.writeFileSync(promptPath, '# ECC generated prompt\n');
+      finalizeLegacySyncState({ statePath });
+
+      fs.mkdirSync(path.dirname(conversationPath), { recursive: true });
+      fs.writeFileSync(conversationPath, 'conversation history');
+      fs.writeFileSync(userFilePath, 'unrelated');
+
+      const uninstallResult = run([], { cwd: projectRoot, homeDir });
+      assert.strictEqual(uninstallResult.code, 0, uninstallResult.stderr);
+      assert.ok(!uninstallResult.stdout.includes('No ECC install-state files found'), uninstallResult.stdout);
+      assert.ok(uninstallResult.stdout.includes('Legacy Codex sync cleanup summary'), uninstallResult.stdout);
+      assert.ok(!fs.existsSync(promptPath));
+      assert.strictEqual(fs.readFileSync(configPath, 'utf8'), 'model = "user"\n');
+      assert.strictEqual(fs.readFileSync(agentsPath, 'utf8'), '# User instructions\n');
+      assert.strictEqual(fs.readFileSync(conversationPath, 'utf8'), 'conversation history');
+      assert.strictEqual(fs.readFileSync(userFilePath, 'utf8'), 'unrelated');
+      assert.ok(!fs.existsSync(statePath));
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);

--- a/tests/scripts/uninstall.test.js
+++ b/tests/scripts/uninstall.test.js
@@ -418,6 +418,56 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('does not misclassify a clean Codex home as a legacy install', () => {
+    const homeDir = createTempDir('uninstall-clean-codex-home-');
+    const projectRoot = createTempDir('uninstall-clean-codex-project-');
+
+    try {
+      const codexHome = path.join(homeDir, '.codex');
+      const configPath = path.join(codexHome, 'config.toml');
+      const conversationPath = path.join(codexHome, 'conversations', 'keep-me.md');
+
+      fs.mkdirSync(codexHome, { recursive: true });
+      fs.writeFileSync(configPath, 'model = "user"\n');
+      fs.mkdirSync(path.dirname(conversationPath), { recursive: true });
+      fs.writeFileSync(conversationPath, 'conversation history');
+
+      const uninstallResult = run([], { cwd: projectRoot, homeDir });
+      assert.strictEqual(uninstallResult.code, 0, uninstallResult.stderr);
+      assert.ok(uninstallResult.stdout.includes('No ECC install-state files found'), uninstallResult.stdout);
+      assert.ok(!uninstallResult.stdout.includes('Legacy Codex sync cleanup summary'), uninstallResult.stdout);
+      assert.strictEqual(fs.readFileSync(configPath, 'utf8'), 'model = "user"\n');
+      assert.strictEqual(fs.readFileSync(conversationPath, 'utf8'), 'conversation history');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('explicit --legacy-codex-sync on a clean home reports not-found without removing files', () => {
+    const homeDir = createTempDir('uninstall-legacy-clean-home-');
+    const projectRoot = createTempDir('uninstall-legacy-clean-project-');
+
+    try {
+      const codexHome = path.join(homeDir, '.codex');
+      const configPath = path.join(codexHome, 'config.toml');
+
+      fs.mkdirSync(codexHome, { recursive: true });
+      fs.writeFileSync(configPath, 'model = "user"\n');
+
+      const uninstallResult = run(['--legacy-codex-sync', '--json'], { cwd: projectRoot, homeDir });
+      assert.strictEqual(uninstallResult.code, 0, uninstallResult.stderr);
+      const parsed = JSON.parse(uninstallResult.stdout);
+      assert.strictEqual(parsed.status, 'not-found');
+      assert.deepStrictEqual(parsed.plannedRemovals, []);
+      assert.deepStrictEqual(parsed.retainedPaths, []);
+      assert.strictEqual(fs.readFileSync(configPath, 'utf8'), 'model = "user"\n');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## What Changed

- `scripts/uninstall.js` now falls back to the legacy `sync-ecc-to-codex.sh` cleanup path when no install-state files are found for the current context.
- It detects the ownership manifest written by `sync-ecc-to-codex.sh` at `~/.codex/ecc/legacy-sync-state.json` and rolls back the managed files recorded there.
- `config.toml` and `AGENTS.md` are restored to their pre-sync content instead of being deleted; generated prompts, docs, and copied files are removed.
- Unrelated Codex conversation history and user config keys are left untouched.
- A new `--legacy-codex-sync` flag still forces the legacy path explicitly, and `--dry-run` previews it.
- Added a regression test in `tests/scripts/uninstall.test.js` covering a fake `sync-ecc-to-codex.sh` install.

## Why This Change

Fixes #2771: `node scripts/ecc.js uninstall` and `npx ecc-universal uninstall` previously failed with "No ECC install-stage files for current home/project context" for users who installed via the legacy `sync-ecc-to-codex.sh` script, which does not write install-state metadata.

## Testing Done

- [x] Manual testing completed — verified `ecc uninstall` against a fake `~/.codex` sync layout
- [x] Automated tests pass locally (`npm test`) — 3940 passed, 0 failed
- [x] Edge cases considered and tested — dry-run, explicit `--legacy-codex-sync`, unrelated `config.toml` keys and conversations preserved

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## If you changed dependencies or `package.json` (`bin` / `files` / deps)

N/A.

## If you added a skill, command, agent, hook, or CLI tool

N/A.

## Documentation

- [ ] Updated relevant documentation
- [x] Added comments for complex logic (help text and test descriptions)
- [ ] README updated (if needed)
