### PR TITLE
fix(skills): consolidate skills-related fixes (6 PRs)

### DIFF
--- a/rules/common/coding-style.md
+++ b/rules/common/coding-style.md
@@ -58,11 +58,19 @@ ALWAYS validate at system boundaries:
 
 ## Naming Conventions
 
-- Variables and functions: `camelCase` with descriptive names
-- Booleans: prefer `is`, `has`, `should`, or `can` prefixes
-- Interfaces, types, and components: `PascalCase`
-- Constants: `UPPER_SNAKE_CASE`
-- Custom hooks: `camelCase` with a `use` prefix
+> **Language note**: This rule may be overridden by language-specific rules for
+> languages where this pattern is not idiomatic. Casing in particular belongs to
+> the language file — e.g. PEP 8 for Python, `snake_case` for Rust, `camelCase`
+> for Java and Kotlin. React hook naming lives in
+> [react/coding-style.md](../react/coding-style.md).
+
+Language-independent:
+
+- Descriptive names: the name says what the thing holds or does, without a comment.
+- Booleans read as a claim: prefix with `is`, `has`, `should` or `can`.
+- Where the language draws the distinction, constants and types are visually
+  distinct from ordinary values (`UPPER_SNAKE_CASE` and `PascalCase` in many
+  languages) — whether it draws it at all is for the language file to say.
 
 ## Code Smells to Avoid
 

