### PR TITLE
fix(agents): correct doc-updater description claiming command-invoking tools

### DIFF
--- a/.kiro/agents/doc-updater.json
+++ b/.kiro/agents/doc-updater.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-updater",
-  "description": "Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Runs /update-codemaps and /update-docs, generates docs/CODEMAPS/*, updates READMEs and guides.",
+  "description": "Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Generates docs/CODEMAPS/*, updates READMEs and guides. Backs the /update-codemaps and /update-docs commands.",
   "mcpServers": {},
   "tools": [
     "@builtin"

--- a/.kiro/agents/doc-updater.md
+++ b/.kiro/agents/doc-updater.md
@@ -1,6 +1,6 @@
 ---
 name: doc-updater
-description: Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Runs /update-codemaps and /update-docs, generates docs/CODEMAPS/*, updates READMEs and guides.
+description: Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Generates docs/CODEMAPS/*, updates READMEs and guides. Backs the /update-codemaps and /update-docs commands.
 allowedTools:
   - read
   - write

--- a/agents/doc-updater.md
+++ b/agents/doc-updater.md
@@ -1,6 +1,6 @@
 ---
 name: doc-updater
-description: Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Runs /update-codemaps and /update-docs, generates docs/CODEMAPS/*, updates READMEs and guides.
+description: Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Generates docs/CODEMAPS/*, updates READMEs and guides. Backs the /update-codemaps and /update-docs commands.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: haiku
 ---


### PR DESCRIPTION
## What Changed

Corrected the `doc-updater` agent description, which claimed a capability the agent does not have.

Before:
> Runs /update-codemaps and /update-docs, generates docs/CODEMAPS/*, updates READMEs and guides.

After:
> Generates docs/CODEMAPS/*, updates READMEs and guides. Backs the /update-codemaps and /update-docs commands.

Applied to the canonical `agents/doc-updater.md` and the two active `.kiro` mirrors carrying the identical string.

## Why This Change

`agents/doc-updater.md` declares `tools: Read, Write, Edit, Bash, Grep, Glob`. There is no command-invoking tool in this repository — `SlashCommand` appears nowhere, and every agent in `agents/` declares an explicit `tools:` allowlist that grants only Read/Write/Edit/Bash/Grep/Glob/WebSearch/WebFetch (plus two context7 MCP tools on `docs-lookup`). No agent can run a slash command.

This matches the documented split: `CONTRIBUTING.md:350` describes commands as user-invoked, `CONTRIBUTING.md:188` describes agents as Task-invoked, and `docs/COMMAND-AGENT-MAP.md:15` records the true direction as `/update-codemaps` -> `doc-updater`.

The agent body was already correct — it invokes generators directly (`npx tsx scripts/codemaps/generate.ts`, `npx madge`, `npx jsdoc2md`) and never mentions a slash command. Only the frontmatter description was wrong.

This matters because agent descriptions drive selection. A description advertising slash-command execution can misroute work here on the assumption the agent can chain commands, which it cannot. It also misleads anyone composing multi-agent flows from the agent catalogue.

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested

Notes:
- `node tests/run-all.js` behaves identically before and after this change. It currently reports one pre-existing failure on `main` unrelated to this PR (`skills/ito-inference` and `skills/ito-training` unreferenced by any install module, from fd27a0ec) — filed separately.
- `npx markdownlint-cli` clean on both changed markdown files.
- `.kiro/agents/doc-updater.json` re-validated as parseable JSON.
- Searched the tree for other copies of the string. The only remaining one is `docs/zh-TW/agents/doc-updater.md`, deliberately left untouched: the locale copies are regenerated as a batch and have already drifted from canonical (they carry `model: opus` where `agents/doc-updater.md` declares `model: haiku`), so a one-locale edit here would add inconsistency rather than remove it. Happy to include it if you would prefer.

## Type of Change

- [x] `fix:` Bug fix

## Security & Quality Checklist

- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable) — n/a, no shell changed
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated relevant documentation — the description itself is the documentation being corrected
- [ ] Added comments for complex logic — n/a
- [ ] README updated (if needed) — n/a, README does not quote this description
