### PR TITLE
fix(hooks): price Sonnet 5 at the published $2/$10 rate

### DIFF
--- a/scripts/hooks/cost-tracker.js
+++ b/scripts/hooks/cost-tracker.js
@@ -71,15 +71,21 @@ function readHarnessCost(sessionId, maxAgeSeconds) {
 // Approximate per-1M-token billing rates (USD).
 // Cache creation: 1.25x input rate. Cache read: 0.1x input rate.
 const RATE_TABLE = {
-  haiku:  { in: 0.80,  out: 4.0,  cacheWrite: 1.00,  cacheRead: 0.08 },
-  sonnet: { in: 3.00,  out: 15.0, cacheWrite: 3.75,  cacheRead: 0.30 },
-  opus:   { in: 15.00, out: 75.0, cacheWrite: 18.75, cacheRead: 1.50 }
+  haiku:    { in: 0.80,  out: 4.0,  cacheWrite: 1.00,  cacheRead: 0.08 },
+  sonnet:   { in: 3.00,  out: 15.0, cacheWrite: 3.75,  cacheRead: 0.30 },
+  sonnet5:  { in: 2.00,  out: 10.0, cacheWrite: 2.50,  cacheRead: 0.20 },
+  opus:     { in: 15.00, out: 75.0, cacheWrite: 18.75, cacheRead: 1.50 }
 };
+
+function isSonnet5(model) {
+  return /(?:^|[^a-z0-9])sonnet-5(?:[^a-z0-9]|$)/.test(model);
+}
 
 function getRates(model) {
   const m = String(model || '').toLowerCase();
-  if (m.includes('haiku')) return RATE_TABLE.haiku;
-  if (m.includes('opus'))  return RATE_TABLE.opus;
+  if (m.includes('haiku'))  return RATE_TABLE.haiku;
+  if (isSonnet5(m))        return RATE_TABLE.sonnet5;
+  if (m.includes('opus'))   return RATE_TABLE.opus;
   return RATE_TABLE.sonnet;
 }
 

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -467,11 +467,10 @@ function runTests() {
     }
   }) ? passed++ : failed++);
 
