### PR TITLE
fix(hooks): consolidate gateguard and destructive-command fixes (3 PRs)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -36,7 +36,7 @@
         "id": "pre:edit-write:suggest-compact"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -73,7 +73,7 @@
         "id": "pre:config-protection"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -98,7 +98,7 @@
     ],
     "PreCompact": [
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -111,7 +111,7 @@
     ],
     "SessionStart": [
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -122,7 +122,7 @@
         "id": "session:start"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -135,7 +135,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -147,7 +147,7 @@
         "id": "post:dispatcher:sync"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -162,7 +162,7 @@
     ],
     "PostToolUseFailure": [
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -186,7 +186,7 @@
     ],
     "Stop": [
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -197,7 +197,7 @@
         "id": "stop:plan-canvas-pending"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -209,7 +209,7 @@
         "id": "stop:format-typecheck"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -220,7 +220,7 @@
         "id": "stop:check-console-log"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -233,7 +233,7 @@
         "id": "stop:session-end"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -246,7 +246,7 @@
         "id": "stop:evaluate-session"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -259,7 +259,7 @@
         "id": "stop:cost-tracker"
       },
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",
@@ -274,7 +274,7 @@
     ],
     "SessionEnd": [
       {
-        "matcher": "*",
+        "matcher": ".*",
         "hooks": [
           {
             "type": "command",

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -44,11 +44,43 @@ const BASH_HOOK_ID = 'pre:bash:gateguard-fact-force';
 const ECC_DISABLE_VALUES = new Set(['0', 'false', 'off', 'disabled', 'disable']);
 const ECC_ENABLE_VALUES = new Set(['1', 'true', 'on', 'enabled', 'enable', 'yes']);
 
-// SQL-keyword + dd patterns stay as a single regex — they are stable
-// phrases without shell-flag ordering concerns. Quoted strings are
-// stripped before this regex runs so a commit message mentioning
-// "drop table" no longer triggers a false positive.
-const DESTRUCTIVE_SQL_DD = /\b(drop\s+table|delete\s+from|truncate|dd\s+if=)\b/i;
+// SQL phrases stay as a single regex — they are stable phrases without
+// shell-flag ordering concerns. Quoted strings are stripped before this
+// regex runs so a commit message mentioning "drop table" no longer
+// triggers a false positive.
+//
+// Two members used to live here and no longer do:
+//
+//   `truncate` was matched bare, so every mention of the word was
+//   destructive — the Jinja/Django filter, a branch name, a filename, a
+//   line of prose in a commit body. SQL truncation always names a table,
+//   so require the pair; the coreutils binary is caught in command
+//   position by `isDestructiveSimpleCommand`.
+//
+//   `dd\s+if=` could never fire on a real invocation. The trailing `\b`
+//   needs a word character after `=`, but every real use continues with
+//   a path: `dd if=/dev/zero of=/dev/sda` did NOT match, while the inert
+//   `dd if=x` did. `of=` — the operand that actually writes — was never
+//   matched at all. `dd` now has a command-position rule.
+const DESTRUCTIVE_SQL = /\b(drop\s+table|delete\s+from|truncate\s+table)\b/i;
+
+// Paths whose removal costs nothing: agent scratch space, build caches,
+// virtualenvs, test artefacts. Bare `/tmp` is deliberately absent — only
+// clearly-derived directories qualify, so `rm -rf /tmp/junk` still gets
+// challenged.
+const DISPOSABLE_PATH = /(^|\/)(scratchpad|node_modules|__pycache__|\.venv|\.cache|\.pytest_cache|\.mypy_cache|\.ruff_cache|\.vite|\.turbo|test-results|playwright-report|\.playwright-mcp|\.superpowers\/sdd)(\/|$)/;
+
+// Stands for a value that came from `$(mktemp ...)` — a directory the
+// shell itself just created, so deleting it is disposable by definition.
+const MKTEMP_SENTINEL = '\u0000mktemp\u0000';
+
+// Quoted text is replaced by `\u0001<n>\u0001` placeholders so a quoted
+// argument stays ONE opaque token — keeping `git commit -m '(rm -rf x)'`
+// harmless — while its literal content stays recoverable for target
+// analysis. Blanking quotes to `''` threw the content away, which made
+// `rm -rf "$SCRATCH/build"` unjudgeable.
+const QUOTE_SLOT = '\u0001';
+const QUOTE_SLOT_RE = new RegExp(`${QUOTE_SLOT}(\\d+)${QUOTE_SLOT}`, 'g');
 
 // Operator-supplied additional destructive patterns. Lazily compiled from
 // `GATEGUARD_BASH_EXTRA_DESTRUCTIVE` (regex source) on first use, then
@@ -147,8 +179,31 @@ function isRoutineBashGateDisabled() {
  * @param {string} input
  * @returns {string}
  */
-function stripQuotedStrings(input) {
-  return input.replace(/'(?:[^'\\]|\\.)*'/g, "''").replace(/"(?:[^"\\]|\\.)*"/g, '""');
+function stripQuotedStrings(input, slots) {
+  return String(input).replace(/'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"/g, match => {
+    if (!slots) return match[0] === "'" ? "''" : '""';
+    slots.push(match.slice(1, -1));
+    return `${QUOTE_SLOT}${slots.length - 1}${QUOTE_SLOT}`;
+  });
+}
+
+/**
+ * Replace quote placeholders with the literal text they stood for. Used
+ * only on already-tokenized operands, never before command detection —
+ * so quoted text can inform a target check but can never become a
+ * command.
+ *
+ * @param {string} token
+ * @param {string[]} slots
+ * @returns {string}
+ */
+function resolveSlots(token, slots) {
+  if (!slots || slots.length === 0) return String(token);
+  QUOTE_SLOT_RE.lastIndex = 0;
+  return String(token).replace(QUOTE_SLOT_RE, (whole, index) => {
+    const i = Number(index);
+    return Number.isInteger(i) && i >= 0 && i < slots.length ? slots[i] : '';
+  });
 }
 
 /**
@@ -182,8 +237,8 @@ function explodeSubshells(input) {
  * @param {string} input
  * @returns {string[]}
  */
-function splitCommandSegments(input) {
-  const stripped = explodeSubshells(stripQuotedStrings(input));
+function splitCommandSegments(input, slots) {
+  const stripped = explodeSubshells(stripQuotedStrings(input, slots));
   return stripped
     .split(/[;|&]+/)
     .map(segment => segment.replace(/(^|\s)#.*/, '$1').trim())
@@ -344,11 +399,19 @@ const SHELL_WRAPPERS = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh']);
  */
 function isDestructiveQuoteAware(raw, depth = 0) {
   if (depth > 4) return false;
+  // `quoteAwareSegments` already unquotes, so there are no slot
+  // placeholders to resolve here — but the assignment map still has to
+  // be threaded through, or a target like `$SCRATCH/build` reaches
+  // `isDisposableTarget` unresolved and every disposable-path decision
+  // made in the main pass is silently reversed by this one.
+  const ctx = { assignments: collectAssignments(raw), slots: null };
   for (const tokens of quoteAwareSegments(raw)) {
     if (tokens.length === 0) continue;
-    if (isDestructiveRm(tokens)) return true;
+    if (isDestructiveRm(tokens, ctx)) return true;
     if (isDestructiveGit(tokens)) return true;
     if (isDestructiveFindExec(tokens.join(' '))) return true;
+    if (isDestructiveFindDelete(tokens)) return true;
+    if (isDestructiveSimpleCommand(tokens, ctx)) return true;
     const base = commandBasename(tokens[0]);
     if (SHELL_WRAPPERS.has(base)) {
       const ci = tokens.indexOf('-c');
@@ -376,31 +439,159 @@ function commandBasename(token) {
 }
 
 /**
- * Detect `rm` invocations that recursively force-delete files. Handles
- * combined (`-rf`, `-fr`, `-Rf`) and split (`-r -f`) flag forms.
+ * Collect `NAME=value` assignments from a raw command line so a delete
+ * target written as `$SCRATCH/build` can be judged at all. Scripts
+ * almost always define the scratch root in the very command that deletes
+ * from it; without this the disposable-path check sees an opaque `$VAR`
+ * and has nothing to go on.
+ *
+ * Values are read from the RAW line because quote stripping runs later.
+ *
+ * @param {string} raw
+ * @returns {Map<string, string>}
+ */
+function collectAssignments(raw) {
+  const assignments = new Map();
+  const re = /(?:^|[\s;&|(])([A-Za-z_][A-Za-z0-9_]*)=("([^"]*)"|'([^']*)'|[^\s;&|)]*)/g;
+  let match;
+  while ((match = re.exec(String(raw || ''))) !== null) {
+    const name = match[1];
+    let value = match[3] !== undefined ? match[3] : match[4] !== undefined ? match[4] : match[2];
+    if (!value) continue;
+    if (/\$\(\s*mktemp\b/.test(value)) value = MKTEMP_SENTINEL;
+    assignments.set(name, value);
+  }
+  return assignments;
+}
+
+/**
+ * Substitute `$NAME` / `${NAME}` from the assignment map. Unknown names
+ * are left untouched on purpose: the caller treats a still-unresolved
+ * target as opaque, and therefore as NOT disposable.
+ *
+ * @param {string} target
+ * @param {Map<string, string>} assignments
+ * @returns {string}
+ */
+function expandAssignments(target, assignments) {
+  let out = String(target || '');
+  for (let i = 0; i < 4; i += 1) {
+    const before = out;
+    out = out.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g, (whole, braced, bare) => {
+      const key = braced || bare;
+      return assignments.has(key) ? assignments.get(key) : whole;
+    });
+    if (out === before) break;
+  }
+  return out;
+}
+
+/**
+ * A delete target is disposable when it resolves to agent scratch space,
+ * a build cache, a virtualenv or a test-artefact directory.
+ *
+ * Conservative in three ways: a target still carrying an unresolved
+ * `$VAR` is never disposable, a bare root or home directory is never
+ * disposable even if a later path component would match, and the caller
+ * requires EVERY operand to qualify before staying silent.
+ *
+ * @param {string} target
+ * @param {Map<string, string>} assignments
+ * @returns {boolean}
+ */
+function isDisposableTarget(target, assignments) {
+  const expanded = expandAssignments(target, assignments || new Map());
+  if (!expanded) return false;
+  if (expanded.includes(MKTEMP_SENTINEL)) return true;
+  if (/\$/.test(expanded)) return false;
+  const normalized = expanded.replace(/\\/g, '/').replace(/\/+$/, '');
+  if (!normalized || normalized === '~' || normalized === '.' || normalized === '..') return false;
+  if (/^\/(usr|etc|var|bin|sbin|lib|opt|home|Users|System|Library|boot|dev|proc)?$/.test(normalized)) return false;
+  return DISPOSABLE_PATH.test(normalized);
+}
+
+/**
+ * Split an argument list into flags and operands, resolving quote
+ * placeholders on the operands so `"$SCRATCH/build"` is judgeable.
+ *
+ * @param {string[]} args
+ * @param {string[]} slots
+ * @returns {{ flags: string[], targets: string[] }}
+ */
+function partitionArgs(args, slots) {
+  const flags = [];
+  const targets = [];
+  let endOfFlags = false;
+  for (const arg of args) {
+    if (!endOfFlags && arg === '--') {
+      endOfFlags = true;
+      continue;
+    }
+    if (!endOfFlags && arg.startsWith('-') && arg.length > 1) {
+      flags.push(arg);
+      continue;
+    }
+    targets.push(resolveSlots(arg, slots));
+  }
+  return { flags, targets };
+}
+
+function isDestructiveRm(tokens, ctx) {
+  if (tokens.length === 0 || commandBasename(tokens[0]) !== 'rm') return false;
+  const { flags, targets } = partitionArgs(tokens.slice(1), ctx && ctx.slots);
+  let hasR = false;
+  for (const flag of flags) {
+    if (flag === '--recursive') {
+      hasR = true;
+      continue;
+    }
+    if (flag.startsWith('--')) continue;
+    if (/[rR]/.test(flag.slice(1))) hasR = true;
+  }
+  if (!hasR) return false;
+  if (targets.length === 0) return true;
+  return !targets.every(target => isDisposableTarget(target, ctx && ctx.assignments));
+}
+
+/**
+ * `find ... -delete` removes without ever naming a command, so neither
+ * the `rm` rule nor `isDestructiveFindExec` sees it.
  *
  * @param {string[]} tokens
  * @returns {boolean}
  */
-function isDestructiveRm(tokens) {
-  if (tokens.length === 0 || commandBasename(tokens[0]) !== 'rm') return false;
-  let hasR = false;
-  let hasF = false;
-  for (const t of tokens.slice(1)) {
-    if (t === '--recursive') {
-      hasR = true;
-      continue;
-    }
-    if (t === '--force') {
-      hasF = true;
-      continue;
-    }
-    if (!t.startsWith('-') || t.startsWith('--')) continue;
-    const body = t.slice(1);
-    if (/[rR]/.test(body)) hasR = true;
-    if (/f/.test(body)) hasF = true;
+function isDestructiveFindDelete(tokens) {
+  if (tokens.length === 0 || commandBasename(tokens[0]) !== 'find') return false;
+  return tokens.slice(1).includes('-delete');
+}
+
+/**
+ * Single-purpose destroyers with no flag subtleties: `shred` (overwrite
+ * then unlink), a standalone `unlink` (previously only caught inside
+ * `find -exec`), the coreutils `truncate` (shrinks a file in place —
+ * the real hazard the bare word-match was reaching for), and `dd`
+ * writing to or reading from a device.
+ *
+ * @param {string[]} tokens
+ * @param {{ assignments: Map<string, string>, slots: string[] }} ctx
+ * @returns {boolean}
+ */
+function isDestructiveSimpleCommand(tokens, ctx) {
+  if (tokens.length === 0) return false;
+  const command = commandBasename(tokens[0]);
+  const args = tokens.slice(1);
+
+  if (command === 'dd') {
+    return args.some(arg => /^(if|of)=/i.test(arg));
   }
-  return hasR && hasF;
+
+  if (command === 'shred' || command === 'unlink' || command === 'truncate') {
+    const { targets } = partitionArgs(args, ctx && ctx.slots);
+    if (targets.length === 0) return true;
+    return !targets.every(target => isDisposableTarget(target, ctx && ctx.assignments));
+  }
+
+  return false;
 }
 
 /**
@@ -672,8 +863,9 @@ function isDestructiveBash(command) {
   // after quoting AND subshell delimiters are normalized so phrases
   // inside `$(...)` or backticks are also caught.
   const raw = String(command || '');
+  const assignments = collectAssignments(raw);
   const flattened = explodeSubshells(stripQuotedStrings(raw));
-  if (DESTRUCTIVE_SQL_DD.test(flattened)) return true;
+  if (DESTRUCTIVE_SQL.test(flattened)) return true;
 
   // Operator-supplied additional destructive patterns. Same scope as the
   // built-in SQL/dd regex: matched against the quote-stripped, subshell-
@@ -697,14 +889,20 @@ function isDestructiveBash(command) {
     }
   }
 
-  const segments = bodies.flatMap(splitCommandSegments);
-  for (const segment of segments) {
-    const stripped = stripQuotedStrings(segment);
-    if (DESTRUCTIVE_SQL_DD.test(stripped)) return true;
-    if (extra && extra.test(stripped)) return true;
-    const tokens = tokenize(segment);
-    if (isDestructiveRm(tokens)) return true;
-    if (isDestructiveGit(tokens)) return true;
+  // Each executable body gets its own slot table: placeholder indices
+  // are only meaningful alongside the strip pass that produced them.
+  for (const body of bodies) {
+    const slots = [];
+    const ctx = { assignments, slots };
+    for (const segment of splitCommandSegments(body, slots)) {
+      if (DESTRUCTIVE_SQL.test(segment)) return true;
+      if (extra && extra.test(segment)) return true;
+      const tokens = tokenize(segment);
+      if (isDestructiveRm(tokens, ctx)) return true;
+      if (isDestructiveGit(tokens)) return true;
+      if (isDestructiveFindDelete(tokens)) return true;
+      if (isDestructiveSimpleCommand(tokens, ctx)) return true;
+    }
   }
 
   // Quote-aware pass: closes the quoted-command-word, newline-separator,

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -1103,6 +1103,17 @@ function getFullDenialBudget() {
   return DEFAULT_FULL_DENIALS;
 }
 
+// Edit/Write fact forcing can be capped per session instead of denying every
+// new path forever. Keep the existing behavior when unset; hosts can opt in
+// to a session-wide ceiling without weakening the destructive-Bash gate.
+function getMaxDenialBudget() {
+  const raw = Number.parseInt(process.env.GATEGUARD_FACT_FORCE_MAX_DENIALS || '', 10);
+  if (Number.isInteger(raw) && raw >= 0) {
+    return raw;
+  }
+  return Number.POSITIVE_INFINITY;
+}
+
 function getDenialCount(state) {
   const n = Number(state && state.fact_force_denials);
   return Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0;
@@ -1402,6 +1413,9 @@ function run(rawInput) {
       if (!ok) {
         return allowWithStateWarning();
       }
+      if (denials > getMaxDenialBudget()) {
+        return rawInput;
+      }
       if (denials > getFullDenialBudget()) {
         const action = toolName === 'Edit' ? 'edit' : 'creation';
         return denyResult(condensedGateMsg(action, filePath, denials), { includeRecoveryHint: false });
@@ -1424,6 +1438,9 @@ function run(rawInput) {
         const { ok, denials } = markCheckedAndCountDenial(filePath);
         if (!ok) {
           return allowWithStateWarning();
+        }
+        if (denials > getMaxDenialBudget()) {
+          return rawInput;
         }
         if (denials > getFullDenialBudget()) {
           return denyResult(condensedGateMsg('edit', filePath, denials), { includeRecoveryHint: false });

--- a/skills/gateguard/SKILL.md
+++ b/skills/gateguard/SKILL.md
@@ -106,6 +106,12 @@ near-identical blocks cannot accumulate in the context window and
 amplify model repetition loops (#2142). Retrying the same file or
 command after presenting facts never re-triggers the gate.
 
+Set `GATEGUARD_FACT_FORCE_MAX_DENIALS` to cap the total number of new-path
+Edit/Write denials in a session. It is opt-in (unset preserves the existing
+behavior); after the configured number of denials new paths are allowed while
+destructive Bash remains gated independently. `GATEGUARD_FACT_FORCE_FULL_DENIALS`
+only controls message detail.
+
 ### Option B: Full package with config
 
 ```bash

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -2222,6 +2222,38 @@ function runTests() {
 
   clearState();
   if (
+    test('allows new paths after the session-wide denial budget', () => {
+      writeState({ checked: [], last_active: Date.now(), fact_force_denials: 3 });
+      const result = runHook(
+        { tool_name: 'Edit', tool_input: { file_path: '/src/after-budget.js' } },
+        { GATEGUARD_FACT_FORCE_MAX_DENIALS: '3' }
+      );
+      assert.strictEqual(result.code, 0);
+      const output = parseOutput(result.stdout);
+      assert.ok(!output || !output.hookSpecificOutput, 'paths after the budget should pass through');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('MultiEdit allows new paths after the session-wide denial budget', () => {
+      writeState({ checked: [], last_active: Date.now(), fact_force_denials: 3 });
+      const result = runHook(
+        { tool_name: 'MultiEdit', tool_input: { edits: [{ file_path: '/src/after-multi-budget.js', old_string: 'a', new_string: 'b' }] } },
+        { GATEGUARD_FACT_FORCE_MAX_DENIALS: '3' }
+      );
+      assert.strictEqual(result.code, 0);
+      const output = parseOutput(result.stdout);
+      assert.ok(!output || !output.hookSpecificOutput, 'MultiEdit paths after the budget should pass through');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
     test('malformed denial counter in state is treated as zero (full block, no crash)', () => {
       writeState({ checked: [], last_active: Date.now(), fact_force_denials: 'garbage' });
       const result = runHook({ tool_name: 'Edit', tool_input: { file_path: '/src/damp-malformed.js' } });

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -2456,6 +2456,95 @@ function runTests() {
     passed++;
   else failed++;
 
+  // --- Destructive-detector precision -------------------------------
+  // Coverage gaps: operations that destroy but named no matched pattern.
+
+  if (test('denies rm -r without -f (recursive delete of a source tree)', () => {
+    expectDestructiveDeny('rm -r /srv/app/src', 'rm -r without -f');
+  })) passed++; else failed++;
+
+  if (test('denies rm --recursive without --force', () => {
+    expectDestructiveDeny('rm --recursive /srv/app/src', 'rm --recursive');
+  })) passed++; else failed++;
+
+  if (test('denies find -delete', () => {
+    expectDestructiveDeny('find /srv -name "*.conf" -delete', 'find -delete');
+  })) passed++; else failed++;
+
+  if (test('denies shred', () => {
+    expectDestructiveDeny('shred -u /srv/secrets.env', 'shred');
+  })) passed++; else failed++;
+
+  if (test('denies standalone unlink outside find -exec', () => {
+    expectDestructiveDeny('unlink /srv/app/config.json', 'bare unlink');
+  })) passed++; else failed++;
+
+  if (test('denies coreutils truncate shrinking a file', () => {
+    expectDestructiveDeny('truncate -s 0 /var/log/audit.log', 'truncate -s 0');
+  })) passed++; else failed++;
+
+  // `dd if=/dev/...` never matched the old `\b`-terminated pattern: `=`
+  // and `/` are both non-word, so the boundary could not hold. The inert
+  // `dd if=x` matched instead. `of=` was never matched at all.
+  if (test('denies dd writing to a raw device (old pattern could not match)', () => {
+    expectDestructiveDeny('dd if=/dev/zero of=/dev/sda bs=1m', 'dd if=/dev/... of=/dev/...');
+  })) passed++; else failed++;
+
+  if (test('denies dd with of= before if=', () => {
+    expectDestructiveDeny('dd of=/dev/sda if=/dev/zero', 'dd of= first');
+  })) passed++; else failed++;
+
+  // Precision: the bare word `truncate` is prose far more often than it
+  // is SQL. Require the pair; keep the SQL sense working.
+  if (test('allows the word truncate in unquoted prose', () => {
+    expectAllow('echo applying the truncate filter to the summary', 'truncate as prose');
+  })) passed++; else failed++;
+
+  if (test('allows a branch or file name containing truncate', () => {
+    expectAllow('git switch feature/truncate-jinja-filter', 'truncate in a ref name');
+  })) passed++; else failed++;
+
+  if (test('still denies SQL TRUNCATE TABLE', () => {
+    expectDestructiveDeny('psql -c TRUNCATE TABLE users', 'truncate table');
+  })) passed++; else failed++;
+
+  // Precision: deleting derived directories is not a loss worth gating.
+  if (test('allows rm -rf of a node_modules cache', () => {
+    expectAllow('rm -rf node_modules/.vite', 'disposable: build cache');
+  })) passed++; else failed++;
+
+  if (test('allows rm -rf of a virtualenv', () => {
+    expectAllow('rm -rf collectors/.venv', 'disposable: virtualenv');
+  })) passed++; else failed++;
+
+  if (test('allows rm -rf of a quoted scratch path built from a variable', () => {
+    expectAllow('S=/var/folders/x/scratchpad && rm -rf "$S/mut"', 'disposable: $VAR scratch');
+  })) passed++; else failed++;
+
+  if (test('allows rm -rf of a $(mktemp -d) directory', () => {
+    expectAllow('SANDBOX="$(mktemp -d)" && rm -rf "$SANDBOX"', 'disposable: mktemp');
+  })) passed++; else failed++;
+
+  // ...but only when EVERY operand is disposable, and never when the
+  // gate cannot resolve what it is being pointed at.
+  if (test('denies rm -rf when one operand is not disposable', () => {
+    expectDestructiveDeny('rm -rf node_modules /srv/app/src', 'mixed operands');
+  })) passed++; else failed++;
+
+  if (test('denies rm -rf of an unresolved variable', () => {
+    expectDestructiveDeny('rm -rf "$UNKNOWN_ROOT/data"', 'unresolved $VAR');
+  })) passed++; else failed++;
+
+  if (test('denies rm -rf of a bare /tmp child (not a derived directory)', () => {
+    expectDestructiveDeny('rm -rf /tmp/junk', '/tmp is not disposable');
+  })) passed++; else failed++;
+
+  // Quote slots must inform target checks without ever letting quoted
+  // text be parsed as a command.
+  if (test('still allows a destructive-looking string inside a commit message', () => {
+    expectAllow("git commit -m 'cleanup: drop the rm -rf /tmp/junk workaround'", 'quoted prose stays inert');
+  })) passed++; else failed++;
+
   // Cleanup only the temp directory created by this test file.
   try {
     if (fs.existsSync(stateDir)) {

--- a/tests/hooks/hooks.test.js
+++ b/tests/hooks/hooks.test.js
@@ -2550,7 +2550,7 @@ async function runTests() {
         ['post:dispatcher:sync', 'post:dispatcher:async'],
         'PostToolUse should have one sync and one async dispatcher'
       );
-      assert.ok(postEntries.every(entry => entry.matcher === '*'));
+      assert.ok(postEntries.every(entry => entry.matcher === '.*'));
 
       const preCommand = Array.isArray(preBash[0].hooks[0].command) ? preBash[0].hooks[0].command.join(' ') : preBash[0].hooks[0].command;
 
@@ -2559,6 +2559,22 @@ async function runTests() {
       assert.ok(postEntries[0].hooks[0].command.endsWith('" sync'));
       assert.ok(postEntries[1].hooks[0].command.includes('posttooluse-dispatcher.js'));
       assert.ok(postEntries[1].hooks[0].command.endsWith('" async'));
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('all string hook matchers are valid regular expressions', () => {
+      const hooksPath = path.join(__dirname, '..', '..', 'hooks', 'hooks.json');
+      const hooks = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+
+      for (const [eventName, hookArray] of Object.entries(hooks.hooks)) {
+        for (const entry of hookArray) {
+          if (typeof entry.matcher !== 'string') continue;
+          assert.doesNotThrow(() => new RegExp(entry.matcher), `${eventName}/${entry.id || 'hook'} should use a valid regex matcher`);
+        }
+      }
     })
   )
     passed++;


### PR DESCRIPTION
## Summary

Consolidates bug fixes for gateguard, destructive command detection, and config protection into a single PR.

### Merged (3)
- #2751 — fix(hooks): use valid wildcard matchers
- #2624 — fix(hooks/gateguard): close destructive-detector gaps
- #2755 — fix(gateguard): cap session fact-force denials

### Conflicts — need rebase by branch owners (7)
- #2832 — fix(gateguard): look past sudo/doas/env
- #2829 — fix(gateguard): deny dd word-initial
- #2837 — fix(block-no-verify): match abbreviated --no-verify
- #2858 — fix(block-no-verify): treat --config-env as hooksPath
- #2721 — fix(hooks): close PowerShell destructive gate bypass
- #2380 — fix(hooks): do not echo raw input
- #2845 — fix(config-protection): protect ignore files

Closes #2751
Closes #2624
Closes #2755
