### PR TITLE
fix: consolidate miscellaneous bug fixes (5 PRs)

### DIFF
--- a/.claude/commands/add-language-rules.md
+++ b/.claude/commands/add-language-rules.md
@@ -1,7 +1,7 @@
 ---
 name: add-language-rules
 description: Workflow command scaffold for add-language-rules in everything-claude-code.
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /add-language-rules

--- a/.claude/commands/database-migration.md
+++ b/.claude/commands/database-migration.md
@@ -1,7 +1,7 @@
 ---
 name: database-migration
 description: Workflow command scaffold for database-migration in everything-claude-code.
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /database-migration

--- a/.claude/commands/feature-development.md
+++ b/.claude/commands/feature-development.md
@@ -1,7 +1,7 @@
 ---
 name: feature-development
 description: Workflow command scaffold for feature-development in everything-claude-code.
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /feature-development

--- a/.kiro/agents/doc-updater.json
+++ b/.kiro/agents/doc-updater.json
@@ -1,6 +1,6 @@
 {
   "name": "doc-updater",
-  "description": "Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Runs /update-codemaps and /update-docs, generates docs/CODEMAPS/*, updates READMEs and guides.",
+  "description": "Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Generates docs/CODEMAPS/*, updates READMEs and guides. Backs the /update-codemaps and /update-docs commands.",
   "mcpServers": {},
   "tools": [
     "@builtin"

--- a/.kiro/agents/doc-updater.md
+++ b/.kiro/agents/doc-updater.md
@@ -1,6 +1,6 @@
 ---
 name: doc-updater
-description: Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Runs /update-codemaps and /update-docs, generates docs/CODEMAPS/*, updates READMEs and guides.
+description: Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Generates docs/CODEMAPS/*, updates READMEs and guides. Backs the /update-codemaps and /update-docs commands.
 allowedTools:
   - read
   - write

--- a/agents/doc-updater.md
+++ b/agents/doc-updater.md
@@ -1,6 +1,6 @@
 ---
 name: doc-updater
-description: Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Runs /update-codemaps and /update-docs, generates docs/CODEMAPS/*, updates READMEs and guides.
+description: Documentation and codemap specialist. Use PROACTIVELY for updating codemaps and documentation. Generates docs/CODEMAPS/*, updates READMEs and guides. Backs the /update-codemaps and /update-docs commands.
 tools: Read, Write, Edit, Bash, Grep, Glob
 model: haiku
 ---

--- a/commands/marketing-campaign.md
+++ b/commands/marketing-campaign.md
@@ -1,6 +1,6 @@
 ---
 description: Plan and execute a full marketing campaign. Accepts a product brief and returns positioning, landing page copy, email sequence, social posts, ad variants, video scripts, and a content calendar. Can also review existing copy for conversion quality.
-allowed_tools: ["Read", "Grep", "Glob", "WebSearch", "WebFetch", "Write"]
+allowed-tools: ["Read", "Grep", "Glob", "WebSearch", "WebFetch", "Write"]
 ---
 
 # /marketing-campaign

--- a/commands/skill-create.md
+++ b/commands/skill-create.md
@@ -1,7 +1,7 @@
 ---
 name: skill-create
 description: Analyze local git history to extract coding patterns and generate SKILL.md files. Local version of the Skill Creator GitHub App.
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /skill-create - Local Skill Generation

--- a/docs/es/commands/skill-create.md
+++ b/docs/es/commands/skill-create.md
@@ -1,7 +1,7 @@
 ---
 name: skill-create
 description: Analizar el historial local de git para extraer patrones de codificación y generar archivos SKILL.md. Versión local de la Skill Creator GitHub App.
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /skill-create - Generación Local de Skills

--- a/docs/ja-JP/commands/skill-create.md
+++ b/docs/ja-JP/commands/skill-create.md
@@ -1,7 +1,7 @@
 ---
 name: skill-create
 description: ローカルのgit履歴を分析してコーディングパターンを抽出し、SKILL.mdファイルを生成します。Skill Creator GitHub Appのローカル版です。
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /skill-create - ローカルスキル生成

--- a/docs/tr/commands/skill-create.md
+++ b/docs/tr/commands/skill-create.md
@@ -1,7 +1,7 @@
 ---
 name: skill-create
 description: Kodlama desenlerini çıkarmak ve SKILL.md dosyaları oluşturmak için yerel git geçmişini analiz et. Skill Creator GitHub App'ın yerel versiyonu.
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /skill-create - Yerel Skill Oluşturma

--- a/docs/zh-CN/commands/skill-create.md
+++ b/docs/zh-CN/commands/skill-create.md
@@ -1,7 +1,7 @@
 ---
 name: skill-create
 description: 分析本地Git历史以提取编码模式并生成SKILL.md文件。Skill Creator GitHub应用的本地版本。
-allowed_tools: ["Bash", "Read", "Write", "Grep", "Glob"]
+allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 
 # /skill-create - 本地技能生成

--- a/scripts/ci/check-unicode-safety.js
+++ b/scripts/ci/check-unicode-safety.js
@@ -15,6 +15,10 @@ const ignoredDirs = new Set([
   '.dmux',
   '.next',
   '.venv',
+  '.pytest_cache',
+  '.ruff_cache',
+  '.turbo',
+  '.cache',
   'coverage',
   'venv',
 ]);

--- a/skills/social-publisher/SKILL.md
+++ b/skills/social-publisher/SKILL.md
@@ -69,7 +69,11 @@ socialclaw assets upload --file ./image.png --json
 
 Before building an X schedule, collect a source packet when the campaign depends on live audience signals rather than the draft alone.
 
-For OpenClaw users who approved TweetClaw in their dependency policy, install the reviewed ClawHub version with `openclaw plugins install clawhub:@xquik/tweetclaw@1.6.44`. OpenClaw records ClawHub and the exact version as the update source. Keep the selector pinned. Review and approve each version change before replacing it.
+For OpenClaw users who have already approved TweetClaw in their dependency policy, use the pinned package as a separate evidence source:
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw@1.6.31
+```
 
 Use it for public tweet search, reply search, follower export, user lookup, media review, monitors, or giveaway evidence. Keep the output as research input for `schedule.json`; SocialClaw remains responsible for validation, scheduling, publishing, and delivery status. Store TweetClaw credentials in its plugin config, not in `SC_API_KEY`, schedule files, or campaign assets. Do not install it as a default ECC or SocialClaw dependency.
 

--- a/skills/social-publisher/SKILL.md
+++ b/skills/social-publisher/SKILL.md
@@ -69,11 +69,7 @@ socialclaw assets upload --file ./image.png --json
 
 Before building an X schedule, collect a source packet when the campaign depends on live audience signals rather than the draft alone.
 
-For OpenClaw users who have already approved TweetClaw in their dependency policy, use the pinned package as a separate evidence source:
-
-```bash
-openclaw plugins install npm:@xquik/tweetclaw@1.6.31
-```
+For OpenClaw users who approved TweetClaw in their dependency policy, install the reviewed ClawHub version with `openclaw plugins install clawhub:@xquik/tweetclaw@1.6.44`. OpenClaw records ClawHub and the exact version as the update source. Keep the selector pinned. Review and approve each version change before replacing it.
 
 Use it for public tweet search, reply search, follower export, user lookup, media review, monitors, or giveaway evidence. Keep the output as research input for `schedule.json`; SocialClaw remains responsible for validation, scheduling, publishing, and delivery status. Store TweetClaw credentials in its plugin config, not in `SC_API_KEY`, schedule files, or campaign assets. Do not install it as a default ECC or SocialClaw dependency.
 

--- a/src/llm/prompt/builder.py
+++ b/src/llm/prompt/builder.py
@@ -118,7 +118,7 @@ _PROVIDER_TEMPLATE_MAP: dict[str, dict[str, Any]] = {
 
 
 def get_provider_builder(provider_name: str) -> PromptBuilder:
-    config_dict = _PROVIDER_TEMPLATE_MAP.get(provider_name.lower(), {})
+    config_dict = _PROVIDER_TEMPLATE_MAP.get(provider_name.strip().lower(), {})
     config = PromptConfig(**config_dict)
     return PromptBuilder(config)
 

--- a/tests/scripts/check-unicode-safety.test.js
+++ b/tests/scripts/check-unicode-safety.test.js
@@ -198,6 +198,24 @@ if (
   passed++;
 else failed++;
 
+if (
+  test('skips tool cache directories (.pytest_cache, .ruff_cache, .turbo, .cache)', () => {
+    const root = makeTempRoot('ecc-unicode-cache-');
+    for (const cacheDir of ['.pytest_cache', '.ruff_cache', '.turbo', '.cache']) {
+      fs.mkdirSync(path.join(root, cacheDir), { recursive: true });
+      fs.writeFileSync(
+        path.join(root, cacheDir, 'cache-data.json'),
+        `{"cached": "${rocketEmoji}"}\n`
+      );
+    }
+
+    const result = runCheck(root);
+    assert.strictEqual(result.status, 0, result.stdout + result.stderr);
+  })
+)
+  passed++;
+else failed++;
+
 console.log(`\nPassed: ${passed}`);
 console.log(`Failed: ${failed}`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -83,3 +83,13 @@ class TestAdaptMessagesForProvider:
         messages = [Message(role=Role.USER, content="Hello")]
         result = adapt_messages_for_provider(messages, "ollama")
         assert len(result) == 1
+
+    def test_provider_names_allow_outer_whitespace(self):
+        messages = [Message(role=Role.USER, content="Hello")]
+        tools = [ToolDefinition(name="search", description="Search the web", parameters={})]
+
+        result = adapt_messages_for_provider(messages, " ollama ", tools)
+
+        assert len(result) == 2
+        assert result[0].role == Role.SYSTEM
+        assert "Available Tools" in result[0].content

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -2,7 +2,7 @@ import pytest
 
 from llm.core.types import Message, Role, ToolDefinition
 from llm.prompt import PromptBuilder, adapt_messages_for_provider
-from llm.prompt.builder import PromptConfig
+from llm.prompt.builder import PromptConfig, get_provider_builder
 
 
 class TestPromptBuilder:
@@ -90,6 +90,7 @@ class TestAdaptMessagesForProvider:
 
         result = adapt_messages_for_provider(messages, " ollama ", tools)
 
+        assert get_provider_builder(" ollama ").config.tool_format == "text"
         assert len(result) == 2
         assert result[0].role == Role.SYSTEM
         assert "Available Tools" in result[0].content


### PR DESCRIPTION
## Summary

Consolidates four focused bug and correctness fixes while preserving the original contributor commits.

### Included PRs
- #2860 — correct the doc-updater capability description
- #2820 — ignore generated tool caches in Unicode safety scanning
- #2690 — use the canonical `allowed-tools` command frontmatter key
- #2531 — trim provider names before prompt-builder selection

### Maintainer corrections
- Removed the TweetClaw source change because the batch attributed it to #2823, but no such ECC issue or pull request exists. The external package-source change should not ride an untraceable maintenance batch.
- Carried forward #2531’s latest contributor-authored assertion proving a whitespace-padded Ollama name selects the Ollama-specific text tool format.
- Updated the batch onto current `main`.

### Verification
- `node scripts/ci/validate-agents.js`
- `node scripts/ci/validate-commands.js`
- `node tests/scripts/check-unicode-safety.test.js` — 15/15
- `node scripts/ci/check-unicode-safety.js`
- Python 3.11: `pytest tests/test_builder.py -q` — 11/11
- `npm test` full repository suite
- `git diff --check`

Closes #2860
Closes #2820
Closes #2690
Closes #2531