-  // 10b. Dated Sonnet 5 IDs and near-misses are matched correctly.
-  (test('prices dated Sonnet 5 IDs at $12 and rejects claude-sonnet-50 near-miss', () => {
+  // 10b. Dated Sonnet 5 IDs are matched correctly.
+  (test('prices dated Sonnet 5 IDs at $12', () => {
     const tmpHome = makeTempDir();
     const sessionId = `sonnet5-dated-${process.pid}-${Date.now()}`;
-    const nearMissSessionId = `sonnet50-near-miss-${process.pid}-${Date.now()}`;
     const transcriptPath = path.join(tmpHome, 'session.jsonl');
     writeTranscript(transcriptPath, [
       {
@@ -486,7 +485,6 @@ function runTests() {
 
     try {
       removeHarnessCostCache(sessionId);
-      removeHarnessCostCache(nearMissSessionId);
       const result = runScript(
         { session_id: sessionId, transcript_path: transcriptPath },
         withTempHome(tmpHome)
@@ -496,32 +494,41 @@ function runTests() {
       const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
       const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
       assert.strictEqual(row.estimated_cost_usd, 12, 'Expected dated Sonnet 5 1M/1M to cost $12.00');
-
-      // Near-miss `claude-sonnet-50` must fall through to the standard Sonnet rate.
-      const nearMissPath = path.join(tmpHome, 'near-miss.jsonl');
-      writeTranscript(nearMissPath, [
-        {
-          type: 'assistant',
-          message: {
-            id: 'msg_sonnet50',
-            model: 'claude-sonnet-50',
-            usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
-          },
-        },
-      ]);
-
-      const nearResult = runScript(
-        { session_id: nearMissSessionId, transcript_path: nearMissPath },
-        withTempHome(tmpHome)
-      );
-      assert.strictEqual(nearResult.code, 0, `Expected exit code 0, got ${nearResult.code}`);
-
-      const lines = fs.readFileSync(metricsFile, 'utf8').trim().split('\n');
-      const nearRow = JSON.parse(lines[lines.length - 1]);
-      assert.strictEqual(nearRow.estimated_cost_usd, 18, 'Expected claude-sonnet-50 near-miss to fall back to $18.00 Sonnet rate');
     } finally {
       removeHarnessCostCache(sessionId);
-      removeHarnessCostCache(nearMissSessionId);
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }) ? passed++ : failed++);
+
+  // 10c. Near-miss Sonnet 5 IDs fall back to standard Sonnet rates.
+  (test('rejects claude-sonnet-50 as a Sonnet 5 near-miss', () => {
+    const tmpHome = makeTempDir();
+    const sessionId = `sonnet50-near-miss-${process.pid}-${Date.now()}`;
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [
+      {
+        type: 'assistant',
+        message: {
+          id: 'msg_sonnet50',
+          model: 'claude-sonnet-50',
+          usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+        },
+      },
+    ]);
+
+    try {
+      removeHarnessCostCache(sessionId);
+      const result = runScript(
+        { session_id: sessionId, transcript_path: transcriptPath },
+        withTempHome(tmpHome)
+      );
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+
+      const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+      const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+      assert.strictEqual(row.estimated_cost_usd, 18, 'Expected claude-sonnet-50 near-miss to fall back to $18.00 Sonnet rate');
+    } finally {
+      removeHarnessCostCache(sessionId);
       fs.rmSync(tmpHome, { recursive: true, force: true });
     }
   }) ? passed++ : failed++);

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -300,6 +300,7 @@ function runTests() {
   // 9. Prices Sonnet 5 at the documented $2/$10 rate.
   (test('prices Sonnet 5 at $12 per 1M input + 1M output tokens', () => {
     const tmpHome = makeTempDir();
+    const sessionId = 'sonnet5-' + Date.now();
     const transcriptPath = path.join(tmpHome, 'session.jsonl');
     writeTranscript(transcriptPath, [
       {
@@ -313,7 +314,7 @@ function runTests() {
     ]);
 
     const result = runScript(
-      { session_id: 'sonnet5-session', transcript_path: transcriptPath },
+      { session_id: sessionId, transcript_path: transcriptPath },
       withTempHome(tmpHome)
     );
     assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
@@ -328,6 +329,7 @@ function runTests() {
   // 9b. Sonnet 5 cache write/read tokens use the correct rates.
   (test('prices Sonnet 5 cache tokens at the documented rates', () => {
     const tmpHome = makeTempDir();
+    const sessionId = 'sonnet5-cache-' + Date.now();
     const transcriptPath = path.join(tmpHome, 'session.jsonl');
     writeTranscript(transcriptPath, [
       {
@@ -346,7 +348,7 @@ function runTests() {
     ]);
 
     const result = runScript(
-      { session_id: 'sonnet5-cache-session', transcript_path: transcriptPath },
+      { session_id: sessionId, transcript_path: transcriptPath },
       withTempHome(tmpHome)
     );
     assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
@@ -361,6 +363,7 @@ function runTests() {
   // 10. Sonnet 4.6 keeps the existing $3/$15 rate and is not mistaken for Sonnet 5.
   (test('prices Sonnet 4.6 at $18 per 1M input + 1M output tokens', () => {
     const tmpHome = makeTempDir();
+    const sessionId = 'sonnet46-' + Date.now();
     const transcriptPath = path.join(tmpHome, 'session.jsonl');
     writeTranscript(transcriptPath, [
       {
@@ -374,7 +377,7 @@ function runTests() {
     ]);
 
     const result = runScript(
-      { session_id: 'sonnet46-session', transcript_path: transcriptPath },
+      { session_id: sessionId, transcript_path: transcriptPath },
       withTempHome(tmpHome)
     );
     assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
@@ -389,6 +392,7 @@ function runTests() {
   // 10b. Dated Sonnet 5 IDs and near-misses are matched correctly.
   (test('prices dated Sonnet 5 IDs at $12 and rejects claude-sonnet-50 near-miss', () => {
     const tmpHome = makeTempDir();
+    const sessionId = 'sonnet5-dated-' + Date.now();
     const transcriptPath = path.join(tmpHome, 'session.jsonl');
     writeTranscript(transcriptPath, [
       {
@@ -402,7 +406,7 @@ function runTests() {
     ]);
 
     const result = runScript(
-      { session_id: 'sonnet5-dated-session', transcript_path: transcriptPath },
+      { session_id: sessionId, transcript_path: transcriptPath },
       withTempHome(tmpHome)
     );
     assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
@@ -425,7 +429,7 @@ function runTests() {
     ]);
 
     const nearResult = runScript(
-      { session_id: 'sonnet50-near-miss-session', transcript_path: nearMissPath },
+      { session_id: 'sonnet50-near-miss-' + Date.now(), transcript_path: nearMissPath },
       withTempHome(tmpHome)
     );
     assert.strictEqual(nearResult.code, 0, `Expected exit code 0, got ${nearResult.code}`);

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -54,6 +54,15 @@ function runScript(input, envOverrides = {}) {
   return { code: result.status || 0, stdout: result.stdout || '', stderr: result.stderr || '' };
 }
 
+function removeHarnessCostCache(sessionId) {
+  const cachePath = path.join(os.tmpdir(), `harness-cost-${sessionId}.json`);
+  try {
+    fs.unlinkSync(cachePath);
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+  }
+}
+
 function runTests() {
   console.log('\n=== Testing cost-tracker.js ===\n');
 
@@ -300,7 +309,7 @@ function runTests() {
   // 9. Prices Sonnet 5 at the documented $2/$10 rate.
   (test('prices Sonnet 5 at $12 per 1M input + 1M output tokens', () => {
     const tmpHome = makeTempDir();
-    const sessionId = 'sonnet5-' + Date.now();
+    const sessionId = `sonnet5-${process.pid}-${Date.now()}`;
     const transcriptPath = path.join(tmpHome, 'session.jsonl');
     writeTranscript(transcriptPath, [
       {
@@ -313,23 +322,33 @@ function runTests() {
       },
     ]);
 
-    const result = runScript(
-      { session_id: sessionId, transcript_path: transcriptPath },
-      withTempHome(tmpHome)
+    fs.writeFileSync(
+      path.join(os.tmpdir(), `harness-cost-${sessionId}.json`),
+      JSON.stringify({ ts: Math.floor(Date.now() / 1000), cost_usd: 999 }),
+      'utf8'
     );
-    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
 
-    const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
-    const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
-    assert.strictEqual(row.estimated_cost_usd, 12, 'Expected Sonnet 5 1M/1M to cost $12.00');
+    try {
+      removeHarnessCostCache(sessionId);
+      const result = runScript(
+        { session_id: sessionId, transcript_path: transcriptPath },
+        withTempHome(tmpHome)
+      );
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
 
-    fs.rmSync(tmpHome, { recursive: true, force: true });
+      const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+      const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+      assert.strictEqual(row.estimated_cost_usd, 12, 'Expected Sonnet 5 1M/1M to cost $12.00');
+    } finally {
+      removeHarnessCostCache(sessionId);
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
   }) ? passed++ : failed++);
 
   // 9b. Sonnet 5 cache write/read tokens use the correct rates.
   (test('prices Sonnet 5 cache tokens at the documented rates', () => {
     const tmpHome = makeTempDir();
-    const sessionId = 'sonnet5-cache-' + Date.now();
+    const sessionId = `sonnet5-cache-${process.pid}-${Date.now()}`;
     const transcriptPath = path.join(tmpHome, 'session.jsonl');
     writeTranscript(transcriptPath, [
       {
@@ -347,23 +366,27 @@ function runTests() {
       },
     ]);
 
-    const result = runScript(
-      { session_id: sessionId, transcript_path: transcriptPath },
-      withTempHome(tmpHome)
-    );
-    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+    try {
+      removeHarnessCostCache(sessionId);
+      const result = runScript(
+        { session_id: sessionId, transcript_path: transcriptPath },
+        withTempHome(tmpHome)
+      );
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
 
-    const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
-    const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
-    assert.strictEqual(row.estimated_cost_usd, 14.7, 'Expected Sonnet 5 1M input + 1M output + 1M cache write + 1M cache read to cost $14.70');
-
-    fs.rmSync(tmpHome, { recursive: true, force: true });
+      const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+      const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+      assert.strictEqual(row.estimated_cost_usd, 14.7, 'Expected Sonnet 5 1M input + 1M output + 1M cache write + 1M cache read to cost $14.70');
+    } finally {
+      removeHarnessCostCache(sessionId);
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
   }) ? passed++ : failed++);
 
   // 10. Sonnet 4.6 keeps the existing $3/$15 rate and is not mistaken for Sonnet 5.
   (test('prices Sonnet 4.6 at $18 per 1M input + 1M output tokens', () => {
     const tmpHome = makeTempDir();
-    const sessionId = 'sonnet46-' + Date.now();
+    const sessionId = `sonnet46-${process.pid}-${Date.now()}`;
     const transcriptPath = path.join(tmpHome, 'session.jsonl');
     writeTranscript(transcriptPath, [
       {
@@ -376,23 +399,28 @@ function runTests() {
       },
     ]);
 
-    const result = runScript(
-      { session_id: sessionId, transcript_path: transcriptPath },
-      withTempHome(tmpHome)
-    );
-    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+    try {
+      removeHarnessCostCache(sessionId);
+      const result = runScript(
+        { session_id: sessionId, transcript_path: transcriptPath },
+        withTempHome(tmpHome)
+      );
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
 
-    const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
-    const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
-    assert.strictEqual(row.estimated_cost_usd, 18, 'Expected Sonnet 4.6 1M/1M to remain $18.00');
-
-    fs.rmSync(tmpHome, { recursive: true, force: true });
+      const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+      const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+      assert.strictEqual(row.estimated_cost_usd, 18, 'Expected Sonnet 4.6 1M/1M to remain $18.00');
+    } finally {
+      removeHarnessCostCache(sessionId);
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
   }) ? passed++ : failed++);
 
   // 10b. Dated Sonnet 5 IDs and near-misses are matched correctly.
   (test('prices dated Sonnet 5 IDs at $12 and rejects claude-sonnet-50 near-miss', () => {
     const tmpHome = makeTempDir();
-    const sessionId = 'sonnet5-dated-' + Date.now();
+    const sessionId = `sonnet5-dated-${process.pid}-${Date.now()}`;
+    const nearMissSessionId = `sonnet50-near-miss-${process.pid}-${Date.now()}`;
     const transcriptPath = path.join(tmpHome, 'session.jsonl');
     writeTranscript(transcriptPath, [
       {
@@ -405,40 +433,46 @@ function runTests() {
       },
     ]);
 
-    const result = runScript(
-      { session_id: sessionId, transcript_path: transcriptPath },
-      withTempHome(tmpHome)
-    );
-    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+    try {
+      removeHarnessCostCache(sessionId);
+      removeHarnessCostCache(nearMissSessionId);
+      const result = runScript(
+        { session_id: sessionId, transcript_path: transcriptPath },
+        withTempHome(tmpHome)
+      );
+      assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
 
-    const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
-    const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
-    assert.strictEqual(row.estimated_cost_usd, 12, 'Expected dated Sonnet 5 1M/1M to cost $12.00');
+      const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+      const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+      assert.strictEqual(row.estimated_cost_usd, 12, 'Expected dated Sonnet 5 1M/1M to cost $12.00');
 
-    // Near-miss `claude-sonnet-50` must fall through to the standard Sonnet rate.
-    const nearMissPath = path.join(tmpHome, 'near-miss.jsonl');
-    writeTranscript(nearMissPath, [
-      {
-        type: 'assistant',
-        message: {
-          id: 'msg_sonnet50',
-          model: 'claude-sonnet-50',
-          usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+      // Near-miss `claude-sonnet-50` must fall through to the standard Sonnet rate.
+      const nearMissPath = path.join(tmpHome, 'near-miss.jsonl');
+      writeTranscript(nearMissPath, [
+        {
+          type: 'assistant',
+          message: {
+            id: 'msg_sonnet50',
+            model: 'claude-sonnet-50',
+            usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+          },
         },
-      },
-    ]);
+      ]);
 
-    const nearResult = runScript(
-      { session_id: 'sonnet50-near-miss-' + Date.now(), transcript_path: nearMissPath },
-      withTempHome(tmpHome)
-    );
-    assert.strictEqual(nearResult.code, 0, `Expected exit code 0, got ${nearResult.code}`);
+      const nearResult = runScript(
+        { session_id: nearMissSessionId, transcript_path: nearMissPath },
+        withTempHome(tmpHome)
+      );
+      assert.strictEqual(nearResult.code, 0, `Expected exit code 0, got ${nearResult.code}`);
 
-    const lines = fs.readFileSync(metricsFile, 'utf8').trim().split('\n');
-    const nearRow = JSON.parse(lines[lines.length - 1]);
-    assert.strictEqual(nearRow.estimated_cost_usd, 18, 'Expected claude-sonnet-50 near-miss to fall back to $18.00 Sonnet rate');
-
-    fs.rmSync(tmpHome, { recursive: true, force: true });
+      const lines = fs.readFileSync(metricsFile, 'utf8').trim().split('\n');
+      const nearRow = JSON.parse(lines[lines.length - 1]);
+      assert.strictEqual(nearRow.estimated_cost_usd, 18, 'Expected claude-sonnet-50 near-miss to fall back to $18.00 Sonnet rate');
+    } finally {
+      removeHarnessCostCache(sessionId);
+      removeHarnessCostCache(nearMissSessionId);
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
   }) ? passed++ : failed++);
 
   // 11. Ignores stale harness-cost cache and falls back to transcript estimate

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -63,6 +63,40 @@ function removeHarnessCostCache(sessionId) {
   }
 }
 
+function assertSonnet5CacheCost(cacheUsage, expectedCost, description) {
+  const tmpHome = makeTempDir();
+  const sessionId = `sonnet5-${description}-${process.pid}-${Date.now()}`;
+  const transcriptPath = path.join(tmpHome, 'session.jsonl');
+  writeTranscript(transcriptPath, [{
+    type: 'assistant',
+    message: {
+      id: `msg_sonnet5_${description}`,
+      model: 'claude-sonnet-5',
+      usage: {
+        input_tokens: 1_000_000,
+        output_tokens: 1_000_000,
+        ...cacheUsage,
+      },
+    },
+  }]);
+
+  try {
+    removeHarnessCostCache(sessionId);
+    const result = runScript(
+      { session_id: sessionId, transcript_path: transcriptPath },
+      withTempHome(tmpHome)
+    );
+    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+
+    const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+    const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+    assert.strictEqual(row.estimated_cost_usd, expectedCost, description);
+  } finally {
+    removeHarnessCostCache(sessionId);
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }
+}
+
 function runTests() {
   console.log('\n=== Testing cost-tracker.js ===\n');
 
@@ -381,6 +415,23 @@ function runTests() {
       removeHarnessCostCache(sessionId);
       fs.rmSync(tmpHome, { recursive: true, force: true });
     }
+  }) ? passed++ : failed++);
+
+  // 9c. Cache write/read rates are independently covered.
+  (test('prices Sonnet 5 cache writes at $2.50 per 1M tokens', () => {
+    assertSonnet5CacheCost(
+      { cache_creation_input_tokens: 1_000_000 },
+      14.5,
+      'cache-write'
+    );
+  }) ? passed++ : failed++);
+
+  (test('prices Sonnet 5 cache reads at $0.20 per 1M tokens', () => {
+    assertSonnet5CacheCost(
+      { cache_read_input_tokens: 1_000_000 },
+      12.2,
+      'cache-read'
+    );
   }) ? passed++ : failed++);
 
   // 10. Sonnet 4.6 keeps the existing $3/$15 rate and is not mistaken for Sonnet 5.

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -297,7 +297,63 @@ function runTests() {
     }
   }) ? passed++ : failed++);
 
-  // 9. Ignores stale harness-cost cache and falls back to transcript estimate
+  // 9. Prices Sonnet 5 at the documented $2/$10 rate.
+  (test('prices Sonnet 5 at $12 per 1M input + 1M output tokens', () => {
+    const tmpHome = makeTempDir();
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [
+      {
+        type: 'assistant',
+        message: {
+          id: 'msg_sonnet5',
+          model: 'claude-sonnet-5',
+          usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+        },
+      },
+    ]);
+
+    const result = runScript(
+      { session_id: 'sonnet5-session', transcript_path: transcriptPath },
+      withTempHome(tmpHome)
+    );
+    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+
+    const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+    const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+    assert.strictEqual(row.estimated_cost_usd, 12, 'Expected Sonnet 5 1M/1M to cost $12.00');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  // 10. Sonnet 4.6 keeps the existing $3/$15 rate and is not mistaken for Sonnet 5.
+  (test('prices Sonnet 4.6 at $18 per 1M input + 1M output tokens', () => {
+    const tmpHome = makeTempDir();
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [
+      {
+        type: 'assistant',
+        message: {
+          id: 'msg_sonnet46',
+          model: 'claude-sonnet-4-6',
+          usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+        },
+      },
+    ]);
+
+    const result = runScript(
+      { session_id: 'sonnet46-session', transcript_path: transcriptPath },
+      withTempHome(tmpHome)
+    );
+    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+
+    const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+    const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+    assert.strictEqual(row.estimated_cost_usd, 18, 'Expected Sonnet 4.6 1M/1M to remain $18.00');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  // 11. Ignores stale harness-cost cache and falls back to transcript estimate
   (test('ignores stale harness-cost cache (>300s) and uses transcript estimate', () => {
     const tmpHome = makeTempDir();
     const sessionId = 'harness-stale-' + Date.now();

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -325,6 +325,39 @@ function runTests() {
     fs.rmSync(tmpHome, { recursive: true, force: true });
   }) ? passed++ : failed++);
 
+  // 9b. Sonnet 5 cache write/read tokens use the correct rates.
+  (test('prices Sonnet 5 cache tokens at the documented rates', () => {
+    const tmpHome = makeTempDir();
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [
+      {
+        type: 'assistant',
+        message: {
+          id: 'msg_sonnet5_cache',
+          model: 'claude-sonnet-5',
+          usage: {
+            input_tokens: 1_000_000,
+            output_tokens: 1_000_000,
+            cache_creation_input_tokens: 1_000_000,
+            cache_read_input_tokens: 1_000_000,
+          },
+        },
+      },
+    ]);
+
+    const result = runScript(
+      { session_id: 'sonnet5-cache-session', transcript_path: transcriptPath },
+      withTempHome(tmpHome)
+    );
+    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+
+    const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+    const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+    assert.strictEqual(row.estimated_cost_usd, 14.7, 'Expected Sonnet 5 1M input + 1M output + 1M cache write + 1M cache read to cost $14.70');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
   // 10. Sonnet 4.6 keeps the existing $3/$15 rate and is not mistaken for Sonnet 5.
   (test('prices Sonnet 4.6 at $18 per 1M input + 1M output tokens', () => {
     const tmpHome = makeTempDir();
@@ -349,6 +382,57 @@ function runTests() {
     const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
     const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
     assert.strictEqual(row.estimated_cost_usd, 18, 'Expected Sonnet 4.6 1M/1M to remain $18.00');
+
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
+  // 10b. Dated Sonnet 5 IDs and near-misses are matched correctly.
+  (test('prices dated Sonnet 5 IDs at $12 and rejects claude-sonnet-50 near-miss', () => {
+    const tmpHome = makeTempDir();
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [
+      {
+        type: 'assistant',
+        message: {
+          id: 'msg_sonnet5_dated',
+          model: 'claude-sonnet-5-20261001',
+          usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+        },
+      },
+    ]);
+
+    const result = runScript(
+      { session_id: 'sonnet5-dated-session', transcript_path: transcriptPath },
+      withTempHome(tmpHome)
+    );
+    assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
+
+    const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+    const row = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+    assert.strictEqual(row.estimated_cost_usd, 12, 'Expected dated Sonnet 5 1M/1M to cost $12.00');
+
+    // Near-miss `claude-sonnet-50` must fall through to the standard Sonnet rate.
+    const nearMissPath = path.join(tmpHome, 'near-miss.jsonl');
+    writeTranscript(nearMissPath, [
+      {
+        type: 'assistant',
+        message: {
+          id: 'msg_sonnet50',
+          model: 'claude-sonnet-50',
+          usage: { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+        },
+      },
+    ]);
+
+    const nearResult = runScript(
+      { session_id: 'sonnet50-near-miss-session', transcript_path: nearMissPath },
+      withTempHome(tmpHome)
+    );
+    assert.strictEqual(nearResult.code, 0, `Expected exit code 0, got ${nearResult.code}`);
+
+    const lines = fs.readFileSync(metricsFile, 'utf8').trim().split('\n');
+    const nearRow = JSON.parse(lines[lines.length - 1]);
+    assert.strictEqual(nearRow.estimated_cost_usd, 18, 'Expected claude-sonnet-50 near-miss to fall back to $18.00 Sonnet rate');
 
     fs.rmSync(tmpHome, { recursive: true, force: true });
   }) ? passed++ : failed++);


### PR DESCRIPTION
## What Changed

`scripts/hooks/cost-tracker.js` now prices `claude-sonnet-5` (and its dated variants) at the published **$2 / $10 per 1M tokens** rate, instead of falling through to the older Sonnet bucket at **$3 / $15**.

- Added a `sonnet5` row to `RATE_TABLE`: `{ in: 2.00, out: 10.0, cacheWrite: 2.50, cacheRead: 0.20 }`.
- Added `isSonnet5()` with a word-boundary regex so `claude-sonnet-5-20260514` matches but `claude-sonnet-4-6` does not.
- Added two regression tests:
  - `claude-sonnet-5` 1M in / 1M out costs $12.00
  - `claude-sonnet-4-6` 1M in / 1M out still costs $18.00

## Why This Change

Claude Sonnet 5 is billed at $2 input / $10 output per million tokens. Anthropic's pricing page now lists this as the standard rate and states that the previously scheduled September 1, 2026 increase to $3/$15 will not occur (https://platform.claude.com/docs/en/about-claude/pricing#claude-sonnet-5-introductory-pricing). The existing `RATE_TABLE` had no Sonnet 5 row, so `getRates()` returned the legacy `sonnet` ($3/$15) rate for any Sonnet 5 session, overcounting spend by 50%.

This touches the canonical `cost-tracker.js` rate source, not the unused `cost-estimate.js` duplicate noted in #2656 / #2777.

## Testing Done

- [x] Targeted automated tests pass locally:
  ```bash
  node tests/hooks/cost-tracker.test.js
  ```
  Result: `Results: Passed: 12, Failed: 0`
- [x] ESLint passes on changed files.
- [x] Edge cases considered and tested: Sonnet 5 word-boundary matching, Sonnet 4.6 unaffected.

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [x] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] Follows conventional commits format
- [x] Pre-commit checks pass (eslint on changed files)

Fixes #2724
