### PR TITLE
fix(block-no-verify): treat --config-env as a hooksPath override

### DIFF
--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -64,6 +64,28 @@ const GIT_INCLUDE_IF_KEY_PATTERN = /^includeif\..*\.path=/;
  * True when a lowercased `key=value` config setting redirects where git looks
  * for hooks, whether directly or through an included file.
  */
+// tokenizeShellWords strips quotes; it does not run the shell. So `$(printf commit)`
+// arrives verbatim while the shell hands git a plain `commit`. Anything that can
+// still change under expansion is opaque to this guard and must not be read as a
+// literal. Deliberately narrow: only the subcommand slot and the KEY half of a
+// config setting are treated this way, so `git commit -m "$(cat msg)"` and
+// `git -c user.email=$EMAIL commit` stay allowed.
+const SHELL_EXPANSION_PATTERN = /\$\(|`|\$\{|\$[A-Za-z_]/;
+
+function hasShellExpansion(value) {
+  return SHELL_EXPANSION_PATTERN.test(value);
+}
+
+/**
+ * True when a `-c`/`--config-env` argument hides WHICH key it sets. The value
+ * half may expand freely — it cannot turn user.name into core.hooksPath — but a
+ * dynamic key half can be anything, including a hooks redirect.
+ */
+function hasOpaqueConfigKey(setting) {
+  const equals = setting.indexOf('=');
+  return hasShellExpansion(equals === -1 ? setting : setting.slice(0, equals));
+}
+
 function isHooksRedirectSetting(loweredSetting) {
   return loweredSetting.startsWith(GIT_CONFIG_KEY_PREFIX)
     || loweredSetting.startsWith(GIT_INCLUDE_KEY_PREFIX)
@@ -95,6 +117,9 @@ const GIT_GLOBAL_OPTIONS_WITH_VALUE = new Set([
 // Global options that can set core.hooksPath, in their `<option> <key>=<value>`
 // and `<option>=<key>=<value>` spellings.
 const GIT_CONFIG_SETTING_OPTIONS = ['-c', '--config-env'];
+
+// Stands in for a subcommand the shell will produce that we cannot read.
+const DYNAMIC_COMMAND = '<shell expansion>';
 
 const COMMIT_OPTIONS_WITH_VALUE = new Set([
   '-m',
@@ -389,6 +414,7 @@ function detectGitCommand(input, start = 0) {
     let bestCmd = null;
     let bestIdx = Infinity;
     let bestEnd = Infinity;
+    let dynamicCommand = false;
     let expectFlagArg = false;
 
     for (const token of tokens) {
@@ -405,7 +431,14 @@ function detectGitCommand(input, start = 0) {
 
       // Whatever sits here occupies the subcommand slot; if it is not one we
       // guard, there is no guarded subcommand in this segment.
-      if (GIT_COMMANDS_WITH_NO_VERIFY.includes(token.value) && !isInComment(input, token.start)) {
+      if (hasShellExpansion(token.value) && !isInComment(input, token.start)) {
+        // Unknown subcommand: keep inspecting rather than block outright, so
+        // `git $CMD status` is fine and `git "$(printf commit)" --no-verify` is not.
+        bestCmd = DYNAMIC_COMMAND;
+        bestIdx = token.start;
+        bestEnd = token.end;
+        dynamicCommand = true;
+      } else if (GIT_COMMANDS_WITH_NO_VERIFY.includes(token.value) && !isInComment(input, token.start)) {
         bestCmd = token.value;
         bestIdx = token.start;
         // token.end, not bestIdx + length: for a quoted subcommand the two differ
@@ -419,6 +452,7 @@ function detectGitCommand(input, start = 0) {
     if (bestCmd) {
       return {
         command: bestCmd,
+        dynamicCommand,
         offset: bestEnd,
         gitStart: git.idx,
         gitEnd: git.idx + git.len,
@@ -492,8 +526,13 @@ function hasHooksPathOverride(input, detected) {
     // `<option> core.hooksPath=...` — the key/value is the next token.
     if (GIT_CONFIG_SETTING_OPTIONS.includes(value)) {
       const next = tokens[i + 1] && tokens[i + 1].value;
-      if (typeof next === 'string' && isHooksRedirectSetting(next.toLowerCase())) {
-        return true;
+      if (typeof next === 'string') {
+        if (isHooksRedirectSetting(next.toLowerCase())) {
+          return true;
+        }
+        if (hasOpaqueConfigKey(next)) {
+          return true;
+        }
       }
       i++;
       continue;
@@ -501,12 +540,17 @@ function hasHooksPathOverride(input, detected) {
 
     // `-ccore.hooksPath=...` (short option, no space) and
     // `--config-env=core.hooksPath=...` (long option, inline value).
-    if (lowered.startsWith('-c') && isHooksRedirectSetting(lowered.slice(2))) {
-      return true;
+    if (lowered.startsWith('-c')) {
+      if (isHooksRedirectSetting(lowered.slice(2)) || hasOpaqueConfigKey(value.slice(2))) {
+        return true;
+      }
     }
 
-    if (lowered.startsWith('--config-env=') && isHooksRedirectSetting(lowered.slice('--config-env='.length))) {
-      return true;
+    if (lowered.startsWith('--config-env=')) {
+      const inline = value.slice('--config-env='.length);
+      if (isHooksRedirectSetting(inline.toLowerCase()) || hasOpaqueConfigKey(inline)) {
+        return true;
+      }
     }
   }
 
@@ -532,7 +576,11 @@ function checkCommand(input) {
       };
     }
 
-    if (hasNoVerifyFlag(input, gitCommand, offset)) {
+    // With the subcommand hidden behind an expansion we cannot know it is not
+    // `commit`, so use the widest flag set (commit's, which includes -n).
+    const flagScanCommand = detected.dynamicCommand ? 'commit' : gitCommand;
+
+    if (hasNoVerifyFlag(input, flagScanCommand, offset)) {
       return {
         blocked: true,
         reason: `BLOCKED: --no-verify flag is not allowed with git ${gitCommand}. Git hooks must not be bypassed.`,

--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -13,6 +13,8 @@
  *   2 = block (bypass flag detected)
  */
 
+const fs = require('fs');
+
 'use strict';
 
 const MAX_STDIN = 1024 * 1024;
@@ -328,23 +330,41 @@ function getCommitShortValueOption(value) {
 
 /**
  * `-n` means --no-verify to `git commit` but "max count" to log/show/diff, so with
- * the subcommand hidden behind an expansion it is ambiguous. The count spellings
- * are safe to exempt, checked against git 2.51:
+ * the subcommand hidden behind an expansion it is ambiguous. What settles it is that
+ * git commit reads the token after `-n` as a PATHSPEC, so the command only does
+ * anything if that path exists. Checked against git 2.51, in a repo whose pre-commit
+ * hook exits 1:
  *
- *   git log -n 5        ok          git commit -n 5   error: pathspec '5' did not match
- *   git log -n5         ok          git commit -n5    error: unknown switch `5'
+ *   git commit -n5           error: unknown switch `5'                   never valid
+ *   git commit -n 9 -m x     error: pathspec '9' did not match           no commit
+ *   git commit -n 1 -m x     [main 326cf0b] x   <- hook never ran        REAL bypass
+ *   git log -n 5             ok                                          ordinary
  *
- * `-n<digits>` git commit rejects outright, so it can never be a bypass. `-n <digits>`
- * it reads as a pathspec, which fails unless a file with that exact numeric name
- * exists — the one residual case, and far narrower than blocking every `git $SUB -n 5`.
- * The unambiguous spellings are untouched: `git $SUB --no-verify` and `git $SUB -n -m x`
- * are still blocked.
+ * So `-n<digits>` is exempt outright — git commit rejects that spelling. Split
+ * `-n <digits>` is exempt only when nothing by that name is on disk: if it is, the
+ * command can be a path-limited commit and must block. That is what separates
+ * `git $SUB -n 5` (a log) from `git $SUB -m msg -n 1` (a commit of the file `1`).
  */
+function namesAnExistingPath(value) {
+  try {
+    return fs.existsSync(value);
+  } catch {
+    // Unreadable cwd, permissions, anything: we cannot rule out a pathspec, so do
+    // not hand out the exemption.
+    return true;
+  }
+}
+
 function isAmbiguousCountFlag(value, nextToken) {
   if (/^-n\d+$/.test(value)) {
     return true;
   }
-  return value === '-n' && typeof nextToken === 'string' && /^\d+$/.test(nextToken);
+
+  if (value !== '-n' || typeof nextToken !== 'string' || !/^\d+$/.test(nextToken)) {
+    return false;
+  }
+
+  return !namesAnExistingPath(nextToken);
 }
 
 function isCommitNoVerifyShortFlag(value) {

--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -13,7 +13,6 @@
  *   2 = block (bypass flag detected)
  */
 
-const fs = require('fs');
 
 'use strict';
 
@@ -330,41 +329,31 @@ function getCommitShortValueOption(value) {
 
 /**
  * `-n` means --no-verify to `git commit` but "max count" to log/show/diff, so with
- * the subcommand hidden behind an expansion it is ambiguous. What settles it is that
- * git commit reads the token after `-n` as a PATHSPEC, so the command only does
- * anything if that path exists. Checked against git 2.51, in a repo whose pre-commit
- * hook exits 1:
+ * the subcommand hidden behind a shell expansion it is ambiguous.
  *
- *   git commit -n5           error: unknown switch `5'                   never valid
- *   git commit -n 9 -m x     error: pathspec '9' did not match           no commit
- *   git commit -n 1 -m x     [main 326cf0b] x   <- hook never ran        REAL bypass
- *   git log -n 5             ok                                          ordinary
+ * Only the ATTACHED spelling is safe to exempt. Checked against git 2.51:
  *
- * So `-n<digits>` is exempt outright — git commit rejects that spelling. Split
- * `-n <digits>` is exempt only when nothing by that name is on disk: if it is, the
- * command can be a path-limited commit and must block. That is what separates
- * `git $SUB -n 5` (a log) from `git $SUB -m msg -n 1` (a commit of the file `1`).
+ *   git log    -n5           ok
+ *   git commit -n5           error: unknown switch `5'
+ *
+ * git commit refuses `-n<digits>` outright, so nothing can turn it into a bypass.
+ *
+ * The split form `-n <digits>` is NOT exempt, because git commit reads that token as
+ * a pathspec and there is no reliable way to tell from the string alone whether such
+ * a path exists. Two verified bypasses came out of trying, both committing with the
+ * pre-commit hook never running:
+ *
+ *   file `1` present         git commit -n 1 -m x   -> [main 326cf0b] x
+ *   `7` staged as a DELETION git commit -n 7 -m x   -> [main 7e7d466] x
+ *
+ * The second is why an existsSync test is not enough: git accepts a staged deletion
+ * as a pathspec while the file is absent from disk. Deciding it properly means asking
+ * git about the index from inside a pre-tool hook, and any cheaper test is incomplete
+ * in a direction that lets hooks be skipped. The cost of failing closed is that
+ * `git $SUB -n 5` blocks; `git $SUB -n5` and `git $SUB --max-count=5` do not.
  */
-function namesAnExistingPath(value) {
-  try {
-    return fs.existsSync(value);
-  } catch {
-    // Unreadable cwd, permissions, anything: we cannot rule out a pathspec, so do
-    // not hand out the exemption.
-    return true;
-  }
-}
-
-function isAmbiguousCountFlag(value, nextToken) {
-  if (/^-n\d+$/.test(value)) {
-    return true;
-  }
-
-  if (value !== '-n' || typeof nextToken !== 'string' || !/^\d+$/.test(nextToken)) {
-    return false;
-  }
-
-  return !namesAnExistingPath(nextToken);
+function isAmbiguousCountFlag(value) {
+  return /^-n\d+$/.test(value);
 }
 
 function isCommitNoVerifyShortFlag(value) {
@@ -548,7 +537,7 @@ function hasNoVerifyFlag(input, command, offset, subcommandUnknown = false) {
       // With the subcommand expanded by the shell we cannot know it is commit, and
       // `git $SUB -n 5` is an ordinary `git log -n 5`. Only the count spellings are
       // exempt; --no-verify and a bare -n still block.
-      if (subcommandUnknown && isAmbiguousCountFlag(value, tokens[i + 1] && tokens[i + 1].value)) {
+      if (subcommandUnknown && isAmbiguousCountFlag(value)) {
         continue;
       }
       return true;

--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -42,6 +42,34 @@ const VALID_BEFORE_GIT = ' \t\n\r;&|$`(<{!"\']/.~\\';
 // case-insensitive."
 const GIT_CONFIG_KEY_PREFIX = 'core.hookspath=';
 
+// core.hooksPath is the direct spelling. `include.path` reaches the same place
+// indirectly: git reads the named file and applies everything in it, so a config
+// that sets core.hooksPath redirects the hooks just as well. Verified against
+// git 2.51 in a repo whose pre-commit hook echoes a marker:
+//
+//   git -c include.path=evil.conf commit -m x   -> commit succeeds, marker absent
+//   git --config-env=include.path=EVIL config --get core.hooksPath
+//                                              -> prints the redirected path
+//
+// includeIf.<condition>.path is the same mechanism behind a condition. It is
+// covered on that basis, NOT on a reproduction: on git 2.51 a conditional include
+// passed on the command line never matched in testing (gitdir:**/ , an absolute
+// gitdir, and gitdir/i all left core.hooksPath untouched), so it may well be inert
+// there. Nothing legitimate passes it to `git commit`, so covering it costs
+// nothing and closes the hole if that ever changes.
+const GIT_INCLUDE_KEY_PREFIX = 'include.path=';
+const GIT_INCLUDE_IF_KEY_PATTERN = /^includeif\..*\.path=/;
+
+/**
+ * True when a lowercased `key=value` config setting redirects where git looks
+ * for hooks, whether directly or through an included file.
+ */
+function isHooksRedirectSetting(loweredSetting) {
+  return loweredSetting.startsWith(GIT_CONFIG_KEY_PREFIX)
+    || loweredSetting.startsWith(GIT_INCLUDE_KEY_PREFIX)
+    || GIT_INCLUDE_IF_KEY_PATTERN.test(loweredSetting);
+}
+
 // Git global options that take their value as the NEXT token. If one of these
 // is not listed, the value token looks like a bare word to the subcommand
 // scanner, which then decides the `commit`/`push` after it cannot be the
@@ -464,7 +492,7 @@ function hasHooksPathOverride(input, detected) {
     // `<option> core.hooksPath=...` — the key/value is the next token.
     if (GIT_CONFIG_SETTING_OPTIONS.includes(value)) {
       const next = tokens[i + 1] && tokens[i + 1].value;
-      if (typeof next === 'string' && next.toLowerCase().startsWith(GIT_CONFIG_KEY_PREFIX)) {
+      if (typeof next === 'string' && isHooksRedirectSetting(next.toLowerCase())) {
         return true;
       }
       i++;
@@ -473,11 +501,11 @@ function hasHooksPathOverride(input, detected) {
 
     // `-ccore.hooksPath=...` (short option, no space) and
     // `--config-env=core.hooksPath=...` (long option, inline value).
-    if (lowered.startsWith(`-c${GIT_CONFIG_KEY_PREFIX}`)) {
+    if (lowered.startsWith('-c') && isHooksRedirectSetting(lowered.slice(2))) {
       return true;
     }
 
-    if (lowered.startsWith(`--config-env=${GIT_CONFIG_KEY_PREFIX}`)) {
+    if (lowered.startsWith('--config-env=') && isHooksRedirectSetting(lowered.slice('--config-env='.length))) {
       return true;
     }
   }
@@ -500,7 +528,7 @@ function checkCommand(input) {
     if (hasHooksPathOverride(input, detected)) {
       return {
         blocked: true,
-        reason: `BLOCKED: Overriding core.hooksPath is not allowed with git ${gitCommand}. Git hooks must not be bypassed.`,
+        reason: `BLOCKED: Redirecting git hooks (core.hooksPath, directly or through include.path) is not allowed with git ${gitCommand}. Git hooks must not be bypassed.`,
       };
     }
 

--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -349,60 +349,49 @@ function detectGitCommand(input, start = 0) {
       continue;
     }
 
-    // Find the first matching subcommand token after "git".
-    // We pick the one closest to "git" so that argument values like
-    // "git push origin commit" don't misclassify "commit" as the subcommand.
+    // The subcommand is the first non-flag token after "git". Tokenizing rather
+    // than splitting raw text matters: a quoted global option keeps its quotes
+    // under a plain split, so `git "-c" "core.hooksPath=/dev/null" commit` and
+    // `git "--config-env=core.hooksPath=MYVAR" commit` read as a bare word in
+    // subcommand position and the whole command escaped inspection. Verified
+    // against git 2.51: the shell strips those quotes, so git sees the option.
+    const segmentEnd = findCommandSegmentEnd(input, git.idx + git.len);
+    const tokens = tokenizeShellWords(input, git.idx + git.len, segmentEnd);
+
     let bestCmd = null;
     let bestIdx = Infinity;
+    let bestEnd = Infinity;
+    let expectFlagArg = false;
 
-    for (const cmd of GIT_COMMANDS_WITH_NO_VERIFY) {
-      let searchPos = git.idx + git.len;
-      while (searchPos < input.length) {
-        const cmdIdx = input.indexOf(cmd, searchPos);
-        if (cmdIdx === -1) break;
+    for (const token of tokens) {
+      if (expectFlagArg) { expectFlagArg = false; continue; }
 
-        const before = cmdIdx > 0 ? input[cmdIdx - 1] : ' ';
-        const after = input[cmdIdx + cmd.length] || ' ';
-        if (!/\s/.test(before)) { searchPos = cmdIdx + 1; continue; }
-        if (!/[\s;&#|>)\]}"']/.test(after) && after !== '') { searchPos = cmdIdx + 1; continue; }
-        if (/[;|]/.test(input.slice(git.idx + git.len, cmdIdx))) break;
-        if (isInComment(input, cmdIdx)) { searchPos = cmdIdx + 1; continue; }
-
-        // Verify this token is the first non-flag word after "git" — i.e. the
-        // actual subcommand, not an argument value to a different subcommand.
-        const gap = input.slice(git.idx + git.len, cmdIdx);
-        const tokens = gap.trim().split(/\s+/).filter(Boolean);
-        // Every token before the candidate must be a flag or a flag argument.
-        // Git global flags like -c take a value argument (e.g. -c key=value).
-        let onlyFlagsAndArgs = true;
-        let expectFlagArg = false;
-        for (const t of tokens) {
-          if (expectFlagArg) { expectFlagArg = false; continue; }
-          if (t.startsWith('-')) {
-            // These git global flags take the next token as their argument, so
-            // that token must not be mistaken for the subcommand position.
-            if (GIT_GLOBAL_OPTIONS_WITH_VALUE.has(t)) {
-              expectFlagArg = true;
-            }
-            continue;
-          }
-          onlyFlagsAndArgs = false;
-          break;
+      if (token.value.startsWith('-')) {
+        // These git global flags take the next token as their argument, so that
+        // token must not be mistaken for the subcommand position.
+        if (GIT_GLOBAL_OPTIONS_WITH_VALUE.has(token.value)) {
+          expectFlagArg = true;
         }
-        if (!onlyFlagsAndArgs) { searchPos = cmdIdx + 1; continue; }
-
-        if (cmdIdx < bestIdx) {
-          bestIdx = cmdIdx;
-          bestCmd = cmd;
-        }
-        break;
+        continue;
       }
+
+      // Whatever sits here occupies the subcommand slot; if it is not one we
+      // guard, there is no guarded subcommand in this segment.
+      if (GIT_COMMANDS_WITH_NO_VERIFY.includes(token.value) && !isInComment(input, token.start)) {
+        bestCmd = token.value;
+        bestIdx = token.start;
+        // token.end, not bestIdx + length: for a quoted subcommand the two differ
+        // by the quote characters, and a short offset leaves the closing quote in
+        // the flag scan's first token.
+        bestEnd = token.end;
+      }
+      break;
     }
 
     if (bestCmd) {
       return {
         command: bestCmd,
-        offset: bestIdx + bestCmd.length,
+        offset: bestEnd,
         gitStart: git.idx,
         gitEnd: git.idx + git.len,
         commandStart: bestIdx,

--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -42,6 +42,32 @@ const VALID_BEFORE_GIT = ' \t\n\r;&|$`(<{!"\']/.~\\';
 // case-insensitive."
 const GIT_CONFIG_KEY_PREFIX = 'core.hookspath=';
 
+// Git global options that take their value as the NEXT token. If one of these
+// is not listed, the value token looks like a bare word to the subcommand
+// scanner, which then decides the `commit`/`push` after it cannot be the
+// subcommand — and the whole guard goes blind for that command, including an
+// explicit --no-verify.
+//
+// `--config-env=<name>=<envvar>` reads a config value out of the environment
+// and is therefore a second spelling of `-c` for hooksPath purposes:
+//   MYVAR=/dev/null git --config-env=core.hooksPath=MYVAR commit
+// git accepts it in both the `=` and space-separated forms. It does NOT accept
+// an abbreviation of the option itself (`--config-en=` is rejected), so exact
+// matching is enough here.
+const GIT_GLOBAL_OPTIONS_WITH_VALUE = new Set([
+  '-c',
+  '-C',
+  '--config-env',
+  '--work-tree',
+  '--git-dir',
+  '--namespace',
+  '--super-prefix',
+]);
+
+// Global options that can set core.hooksPath, in their `<option> <key>=<value>`
+// and `<option>=<key>=<value>` spellings.
+const GIT_CONFIG_SETTING_OPTIONS = ['-c', '--config-env'];
+
 const COMMIT_OPTIONS_WITH_VALUE = new Set([
   '-m',
   '--message',
@@ -353,9 +379,9 @@ function detectGitCommand(input, start = 0) {
         for (const t of tokens) {
           if (expectFlagArg) { expectFlagArg = false; continue; }
           if (t.startsWith('-')) {
-            // -c is a git global flag that takes the next token as its argument
-            if (t === '-c' || t === '-C' || t === '--work-tree' || t === '--git-dir' ||
-                t === '--namespace' || t === '--super-prefix') {
+            // These git global flags take the next token as their argument, so
+            // that token must not be mistaken for the subcommand position.
+            if (GIT_GLOBAL_OPTIONS_WITH_VALUE.has(t)) {
               expectFlagArg = true;
             }
             continue;
@@ -446,7 +472,8 @@ function hasHooksPathOverride(input, detected) {
     // must compare against the lowercased token.
     const lowered = value.toLowerCase();
 
-    if (value === '-c') {
+    // `<option> core.hooksPath=...` — the key/value is the next token.
+    if (GIT_CONFIG_SETTING_OPTIONS.includes(value)) {
       const next = tokens[i + 1] && tokens[i + 1].value;
       if (typeof next === 'string' && next.toLowerCase().startsWith(GIT_CONFIG_KEY_PREFIX)) {
         return true;
@@ -455,7 +482,13 @@ function hasHooksPathOverride(input, detected) {
       continue;
     }
 
+    // `-ccore.hooksPath=...` (short option, no space) and
+    // `--config-env=core.hooksPath=...` (long option, inline value).
     if (lowered.startsWith(`-c${GIT_CONFIG_KEY_PREFIX}`)) {
+      return true;
+    }
+
+    if (lowered.startsWith(`--config-env=${GIT_CONFIG_KEY_PREFIX}`)) {
       return true;
     }
   }

--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -326,6 +326,27 @@ function getCommitShortValueOption(value) {
   return null;
 }
 
+/**
+ * `-n` means --no-verify to `git commit` but "max count" to log/show/diff, so with
+ * the subcommand hidden behind an expansion it is ambiguous. The count spellings
+ * are safe to exempt, checked against git 2.51:
+ *
+ *   git log -n 5        ok          git commit -n 5   error: pathspec '5' did not match
+ *   git log -n5         ok          git commit -n5    error: unknown switch `5'
+ *
+ * `-n<digits>` git commit rejects outright, so it can never be a bypass. `-n <digits>`
+ * it reads as a pathspec, which fails unless a file with that exact numeric name
+ * exists — the one residual case, and far narrower than blocking every `git $SUB -n 5`.
+ * The unambiguous spellings are untouched: `git $SUB --no-verify` and `git $SUB -n -m x`
+ * are still blocked.
+ */
+function isAmbiguousCountFlag(value, nextToken) {
+  if (/^-n\d+$/.test(value)) {
+    return true;
+  }
+  return value === '-n' && typeof nextToken === 'string' && /^\d+$/.test(nextToken);
+}
+
 function isCommitNoVerifyShortFlag(value) {
   if (!value.startsWith('-') || value.startsWith('--') || value === '-') {
     return false;
@@ -471,12 +492,13 @@ function detectGitCommand(input, start = 0) {
  * right after the detected subcommand keyword) so that flags belonging to
  * earlier commands in a chain are not falsely matched.
  */
-function hasNoVerifyFlag(input, command, offset) {
+function hasNoVerifyFlag(input, command, offset, subcommandUnknown = false) {
   const segmentEnd = findCommandSegmentEnd(input, offset);
   const tokens = tokenizeShellWords(input, offset, segmentEnd);
   let skipNext = false;
 
-  for (const token of tokens) {
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
     const value = token.value;
 
     if (skipNext) {
@@ -503,6 +525,12 @@ function hasNoVerifyFlag(input, command, offset) {
 
     // For commit, -n is shorthand for --no-verify.
     if (command === 'commit' && isCommitNoVerifyShortFlag(value)) {
+      // With the subcommand expanded by the shell we cannot know it is commit, and
+      // `git $SUB -n 5` is an ordinary `git log -n 5`. Only the count spellings are
+      // exempt; --no-verify and a bare -n still block.
+      if (subcommandUnknown && isAmbiguousCountFlag(value, tokens[i + 1] && tokens[i + 1].value)) {
+        continue;
+      }
       return true;
     }
   }
@@ -580,7 +608,7 @@ function checkCommand(input) {
     // `commit`, so use the widest flag set (commit's, which includes -n).
     const flagScanCommand = detected.dynamicCommand ? 'commit' : gitCommand;
 
-    if (hasNoVerifyFlag(input, flagScanCommand, offset)) {
+    if (hasNoVerifyFlag(input, flagScanCommand, offset, detected.dynamicCommand)) {
       return {
         blocked: true,
         reason: `BLOCKED: --no-verify flag is not allowed with git ${gitCommand}. Git hooks must not be bypassed.`,

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -3,6 +3,7 @@
  */
 
 const assert = require('assert');
+const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
@@ -478,6 +479,48 @@ if (test('still blocks --no-verify behind an expanded subcommand regardless of -
 
 if (test('the count exemption does not leak to a literal commit', () => {
   const r = runHook({ tool_input: { command: 'git commit -n 5' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+// What settles the ambiguous `-n` is that git commit reads the NEXT token as a
+// pathspec, so the command only does anything if that path exists. Checked against
+// git 2.51 in a repo whose pre-commit hook exits 1:
+//   git commit -n 9 -m x   error: pathspec '9' did not match      -> no commit
+//   git commit -n 1 -m x   [main 326cf0b] x, hook never ran       -> real bypass
+// So the split form is exempt only while nothing by that name is on disk. The hook
+// runs with the repo root as cwd, so these two cases create and remove the path.
+const NUMERIC_PATH = '987654321';
+
+if (test('blocks split -n <digits> when that path exists (path-limited commit)', () => {
+  fs.writeFileSync(NUMERIC_PATH, '');
+  try {
+    const r = runHook({ tool_input: { command: `git $SUB -m "msg" -n ${NUMERIC_PATH}` } });
+    assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+  } finally {
+    fs.rmSync(NUMERIC_PATH, { force: true });
+  }
+})) passed++; else failed++;
+
+if (test('allows split -n <digits> when no such path exists (git commit would error)', () => {
+  assert.ok(!fs.existsSync(NUMERIC_PATH), 'fixture path must be absent');
+  const r = runHook({ tool_input: { command: `git $SUB -n ${NUMERIC_PATH}` } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('attached -n<digits> stays allowed even when that path exists', () => {
+  fs.writeFileSync(NUMERIC_PATH, '');
+  try {
+    // git commit rejects `-n<digits>` outright ("unknown switch"), so it can never
+    // be a bypass regardless of the filesystem.
+    const r = runHook({ tool_input: { command: `git $SUB -n${NUMERIC_PATH}` } });
+    assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+  } finally {
+    fs.rmSync(NUMERIC_PATH, { force: true });
+  }
+})) passed++; else failed++;
+
+if (test('a literal commit with a numeric pathspec blocks whether or not it exists', () => {
+  const r = runHook({ tool_input: { command: `git commit -n ${NUMERIC_PATH} -m "msg"` } });
   assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
 })) passed++; else failed++;
 

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -310,6 +310,63 @@ if (test('still allows a quoted global option that sets an unrelated key', () =>
   assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
 })) passed++; else failed++;
 
+// core.hooksPath is not the only key that moves the hooks. `include.path` makes
+// git read another config file and apply everything in it -- core.hooksPath
+// included -- so it is the same bypass one level of indirection away.
+// Verified against git 2.51, in a repo whose pre-commit hook echoes a marker:
+//   git -c include.path=evil.conf commit -m x   -> commit succeeds, marker absent
+//   git --config-env=include.path=EVIL config --get core.hooksPath
+//                                              -> prints the redirected path
+// includeIf.<condition>.path is covered as the same capability, not as a
+// reproduction: on git 2.51 a command-line conditional include never matched in
+// testing, so it may be inert there.
+
+if (test('blocks -c include.path, which can redirect core.hooksPath', () => {
+  const r = runHook({ tool_input: { command: 'git -c include.path=/tmp/evil.conf commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+  assert.ok(/include\.path/i.test(r.stderr), `stderr should mention include.path: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('blocks a quoted -c include.path override', () => {
+  const r = runHook({ tool_input: { command: 'git "-c" "include.path=/tmp/evil.conf" commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --config-env=include.path', () => {
+  const r = runHook({ tool_input: { command: 'git --config-env=include.path=EVIL commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --config-env include.path (space-separated)', () => {
+  const r = runHook({ tool_input: { command: 'git --config-env include.path=EVIL commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks INCLUDE.PATH (config keys are case-insensitive)', () => {
+  const r = runHook({ tool_input: { command: 'git -c INCLUDE.PATH=/tmp/evil.conf commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks includeIf.<condition>.path', () => {
+  const r = runHook({ tool_input: { command: 'git -c includeIf.gitdir:/x/.path=/tmp/evil.conf commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks -c include.path on git push', () => {
+  const r = runHook({ tool_input: { command: 'git -c include.path=/tmp/evil.conf push origin main' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('still allows an unrelated -c setting', () => {
+  const r = runHook({ tool_input: { command: 'git -c user.name=x commit -m "msg"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('still allows a key that merely ends in .path', () => {
+  const r = runHook({ tool_input: { command: 'git -c diff.external.path=/usr/bin/diff commit -m "msg"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
 console.log('─'.repeat(50));
 console.log(`Passed: ${passed}  Failed: ${failed}`);
 

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -219,6 +219,51 @@ if (test('still allows -tn (n is the -t template path, not a flag)', () => {
   assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
 })) passed++; else failed++;
 
+// --- --config-env: the second spelling of -c ---
+//
+// `git --config-env=<name>=<envvar>` reads a config value out of the
+// environment, so it sets core.hooksPath exactly as `-c` does:
+//   MYVAR=/dev/null git --config-env=core.hooksPath=MYVAR commit -m x
+// Verified against git 2.51: both the `=` and space-separated forms are
+// accepted and skip the hooks. (An abbreviation of the option itself,
+// `--config-en=`, is rejected by git, so exact matching is sufficient.)
+
+if (test('blocks --config-env=core.hooksPath override', () => {
+  const r = runHook({ tool_input: { command: 'git --config-env=core.hooksPath=MYVAR commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+  assert.ok(/core\.hookspath/i.test(r.stderr), `stderr should mention core.hooksPath: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('blocks --config-env core.hooksPath override (space-separated)', () => {
+  const r = runHook({ tool_input: { command: 'git --config-env core.hooksPath=MYVAR commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --config-env core.HOOKSPATH override (case-variant key)', () => {
+  const r = runHook({ tool_input: { command: 'git --config-env=core.HOOKSPATH=MYVAR commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --config-env core.hooksPath override on git push', () => {
+  const r = runHook({ tool_input: { command: 'git --config-env core.hooksPath=MYVAR push origin main' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+// An unrecognised value-taking global option used to blind the subcommand
+// scanner: its value token looked like a bare word, so the `commit` after it
+// was rejected as the subcommand and the guard stopped inspecting the command
+// entirely -- letting even an explicit --no-verify through.
+if (test('sees --no-verify past a --config-env that sets an unrelated key', () => {
+  const r = runHook({ tool_input: { command: 'git --config-env other.key=MYVAR commit --no-verify -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+  assert.ok(/no-verify/i.test(r.stderr), `stderr should mention --no-verify: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('still allows --config-env that sets an unrelated key', () => {
+  const r = runHook({ tool_input: { command: 'git --config-env=other.key=MYVAR commit -m "msg"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
 console.log('─'.repeat(50));
 console.log(`Passed: ${passed}  Failed: ${failed}`);
 

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -437,6 +437,50 @@ if (test('still allows a dynamic branch name on push', () => {
   assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
 })) passed++; else failed++;
 
+// `-n` is --no-verify to git commit but "max count" to log/show/diff. Widening the
+// flag scan to commit's set for an expanded subcommand therefore rejected an ordinary
+// `git $SUB -n 5`. Checked against git 2.51:
+//   git log -n 5   ok        git commit -n 5  error: pathspec '5' did not match
+//   git log -n5    ok        git commit -n5   error: unknown switch `5'
+// so `-n<digits>` can never be a commit bypass, and `-n <digits>` is a pathspec that
+// fails unless a file with that numeric name exists. Only those two spellings are
+// exempt, and only when the subcommand is unknown.
+
+if (test('allows an expanded subcommand with -n <count>', () => {
+  const r = runHook({ tool_input: { command: 'git $SUB -n 5' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('allows an expanded subcommand with -n<count> attached', () => {
+  const r = runHook({ tool_input: { command: 'git $SUB -n5' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('allows an expanded subcommand with -n <count> and further flags', () => {
+  const r = runHook({ tool_input: { command: 'git $SUB -n 5 --oneline' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('still blocks a bare -n behind an expanded subcommand', () => {
+  const r = runHook({ tool_input: { command: 'git $SUB -n -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('still blocks -n with no argument behind an expanded subcommand', () => {
+  const r = runHook({ tool_input: { command: 'git $SUB -n' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('still blocks --no-verify behind an expanded subcommand regardless of -n rules', () => {
+  const r = runHook({ tool_input: { command: 'git $SUB --no-verify -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('the count exemption does not leak to a literal commit', () => {
+  const r = runHook({ tool_input: { command: 'git commit -n 5' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
 console.log('─'.repeat(50));
 console.log(`Passed: ${passed}  Failed: ${failed}`);
 

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -264,6 +264,52 @@ if (test('still allows --config-env that sets an unrelated key', () => {
   assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
 })) passed++; else failed++;
 
+// Quoting is transparent to the shell but was not to the guard: detectGitCommand
+// split raw text on whitespace, so `"--config-env=core.hooksPath=MYVAR"` kept its
+// quotes, failed the `startsWith('-')` flag check and landed in subcommand position
+// -- the whole command then escaped inspection. The same hole covered `-c`, which
+// predates --config-env, and a quoted subcommand. Verified against git 2.51: the
+// shell strips these quotes, so git receives the option and skips the hooks.
+// (`git "-c core.hooksPath=..."` as ONE argv is not covered because git itself
+// rejects it: "unknown option: -c core.hooksPath=...", exit 129.)
+
+if (test('blocks a quoted --config-env=core.hooksPath override', () => {
+  const r = runHook({ tool_input: { command: 'git "--config-env=core.hooksPath=MYVAR" commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+  assert.ok(/core\.hookspath/i.test(r.stderr), `stderr should mention core.hooksPath: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('blocks a quoted space-separated --config-env override', () => {
+  const r = runHook({ tool_input: { command: 'git "--config-env" "core.hooksPath=MYVAR" commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks a single-quoted --config-env override', () => {
+  const r = runHook({ tool_input: { command: "git '--config-env=core.hooksPath=MYVAR' commit -m 'msg'" } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks a quoted -c core.hooksPath override', () => {
+  const r = runHook({ tool_input: { command: 'git "-c" "core.hooksPath=/dev/null" commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('sees --no-verify past a quoted global option', () => {
+  const r = runHook({ tool_input: { command: 'git "--config-env=other.key=MYVAR" commit --no-verify -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+  assert.ok(/no-verify/i.test(r.stderr), `stderr should mention --no-verify: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('sees --no-verify past a quoted subcommand', () => {
+  const r = runHook({ tool_input: { command: 'git "commit" --no-verify -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('still allows a quoted global option that sets an unrelated key', () => {
+  const r = runHook({ tool_input: { command: 'git "--config-env=other.key=MYVAR" commit -m "msg"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
 console.log('─'.repeat(50));
 console.log(`Passed: ${passed}  Failed: ${failed}`);
 

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -367,6 +367,76 @@ if (test('still allows a key that merely ends in .path', () => {
   assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
 })) passed++; else failed++;
 
+// tokenizeShellWords strips quotes but does not run the shell, so `$(printf commit)`
+// arrived verbatim while the shell handed git a plain `commit`. Same for the config
+// key: `-c "$(printf core.hooksPath=/dev/null)"` did not match any known key.
+// Both predate this PR -- verified ALLOWED against the merge base d8409a4b too.
+//
+// Failing closed here is deliberately narrow. A dynamic subcommand does not block on
+// its own: the guard keeps inspecting and blocks only if --no-verify or a hook
+// redirect is also present, so `git $CMD status` is fine. For `-c`, only the KEY half
+// is treated as opaque -- an expanded VALUE cannot turn user.name into core.hooksPath.
+
+if (test('blocks --no-verify behind a command-substituted subcommand', () => {
+  const r = runHook({ tool_input: { command: 'git "$(printf commit)" --no-verify -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-verify behind a backticked subcommand', () => {
+  const r = runHook({ tool_input: { command: 'git `echo commit` --no-verify -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-verify behind a variable subcommand', () => {
+  const r = runHook({ tool_input: { command: 'git $SUB --no-verify -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-verify behind a braced variable subcommand', () => {
+  const r = runHook({ tool_input: { command: 'git ${SUB} --no-verify -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks a command-substituted config key', () => {
+  const r = runHook({ tool_input: { command: 'git -c "$(printf core.hooksPath=/dev/null)" commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks a config key hidden in a variable', () => {
+  const r = runHook({ tool_input: { command: 'git -c $CFG commit -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('still allows a command substitution in the commit message', () => {
+  const r = runHook({ tool_input: { command: 'git commit -m "$(cat msg.txt)"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('still allows a backtick inside the commit message', () => {
+  const r = runHook({ tool_input: { command: 'git commit -m "see `date`"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('still allows an expanded VALUE on a literal config key', () => {
+  const r = runHook({ tool_input: { command: 'git -c user.email=$EMAIL commit -m "msg"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('still allows a command-substituted config VALUE', () => {
+  const r = runHook({ tool_input: { command: 'git -c user.name="$(whoami)" commit -m "msg"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('still allows a dynamic subcommand with no bypass flag', () => {
+  const r = runHook({ tool_input: { command: 'git $CMD status' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('still allows a dynamic branch name on push', () => {
+  const r = runHook({ tool_input: { command: 'git push origin $BRANCH' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
 console.log('─'.repeat(50));
 console.log(`Passed: ${passed}  Failed: ${failed}`);
 

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -3,7 +3,6 @@
  */
 
 const assert = require('assert');
-const fs = require('fs');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
@@ -438,27 +437,37 @@ if (test('still allows a dynamic branch name on push', () => {
   assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
 })) passed++; else failed++;
 
-// `-n` is --no-verify to git commit but "max count" to log/show/diff. Widening the
-// flag scan to commit's set for an expanded subcommand therefore rejected an ordinary
-// `git $SUB -n 5`. Checked against git 2.51:
-//   git log -n 5   ok        git commit -n 5  error: pathspec '5' did not match
-//   git log -n5    ok        git commit -n5   error: unknown switch `5'
-// so `-n<digits>` can never be a commit bypass, and `-n <digits>` is a pathspec that
-// fails unless a file with that numeric name exists. Only those two spellings are
-// exempt, and only when the subcommand is unknown.
+// `-n` is --no-verify to git commit but "max count" to log/show/diff, so behind a
+// shell-expanded subcommand it is ambiguous. Only the ATTACHED spelling is exempt,
+// because git commit refuses it outright (git 2.51):
+//   git log -n5      ok          git commit -n5   error: unknown switch `5'
+//
+// The split form is NOT exempt. git commit reads that token as a pathspec, and two
+// verified bypasses came out of trying to decide it from the string, both committing
+// with the pre-commit hook never running:
+//   file `1` present          git commit -n 1 -m x  -> [main 326cf0b] x
+//   `7` staged as a DELETION  git commit -n 7 -m x  -> [main 7e7d466] x
+// The second is why an existsSync test is not enough: git takes a staged deletion as
+// a pathspec while the file is absent from disk. Failing closed costs
+// `git $SUB -n 5`; `git $SUB -n5` and `git $SUB --max-count=5` still work.
 
-if (test('allows an expanded subcommand with -n <count>', () => {
+if (test('blocks split -n <count> behind an expanded subcommand', () => {
   const r = runHook({ tool_input: { command: 'git $SUB -n 5' } });
-  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
 })) passed++; else failed++;
 
-if (test('allows an expanded subcommand with -n<count> attached', () => {
+if (test('blocks the staged-deletion shape that defeated a filesystem check', () => {
+  const r = runHook({ tool_input: { command: 'git $SUB -m "msg" -n 7' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('allows the attached -n<count>, which git commit rejects outright', () => {
   const r = runHook({ tool_input: { command: 'git $SUB -n5' } });
   assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
 })) passed++; else failed++;
 
-if (test('allows an expanded subcommand with -n <count> and further flags', () => {
-  const r = runHook({ tool_input: { command: 'git $SUB -n 5 --oneline' } });
+if (test('allows --max-count behind an expanded subcommand', () => {
+  const r = runHook({ tool_input: { command: 'git $SUB --max-count=5' } });
   assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
 })) passed++; else failed++;
 
@@ -467,62 +476,16 @@ if (test('still blocks a bare -n behind an expanded subcommand', () => {
   assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
 })) passed++; else failed++;
 
-if (test('still blocks -n with no argument behind an expanded subcommand', () => {
-  const r = runHook({ tool_input: { command: 'git $SUB -n' } });
-  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
-})) passed++; else failed++;
-
-if (test('still blocks --no-verify behind an expanded subcommand regardless of -n rules', () => {
+if (test('still blocks --no-verify behind an expanded subcommand', () => {
   const r = runHook({ tool_input: { command: 'git $SUB --no-verify -m "msg"' } });
   assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
 })) passed++; else failed++;
 
-if (test('the count exemption does not leak to a literal commit', () => {
-  const r = runHook({ tool_input: { command: 'git commit -n 5' } });
+if (test('the attached-form exemption does not leak to a literal commit', () => {
+  const r = runHook({ tool_input: { command: 'git commit -n5 -m "msg"' } });
   assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
 })) passed++; else failed++;
 
-// What settles the ambiguous `-n` is that git commit reads the NEXT token as a
-// pathspec, so the command only does anything if that path exists. Checked against
-// git 2.51 in a repo whose pre-commit hook exits 1:
-//   git commit -n 9 -m x   error: pathspec '9' did not match      -> no commit
-//   git commit -n 1 -m x   [main 326cf0b] x, hook never ran       -> real bypass
-// So the split form is exempt only while nothing by that name is on disk. The hook
-// runs with the repo root as cwd, so these two cases create and remove the path.
-const NUMERIC_PATH = '987654321';
-
-if (test('blocks split -n <digits> when that path exists (path-limited commit)', () => {
-  fs.writeFileSync(NUMERIC_PATH, '');
-  try {
-    const r = runHook({ tool_input: { command: `git $SUB -m "msg" -n ${NUMERIC_PATH}` } });
-    assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
-  } finally {
-    fs.rmSync(NUMERIC_PATH, { force: true });
-  }
-})) passed++; else failed++;
-
-if (test('allows split -n <digits> when no such path exists (git commit would error)', () => {
-  assert.ok(!fs.existsSync(NUMERIC_PATH), 'fixture path must be absent');
-  const r = runHook({ tool_input: { command: `git $SUB -n ${NUMERIC_PATH}` } });
-  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
-})) passed++; else failed++;
-
-if (test('attached -n<digits> stays allowed even when that path exists', () => {
-  fs.writeFileSync(NUMERIC_PATH, '');
-  try {
-    // git commit rejects `-n<digits>` outright ("unknown switch"), so it can never
-    // be a bypass regardless of the filesystem.
-    const r = runHook({ tool_input: { command: `git $SUB -n${NUMERIC_PATH}` } });
-    assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
-  } finally {
-    fs.rmSync(NUMERIC_PATH, { force: true });
-  }
-})) passed++; else failed++;
-
-if (test('a literal commit with a numeric pathspec blocks whether or not it exists', () => {
-  const r = runHook({ tool_input: { command: `git commit -n ${NUMERIC_PATH} -m "msg"` } });
-  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
-})) passed++; else failed++;
 
 console.log('─'.repeat(50));
 console.log(`Passed: ${passed}  Failed: ${failed}`);


### PR DESCRIPTION
## The gap

`git --config-env=<name>=<envvar>` reads a config value out of the environment. For `core.hooksPath` it is simply a second spelling of `-c`:

```sh
MYVAR=/dev/null git --config-env=core.hooksPath=MYVAR commit -m x
```

The guard knew about `-c core.hooksPath=` and `-ccore.hooksPath=`, but not this form — so that command ran with the hooks skipped and the hook exited 0.

Verified against **git 2.51** in a scratch repo whose `pre-commit` hook prints and exits 1:

| command | hook ran? | committed? |
| --- | --- | --- |
| `git commit -m t` (control) | yes | no — blocked |
| `git --config-env=core.hooksPath=VAR commit -m t` | **no** | **yes** |
| `git --config-env core.hooksPath=VAR commit -m t` | **no** | **yes** |

An abbreviation of the option name itself (`--config-en=`) is rejected by git, so exact matching of the option is sufficient here — unlike the long flags handled in #2837.

## The wider half: an unknown value-taking global flag blinds the guard

The space-separated form exposed a second problem. `detectGitCommand()` walks the tokens between `git` and the subcommand and requires each one to be a flag or a known flag argument. `--config-env` was not on that list, so its value token (`core.hooksPath=VAR`) read as a bare word, the scanner concluded the following `commit` was not the subcommand, and the guard **stopped inspecting the command altogether**.

That blinded it to everything, not just hooksPath:

```sh
git --config-env other.key=VAR commit --no-verify -m x    # was allowed
```

An explicit `--no-verify` passed straight through. The hardcoded list is now a named set, `GIT_GLOBAL_OPTIONS_WITH_VALUE`, with `--config-env` added.

## What I deliberately did not claim

I also probed `--exec-path` and `--attr-source`, which blind the scanner in the same way. **Neither is exploitable**, so neither is treated as a config-setting option:

- `git --attr-source HEAD commit` — git rejects it; the space form is not valid.
- `git --exec-path /path commit` — bare `--exec-path` prints the exec path and exits 0 **without committing at all**. It looks like a bypass in a naive test (exit 0, no hook output) but no commit is created.

I only found this out by checking whether a commit was actually produced, rather than trusting the exit code — worth flagging in case someone extends the list later.

## Tests

Six cases added to `tests/hooks/block-no-verify.test.js`:

- blocks `--config-env=core.hooksPath=…`
- blocks `--config-env core.hooksPath=…` (space-separated)
- blocks `--config-env=core.HOOKSPATH=…` (config keys are case-insensitive)
- blocks it on `git push` too
- sees `--no-verify` past a `--config-env` that sets an unrelated key (the blinding case)
- **still allows** a `--config-env` that sets an unrelated key (false-positive guard)

```
node tests/hooks/block-no-verify.test.js
Passed: 35  Failed: 0
```

## Note for review

This touches the same file as the still-open #2837, but a different part of it — `detectGitCommand` / `hasHooksPathOverride` here, vs the long-flag matching in `hasNoVerifyFlag` there. The two should merge cleanly in either order. #2837 covers abbreviated `--no-verify` spellings; this covers the config-override channel, so they are complementary rather than overlapping.