--- a/rules/typescript/coding-style.md
+++ b/rules/typescript/coding-style.md
@@ -113,6 +113,39 @@ export function formatUser(user) {
 }
 ```
 
+## Naming Conventions
+
+Follow standard TypeScript/JavaScript naming conventions:
+
+- Variables, functions, methods, and object properties: `camelCase` with descriptive names
+- Interfaces, type aliases, classes, enums, and React components: `PascalCase`
+- Constants and top-level immutable configurations: `UPPER_SNAKE_CASE`
+- Booleans: prefer `is`, `has`, `should`, or `can` prefixes (`isActive`, `hasPermission`, `shouldRetry`)
+- React custom hooks: `camelCase` with a `use` prefix (`useAuth`, `useLocalStorage`)
+- Generics: single uppercase letter (`T`, `K`, `V`) or descriptive PascalCase with `T` prefix (`TData`, `TError`)
+
+```typescript
+// Variables and functions
+const userProfile = await fetchUserProfile(userId)
+
+// Interfaces and types
+interface UserProfile {
+  userId: string
+  isActive: boolean
+}
+
+type QueryStatus = 'idle' | 'loading' | 'success' | 'error'
+
+// Constants
+const MAX_RETRY_COUNT = 3
+const DEFAULT_TIMEOUT_MS = 5000
+
+// React custom hooks
+function useDebounce<TValue>(value: TValue, delayMs: number): TValue {
+  // ...
+}
+```
+
 ## Immutability
 
 Use spread operator for immutable updates:

--- a/scripts/ci/validate-skills.js
+++ b/scripts/ci/validate-skills.js
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 /**
- * Validate curated skill directories (skills/ in repo).
+ * Validate curated skill directories (skills/ in repo) and their
+ * translated mirrors (docs/{locale}/skills/ in repo).
  *
  * Checks:
  *   1. Each sub-directory of skills/ contains a SKILL.md file.
  *   2. SKILL.md is non-empty.
- *   3. SKILL.md frontmatter (if present) declares a `name:` field.
+ *   3. SKILL.md frontmatter is present and declares both `name:` and
+ *      `description:` fields.
  *   4. SKILL.md frontmatter `description:` uses an inline scalar — not a
  *      literal block scalar (`|` / `|-` / `|+`), which preserves internal
  *      newlines and breaks flat-table renderers keyed off `description`.
@@ -17,14 +19,16 @@
  *
  * Structural findings (missing/empty SKILL.md) are always errors.
  *
- * Scope: curated only. Learned/imported/evolved roots are out of scope.
- * If skills/ does not exist, exit 0 (no curated skills to validate).
+ * Scope: curated skills/ plus translated docs/{locale}/skills/ mirrors.
+ * Learned/imported/evolved roots are out of scope. If neither root
+ * exists, exit 0 (nothing to validate).
  */
 
 const fs = require('fs');
 const path = require('path');
 
 const SKILLS_DIR = path.join(__dirname, '../../skills');
+const DOCS_DIR = path.join(__dirname, '../../docs');
 
 const STRICT = process.argv.includes('--strict') || process.env.CI_STRICT_SKILLS === '1';
 
@@ -66,6 +70,7 @@ function extractFrontmatter(content) {
  */
 function inspectFrontmatter(lines) {
   const values = Object.create(null);
+  const syntaxErrors = [];
   let descriptionIndicator = null;
   let inBlockScalar = false;
   let blockScalarIndent = -1;
@@ -96,6 +101,27 @@ function inspectFrontmatter(lines) {
       .trim();
     values[key] = valueNoComment;
 
+    const isQuoted = /^"(?:[^"\\]|\\.)*"$/.test(valueNoComment) || /^'(?:[^']|'')*'$/.test(valueNoComment);
+
+    if (!isQuoted && valueNoComment !== '') {
+      // A plain (unquoted) YAML scalar can never contain ": " — that
+      // sequence starts a new mapping key. When the translation pass
+      // drops a value's quoting, or glues the next frontmatter key onto
+      // the end of a value, this is exactly what shows up (see #2630).
+      if (valueNoComment.includes(': ')) {
+        syntaxErrors.push(
+          `${key}: unquoted value contains ': ' — invalid YAML; ` + `quote the value or the next key was likely glued onto this line`
+        );
+      }
+
+      // '@' and '`' are reserved YAML indicators and cannot start a
+      // plain scalar (see #2630 — a reordering during translation moved
+      // '@' into the first column of an unquoted description).
+      if (/^[@`]/.test(valueNoComment)) {
+        syntaxErrors.push(`${key}: unquoted value starts with reserved character '${valueNoComment[0]}' — quote the value`);
+      }
+    }
+
     // Detect literal / folded block-scalar indicators. Accept chomp
     // modifiers (`-` / `+`) and optional indent-indicator digits in
     // either order, per YAML 1.2.
@@ -108,7 +134,7 @@ function inspectFrontmatter(lines) {
     }
   }
 
-  return { values, descriptionIndicator };
+  return { values, descriptionIndicator, syntaxErrors };
 }
 
 /**
@@ -120,6 +146,10 @@ function inspectFrontmatter(lines) {
  * `reportFrontmatterFinding`, which owns the WARN/ERROR decision based
  * on strict mode.
  *
+ * Curated skills/ tolerates a SKILL.md with no frontmatter block at all
+ * (frontmatter checks only apply when a block is present) — this mirrors
+ * pre-existing behavior and is covered by an explicit regression test.
+ *
  * @param {string} dir
  * @param {string} skillsDir
  * @param {(msg: string) => void} reportFrontmatterFinding
@@ -127,8 +157,35 @@ function inspectFrontmatter(lines) {
  */
 function validateSkillDir(dir, skillsDir, reportFrontmatterFinding) {
   const skillMd = path.join(skillsDir, dir, 'SKILL.md');
+  return validateSkillFile(skillMd, `${dir}/SKILL.md`, reportFrontmatterFinding, { requireFrontmatter: false });
+}
+
+/**
+ * Validate a single SKILL.md file at an arbitrary path.
+ *
+ * Shared by the curated skills/ scan and the translated
+ * docs/{locale}/skills/ scan — same checks apply to both, since a
+ * translated mirror's frontmatter must be just as parseable as the
+ * English original (see #2630).
+ *
+ * `requireFrontmatter: true` (used for docs/{locale}/skills/ mirrors)
+ * flags a completely missing frontmatter block as a finding — the
+ * translated mirror must carry the same `name`/`description` as its
+ * English original. Curated skills/ (requireFrontmatter: false) keeps
+ * the pre-existing tolerant behavior of skipping checks entirely when no
+ * block is present.
+ *
+ * @param {string} skillMd
+ * @param {string} label
+ * @param {(msg: string) => void} reportFrontmatterFinding
+ * @param {{requireFrontmatter?: boolean}} [opts]
+ * @returns {{fatal: boolean}}
+ */
+function validateSkillFile(skillMd, label, reportFrontmatterFinding, opts = {}) {
+  const { requireFrontmatter = false } = opts;
+
   if (!fs.existsSync(skillMd)) {
-    console.error(`ERROR: ${dir}/ - Missing SKILL.md`);
+    console.error(`ERROR: ${label} - Missing SKILL.md`);
     return { fatal: true };
   }
 
@@ -136,42 +193,93 @@ function validateSkillDir(dir, skillsDir, reportFrontmatterFinding) {
   try {
     content = fs.readFileSync(skillMd, 'utf-8');
   } catch (err) {
-    console.error(`ERROR: ${dir}/SKILL.md - ${err.message}`);
+    console.error(`ERROR: ${label} - ${err.message}`);
     return { fatal: true };
   }
   if (content.trim().length === 0) {
-    console.error(`ERROR: ${dir}/SKILL.md - Empty file`);
+    console.error(`ERROR: ${label} - Empty file`);
     return { fatal: true };
   }
 
   const fm = extractFrontmatter(content);
-  if (fm.present) {
-    const { values, descriptionIndicator } = inspectFrontmatter(fm.lines);
-
-    if (!Object.prototype.hasOwnProperty.call(values, 'name')) {
-      reportFrontmatterFinding(`${dir}/SKILL.md - frontmatter missing required field: name`);
-    } else if (values.name === '') {
-      reportFrontmatterFinding(`${dir}/SKILL.md - frontmatter 'name' is empty`);
+  if (!fm.present) {
+    if (requireFrontmatter) {
+      reportFrontmatterFinding(`${label} - no frontmatter block found (missing name/description)`);
     }
+    return { fatal: false };
+  }
 
-    if (descriptionIndicator && descriptionIndicator.startsWith('|')) {
-      reportFrontmatterFinding(
-        `${dir}/SKILL.md - frontmatter description uses literal block scalar ` + `'${descriptionIndicator}' which preserves internal newlines; ` + `use an inline string or folded '>' scalar instead`
-      );
-    }
+  const { values, descriptionIndicator, syntaxErrors } = inspectFrontmatter(fm.lines);
+
+  if (!Object.prototype.hasOwnProperty.call(values, 'name')) {
+    reportFrontmatterFinding(`${label} - frontmatter missing required field: name`);
+  } else if (values.name === '') {
+    reportFrontmatterFinding(`${label} - frontmatter 'name' is empty`);
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(values, 'description')) {
+    reportFrontmatterFinding(`${label} - frontmatter missing required field: description`);
+  } else if (values.description === '') {
+    reportFrontmatterFinding(`${label} - frontmatter 'description' is empty`);
+  }
+
+  if (descriptionIndicator && descriptionIndicator.startsWith('|')) {
+    reportFrontmatterFinding(
+      `${label} - frontmatter description uses literal block scalar ` + `'${descriptionIndicator}' which preserves internal newlines; ` + `use an inline string or folded '>' scalar instead`
+    );
+  }
+
+  for (const syntaxError of syntaxErrors) {
+    reportFrontmatterFinding(`${label} - frontmatter ${syntaxError}`);
   }
 
   return { fatal: false };
 }
 
-function validateSkills() {
-  if (!fs.existsSync(SKILLS_DIR)) {
-    console.log('No curated skills directory (skills/), skipping');
-    process.exit(0);
+/**
+ * Find every SKILL.md under docs/{locale}/skills/*, mirroring the
+ * curated skills/ layout one locale directory deeper.
+ *
+ * @param {string} docsDir
+ * @returns {Array<{skillMd: string, label: string}>}
+ */
+function findDocsSkillFiles(docsDir) {
+  if (!fs.existsSync(docsDir)) return [];
+
+  const files = [];
+  const locales = fs
+    .readdirSync(docsDir, { withFileTypes: true })
+    .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+    .map(e => e.name);
+
+  for (const locale of locales) {
+    const localeSkillsDir = path.join(docsDir, locale, 'skills');
+    if (!fs.existsSync(localeSkillsDir)) continue;
+
+    const skillDirs = fs
+      .readdirSync(localeSkillsDir, { withFileTypes: true })
+      .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+      .map(e => e.name);
+
+    for (const skillDir of skillDirs) {
+      files.push({
+        skillMd: path.join(localeSkillsDir, skillDir, 'SKILL.md'),
+        label: `docs/${locale}/skills/${skillDir}/SKILL.md`
+      });
+    }
   }
 
-  const entries = fs.readdirSync(SKILLS_DIR, { withFileTypes: true });
-  const dirs = entries.filter(e => e.isDirectory() && !e.name.startsWith('.')).map(e => e.name);
+  return files;
+}
+
+function validateSkills() {
+  const curatedExists = fs.existsSync(SKILLS_DIR);
+  const docsSkillFiles = findDocsSkillFiles(DOCS_DIR);
+
+  if (!curatedExists && docsSkillFiles.length === 0) {
+    console.log('No skills directory (skills/ or docs/*/skills/), skipping');
+    process.exit(0);
+  }
 
   let hasErrors = false;
   let warnCount = 0;
@@ -187,8 +295,22 @@ function validateSkills() {
     }
   };
 
-  for (const dir of dirs) {
-    const { fatal } = validateSkillDir(dir, SKILLS_DIR, reportFrontmatterFinding);
+  if (curatedExists) {
+    const entries = fs.readdirSync(SKILLS_DIR, { withFileTypes: true });
+    const dirs = entries.filter(e => e.isDirectory() && !e.name.startsWith('.')).map(e => e.name);
+
+    for (const dir of dirs) {
+      const { fatal } = validateSkillDir(dir, SKILLS_DIR, reportFrontmatterFinding);
+      if (fatal) {
+        hasErrors = true;
+        continue;
+      }
+      validCount++;
+    }
+  }
+
+  for (const { skillMd, label } of docsSkillFiles) {
+    const { fatal } = validateSkillFile(skillMd, label, reportFrontmatterFinding, { requireFrontmatter: true });
     if (fatal) {
       hasErrors = true;
       continue;

--- a/skills/autonomous-agent-harness/SKILL.md
+++ b/skills/autonomous-agent-harness/SKILL.md
@@ -119,13 +119,13 @@ Trigger Claude Code agents remotely for event-driven workflows.
 **Dispatch patterns:**
 
 ```bash
-# Trigger from CI/CD
-curl -X POST "https://api.anthropic.com/dispatch" \
-  -H "Authorization: Bearer $ANTHROPIC_API_KEY" \
-  -d '{"prompt": "Build failed on main. Diagnose and fix.", "project": "/repo"}'
+# Trigger from CI/CD — run Claude Code headless inside the pipeline
+# (e.g., a GitHub Actions step; there is no hosted Anthropic "dispatch" endpoint)
+claude -p "Build failed on main. Read the CI logs in ci-failure.log, diagnose, and fix." \
+  --allowedTools "Read,Edit,Bash,Grep,Glob"
 
 # Trigger from webhook
-# GitHub webhook → dispatch → Claude agent → fix → PR
+# GitHub webhook → your listener → spawns `claude -p` in the repo → fix → PR
 
 # Trigger from another agent
 claude -p "Analyze the output of the security scan and create issues for findings"
@@ -186,24 +186,29 @@ description: Persistent task queue for autonomous operation
 
 ## Setup Guide
 
-### Step 1: Configure MCP Servers
+### Step 1: Wire Up Memory, Scheduling, and Browser Control
 
-Ensure these are in `~/.claude.json`:
+Use the capabilities that actually ship with Claude Code — Anthropic does not
+publish npm packages for these:
+
+- **Memory**: Claude Code's built-in persistent memory
+  (`~/.claude/projects/<project>/memory/` + `MEMORY.md` index). For a graph
+  layer, add a community memory MCP server of your choice to `mcpServers`
+  after reviewing its source.
+- **Scheduling**: Claude Code's native scheduled/background tasks (Cron tools
+  in supported clients) or plain OS schedulers (Windows Task Scheduler,
+  cron/launchd) invoking `claude -p "..."`.
+- **Browser / computer control**: the Claude in Chrome extension
+  (`mcp__claude-in-chrome__*` tools) or a Playwright MCP server.
+
+Example `mcpServers` entry (only add servers you have vetted):
 
 ```json
 {
   "mcpServers": {
-    "memory": {
+    "playwright": {
       "command": "npx",
-      "args": ["-y", "@anthropic/memory-mcp-server"]
-    },
-    "scheduled-tasks": {
-      "command": "npx",
-      "args": ["-y", "@anthropic/scheduled-tasks-mcp-server"]
-    },
-    "computer-use": {
-      "command": "npx",
-      "args": ["-y", "@anthropic/computer-use-mcp-server"]
+      "args": ["-y", "@playwright/mcp@latest"]
     }
   }
 }

--- a/skills/browser-qa/SKILL.md
+++ b/skills/browser-qa/SKILL.md
@@ -98,7 +98,7 @@ credentials/tokens/PII before saving any screenshot.
 ## Integration
 
 Works with any browser MCP:
-- `mChild__claude-in-chrome__*` tools (preferred — uses your actual Chrome)
+- `mcp__claude-in-chrome__*` tools (preferred — uses your actual Chrome)
 - Playwright via `mcp__browserbase__*`
 - Direct Puppeteer scripts
 

--- a/skills/rules-distill/scripts/scan-rules.sh
+++ b/skills/rules-distill/scripts/scan-rules.sh
@@ -19,7 +19,7 @@ fi
 files=()
 while IFS= read -r f; do
   files+=("$f")
-done < <(find "$RULES_DIR" -name '*.md' -not -path '*/_archived/*' -print | sort)
+done < <(find -L "$RULES_DIR" -name '*.md' -not -path '*/_archived/*' -print | sort)
 
 total=${#files[@]}
 

--- a/skills/rules-distill/scripts/scan-skills.sh
+++ b/skills/rules-distill/scripts/scan-skills.sh
@@ -77,7 +77,7 @@ scan_dir_to_json() {
       '{path:$path,name:$name,description:$description,mtime:$mtime}' \
       > "$tmpdir/$i.json"
     i=$((i+1))
-  done < <(find "$dir" -name "SKILL.md" -type f 2>/dev/null | sort)
+  done < <(find -L "$dir" -name "SKILL.md" -type f 2>/dev/null | sort)
 
   if [[ $i -eq 0 ]]; then
     echo "[]"

--- a/skills/skill-stocktake/scripts/scan.sh
+++ b/skills/skill-stocktake/scripts/scan.sh
@@ -118,7 +118,7 @@ scan_dir_to_json() {
       '{path:$path,name:$name,description:$description,use_7d:$use_7d,use_30d:$use_30d,mtime:$mtime}' \
       > "$tmpdir/$i.json"
     i=$((i+1))
-  done < <(find "$dir" -name "*.md" -type f 2>/dev/null | sort)
+  done < <(find -L "$dir" -name "*.md" -type f 2>/dev/null | sort)
 
   if [[ $i -eq 0 ]]; then
     echo "[]"

--- a/tests/ci/validators.test.js
+++ b/tests/ci/validators.test.js
@@ -213,13 +213,19 @@ function runCatalogValidator(overrides = {}) {
 // Captures stderr on both success and failure (the shared
 // runSourceViaTempFile helper only surfaces stderr when the child
 // exits non-zero, which hides WARN lines in the default mode).
-function runSkillsValidator(testDir, argv = [], envOverrides = {}) {
+function runSkillsValidator(testDir, argv = [], envOverrides = {}, docsDir) {
   const validatorPath = path.join(validatorsDir, 'validate-skills.js');
   let source = fs.readFileSync(validatorPath, 'utf8');
   source = stripShebang(source);
   source = source.replace(
     /const SKILLS_DIR = .*?;/,
     `const SKILLS_DIR = ${JSON.stringify(testDir)};`,
+  );
+  // Default to a nonexistent docs root so tests exercising only
+  // SKILLS_DIR aren't polluted by this repo's real docs/*/skills/ tree.
+  source = source.replace(
+    /const DOCS_DIR = .*?;/,
+    `const DOCS_DIR = ${JSON.stringify(docsDir || '/nonexistent-docs-dir-for-tests')};`,
   );
   if (argv.length > 0) {
     const argvPreamble = argv
@@ -2798,6 +2804,95 @@ function runTests() {
     assert.strictEqual(result.code, 1, 'Should reject empty SKILL.md');
     assert.ok(result.stderr.includes('Empty file'),
       `Should report "Empty file", got: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  // ── Round 84: validate-skills docs/{locale}/skills/ mirror scan (#2630) ──
+
+  console.log('\nRound 84: validate-skills.js (docs/{locale}/skills/ frontmatter, #2630):');
+
+  if (test('flags a glued key onto description as invalid YAML', () => {
+    const testDir = createTestDir();
+    const docsDir = path.join(testDir, 'docs-root');
+    const skillDir = path.join(docsDir, 'ja-JP', 'skills', 'example');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\nname: example\ndescription: some text.license: Apache-2.0\nversion: 1.0.0\n---\n# Example');
+
+    const result = runSkillsValidator('/nonexistent/skills-dir', ['--strict'], {}, docsDir);
+    assert.strictEqual(result.code, 1, 'Should fail on glued key');
+    assert.ok(result.stderr.includes("unquoted value contains ': '"),
+      `Should report the glued-key defect, got: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('flags a dropped-quote description containing a colon as invalid YAML', () => {
+    const testDir = createTestDir();
+    const docsDir = path.join(testDir, 'docs-root');
+    const skillDir = path.join(docsDir, 'ja-JP', 'skills', 'example');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\nname: example\ndescription: Verification loop: migrations, linting\n---\n# Example');
+
+    const result = runSkillsValidator('/nonexistent/skills-dir', ['--strict'], {}, docsDir);
+    assert.strictEqual(result.code, 1, 'Should fail on unquoted colon in description');
+    assert.ok(result.stderr.includes("unquoted value contains ': '"),
+      `Should report the dropped-quote defect, got: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('flags a description starting with the reserved @ indicator', () => {
+    const testDir = createTestDir();
+    const docsDir = path.join(testDir, 'docs-root');
+    const skillDir = path.join(docsDir, 'ja-JP', 'skills', 'example');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\nname: example\ndescription: @Observable state management\n---\n# Example');
+
+    const result = runSkillsValidator('/nonexistent/skills-dir', ['--strict'], {}, docsDir);
+    assert.strictEqual(result.code, 1, 'Should fail on leading @');
+    assert.ok(result.stderr.includes("reserved character '@'"),
+      `Should report the reserved-indicator defect, got: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('flags a docs mirror SKILL.md with no frontmatter block at all', () => {
+    const testDir = createTestDir();
+    const docsDir = path.join(testDir, 'docs-root');
+    const skillDir = path.join(docsDir, 'ja-JP', 'skills', 'example');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# Example\n\nNo frontmatter here.');
+
+    const result = runSkillsValidator('/nonexistent/skills-dir', ['--strict'], {}, docsDir);
+    assert.strictEqual(result.code, 1, 'Should fail when docs mirror has no frontmatter');
+    assert.ok(result.stderr.includes('no frontmatter block found'),
+      `Should report the missing-frontmatter defect, got: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('curated skills/ still tolerates a SKILL.md with no frontmatter (unchanged)', () => {
+    const testDir = createTestDir();
+    const skillDir = path.join(testDir, 'no-frontmatter-skill');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# Example\n\nNo frontmatter here.');
+
+    const result = runSkillsValidator(testDir, ['--strict']);
+    assert.strictEqual(result.code, 0,
+      `Curated skills/ must not require frontmatter, got stderr: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('passes on a valid docs/{locale}/skills/ mirror', () => {
+    const testDir = createTestDir();
+    const docsDir = path.join(testDir, 'docs-root');
+    const skillDir = path.join(docsDir, 'zh-CN', 'skills', 'example');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\nname: example\ndescription: "Well-formed: quoted value"\n---\n# Example');
+
+    const result = runSkillsValidator('/nonexistent/skills-dir', ['--strict'], {}, docsDir);
+    assert.strictEqual(result.code, 0, `Should pass on well-formed mirror, got: ${result.stderr}`);
+    assert.ok(result.stdout.includes('Validated 1'), 'Should count the one docs skill file');
     cleanupTestDir(testDir);
   })) passed++; else failed++;
 

--- a/tests/scripts/skill-stocktake-discovery.test.js
+++ b/tests/scripts/skill-stocktake-discovery.test.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const scanScript = path.join(repoRoot, 'skills', 'skill-stocktake', 'scripts', 'scan.sh');
+const quickDiffScript = path.join(repoRoot, 'skills', 'skill-stocktake', 'scripts', 'quick-diff.sh');
+
+let passed = 0;
+let failed = 0;
+
+function test(description, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${description}`);
+    passed++;
+  } catch (error) {
+    console.log(`  ✗ ${description}: ${error.message}`);
+    failed++;
+  }
+}
+
+function writeSkill(skillDir, name) {
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: test fixture\n---\n# ${name}\n`,
+  );
+}
+
+function runBash(scriptPath, args, env) {
+  return spawnSync('bash', [scriptPath, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+}
+
+console.log('\nSkill stocktake discovery tests:');
+
+test('both scanners use canonical, error-visible, NUL-delimited discovery', () => {
+  for (const scriptPath of [scanScript, quickDiffScript]) {
+    const source = fs.readFileSync(scriptPath, 'utf8');
+    assert.match(source, /find -L "\$dir" -name "SKILL\.md" -type f -print0/);
+    assert.match(source, /sort -z -o "\$find_out" "\$find_out"/);
+    assert.match(source, /read -r -d '' file/);
+    assert.doesNotMatch(source, /find [^\n]*2>\/dev\/null/, `${path.basename(scriptPath)} still hides find errors`);
+  }
+});
+
+if (process.platform === 'win32') {
+  console.log('  ↷ POSIX symlink and newline-path integration cases skipped on Windows');
+} else {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-skill-stocktake-'));
+  try {
+    const projectSkills = path.join(tempRoot, 'project', '.claude', 'skills');
+    const directSkill = path.join(projectSkills, 'direct-skill');
+    const linkedTarget = path.join(tempRoot, 'shared', 'linked-skill');
+    const newlineSkill = path.join(projectSkills, 'newline\nskill');
+    const resultsPath = path.join(tempRoot, 'results.json');
+
+    writeSkill(directSkill, 'direct-skill');
+    writeSkill(linkedTarget, 'linked-skill');
+    writeSkill(newlineSkill, 'newline-skill');
+    fs.symlinkSync(linkedTarget, path.join(projectSkills, 'linked-skill'), 'dir');
+    fs.mkdirSync(path.join(directSkill, 'references'), { recursive: true });
+    fs.writeFileSync(path.join(directSkill, 'references', 'notes.md'), '# supporting notes\n');
+    fs.writeFileSync(
+      resultsPath,
+      JSON.stringify({ evaluated_at: '2099-01-01T00:00:00Z', skills: [] }),
+    );
+
+    const env = {
+      SKILL_STOCKTAKE_GLOBAL_DIR: path.join(tempRoot, 'missing-global'),
+      SKILL_STOCKTAKE_PROJECT_DIR: projectSkills,
+      SKILL_STOCKTAKE_OBSERVATIONS: path.join(tempRoot, 'missing-observations.jsonl'),
+    };
+
+    test('scan follows symlinked skills and ignores nested Markdown assets', () => {
+      const result = runBash(scanScript, [], env);
+      assert.strictEqual(result.status, 0, result.stderr);
+      const output = JSON.parse(result.stdout);
+      assert.strictEqual(output.scan_summary.project.count, 3);
+      assert.deepStrictEqual(
+        output.skills.map(skill => skill.name).sort(),
+        ['direct-skill', 'linked-skill', 'newline-skill'],
+      );
+    });
+
+    test('quick diff keeps newline-containing skill paths as one record', () => {
+      const result = runBash(quickDiffScript, [resultsPath], env);
+      assert.strictEqual(result.status, 0, result.stderr);
+      const output = JSON.parse(result.stdout);
+      assert.strictEqual(output.length, 3);
+      assert.strictEqual(
+        output.filter(entry => entry.path.includes('newline\nskill/SKILL.md')).length,
+        1,
+      );
+      assert.ok(output.every(entry => entry.is_new === true));
+    });
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/skills/scan-symlinks.test.js
+++ b/tests/skills/scan-symlinks.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const scanStocktake = path.join(repoRoot, 'skills', 'skill-stocktake', 'scripts', 'scan.sh');
+const scanDistillSkills = path.join(repoRoot, 'skills', 'rules-distill', 'scripts', 'scan-skills.sh');
+const scanDistillRules = path.join(repoRoot, 'skills', 'rules-distill', 'scripts', 'scan-rules.sh');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed += 1;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    failed += 1;
+  }
+}
+
+console.log('\n=== Scan scripts symlink support tests ===\n');
+
+test('scan.sh enumerates symlinked skill directories', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-scan-test-'));
+  try {
+    const globalSkillsDir = path.join(tmpDir, 'global-skills');
+    const externalSkillsDir = path.join(tmpDir, 'external-skills');
+    fs.mkdirSync(path.join(globalSkillsDir, 'skill-direct'), { recursive: true });
+    fs.mkdirSync(path.join(externalSkillsDir, 'skill-symlinked'), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(globalSkillsDir, 'skill-direct', 'SKILL.md'),
+      '---\nname: skill-direct\ndescription: "Direct skill"\n---\n# Direct'
+    );
+    fs.writeFileSync(
+      path.join(externalSkillsDir, 'skill-symlinked', 'SKILL.md'),
+      '---\nname: skill-symlinked\ndescription: "Symlinked skill"\n---\n# Symlinked'
+    );
+
+    // Symlink external skill into global skills directory
+    fs.symlinkSync(
+      path.join(externalSkillsDir, 'skill-symlinked'),
+      path.join(globalSkillsDir, 'skill-symlinked'),
+      'dir'
+    );
+
+    const stdout = execFileSync('bash', [scanStocktake], {
+      env: {
+        ...process.env,
+        SKILL_STOCKTAKE_GLOBAL_DIR: globalSkillsDir,
+        SKILL_STOCKTAKE_PROJECT_DIR: '',
+      },
+      encoding: 'utf8',
+    });
+
+    const parsed = JSON.parse(stdout);
+    assert.strictEqual(parsed.scan_summary.global.found, true);
+    assert.strictEqual(parsed.scan_summary.global.count, 2, 'Expected 2 skills (1 direct, 1 symlinked)');
+
+    const names = parsed.skills.map((s) => s.name).sort();
+    assert.deepStrictEqual(names, ['skill-direct', 'skill-symlinked']);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('scan-skills.sh enumerates symlinked skill directories', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-scan-skills-test-'));
+  try {
+    const globalSkillsDir = path.join(tmpDir, 'global-skills');
+    const externalSkillsDir = path.join(tmpDir, 'external-skills');
+    fs.mkdirSync(path.join(globalSkillsDir, 'skill-alpha'), { recursive: true });
+    fs.mkdirSync(path.join(externalSkillsDir, 'skill-beta'), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(globalSkillsDir, 'skill-alpha', 'SKILL.md'),
+      '---\nname: skill-alpha\ndescription: "Alpha skill"\n---\n# Alpha'
+    );
+    fs.writeFileSync(
+      path.join(externalSkillsDir, 'skill-beta', 'SKILL.md'),
+      '---\nname: skill-beta\ndescription: "Beta skill"\n---\n# Beta'
+    );
+
+    fs.symlinkSync(
+      path.join(externalSkillsDir, 'skill-beta'),
+      path.join(globalSkillsDir, 'skill-beta'),
+      'dir'
+    );
+
+    const stdout = execFileSync('bash', [scanDistillSkills], {
+      env: {
+        ...process.env,
+        RULES_DISTILL_GLOBAL_DIR: globalSkillsDir,
+        RULES_DISTILL_PROJECT_DIR: '',
+      },
+      encoding: 'utf8',
+    });
+
+    const parsed = JSON.parse(stdout);
+    assert.strictEqual(parsed.scan_summary.global.count, 2, 'Expected 2 skills in rules-distill scan-skills');
+    const names = parsed.skills.map((s) => s.name).sort();
+    assert.deepStrictEqual(names, ['skill-alpha', 'skill-beta']);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('scan-rules.sh enumerates symlinked rule files', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-scan-rules-test-'));
+  try {
+    const rulesDir = path.join(tmpDir, 'rules');
+    const externalDir = path.join(tmpDir, 'external-rules');
+    fs.mkdirSync(rulesDir, { recursive: true });
+    fs.mkdirSync(externalDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(rulesDir, 'rule-a.md'),
+      '# Rule A\n\n## Section 1\nContent'
+    );
+    fs.writeFileSync(
+      path.join(externalDir, 'rule-b.md'),
+      '# Rule B\n\n## Section 2\nContent'
+    );
+
+    fs.symlinkSync(
+      path.join(externalDir, 'rule-b.md'),
+      path.join(rulesDir, 'rule-b.md'),
+      'file'
+    );
+
+    const stdout = execFileSync('bash', [scanDistillRules, rulesDir], {
+      env: {
+        ...process.env,
+      },
+      encoding: 'utf8',
+    });
+
+    const parsed = JSON.parse(stdout);
+    assert.strictEqual(parsed.total, 2, 'Expected 2 rules (1 direct, 1 symlinked)');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Consolidates skills-related fixes (symlinks, naming, stocktake, frontmatter) into a single PR.

### Merged (6)
- #2836 — fix(skills): support symlinked directories in skill/rule scan
- #2833 — docs(rules): add naming conventions to TypeScript/JavaScript
- #2831 — fix(rules): stop prescribing JS casing for every language
- #2640 — fix(skill-stocktake): follow symlinks and match only SKILL.md
- #2492 — fix(skill-stocktake): Windows Git Bash/MSYS compatibility
- #2631 — fix(ci): validate SKILL.md frontmatter under docs/{locale}/skills/

### Conflicts — need rebase by branch owner (1)
- #2731 — fix(skill-comply): redact operator home path

Closes #2836
Closes #2833
Closes #2831
Closes #2640
Closes #2492
Closes #2631
