### PR TITLE
feat: consolidate new features (5 PRs)

### DIFF
--- a/agent.yaml
+++ b/agent.yaml
@@ -105,6 +105,7 @@ skills:
   - nextjs-turbopack
   - nutrient-document-processing
   - nuxt4-patterns
+  - otif-analysis
   - perl-patterns
   - perl-security
   - perl-testing

--- a/commands/jira.md
+++ b/commands/jira.md
@@ -26,7 +26,7 @@ Interact with Jira tickets directly from your workflow — fetch tickets, analyz
 
 ### `/jira get <TICKET-KEY>`
 
-1. Fetch the ticket from Jira (via MCP `jira_get_issue` or REST API)
+1. Fetch the ticket from Jira (via MCP `get_issue` or REST API)
 2. Extract all fields: summary, description, acceptance criteria, priority, labels, linked issues
 3. Optionally fetch comments for additional context
 4. Produce a structured analysis:
@@ -80,7 +80,11 @@ Recommended Next Steps:
 This command requires Jira credentials. Choose one:
 
 **Option A — MCP Server (recommended):**
-Add `jira` to your `mcpServers` config (see `mcp-configs/mcp-servers.json` for the template).
+Use the jira-cli MCP server (see `mcp-configs/mcp-servers.json` for the template). Setup:
+
+1. Install the `jira` binary from <https://github.com/LuPaLa-Coder/mcp_jira> (self-contained binaries in `publish/`, or build with `dotnet publish`)
+2. Register your instance — Cloud: `jira config add --site <name> --url <url> --email <email> --token <token>`; Server/Data Center: add `--auth-mode bearer`
+3. Verify with `jira context`, then start the MCP server with `jira mcp serve`
 
 **Option B — Environment variables:**
 ```bash

--- a/docs/pr-jira-cli-lupala.md
+++ b/docs/pr-jira-cli-lupala.md
@@ -1,0 +1,159 @@
+---
+tags: [ecc, jira, mcp, pr]
+created: 2026-08-15
+---
+
+# PR — Use the jira-cli MCP server for `/ecc:jira` instead of mcp-atlassian
+
+> Ready-to-use PR body. Goal: switch `/ecc:jira` from the `mcp-atlassian` MCP server (Python, `uvx`) to **jira-cli** (C#/.NET 8, single binary, 68 MCP tools) as the recommended MCP backend, while keeping the direct REST API fallback unchanged.
+
+## Summary
+
+- Replace the `jira` entry in `mcp-configs/mcp-servers.json` with the jira-cli MCP server (`jira mcp serve`).
+- Update `commands/jira.md` and `skills/jira-integration/SKILL.md` to reference jira-cli tools and configuration.
+- Keep the direct REST API fallback (Option B) untouched.
+- No secrets or company URLs committed.
+
+---
+
+## 1. Current state (verified in this repo)
+
+| File | Role | Detail |
+|---|---|---|
+| `commands/jira.md` | Slash command | 4 subcommands: `get`, `comment`, `transition`, `search`. Frontmatter: "Uses the jira-integration skill and MCP or REST API". |
+| `skills/jira-integration/SKILL.md` | Supporting skill | MCP `mcp-atlassian` (recommended) or direct REST API v3 with `curl`. |
+| `mcp-configs/mcp-servers.json` | MCP template | `jira` entry: `uvx mcp-atlassian==0.21.0`, env `JIRA_URL` / `JIRA_EMAIL` / `JIRA_API_TOKEN` (placeholders only). |
+| `manifests/install-modules.json` | Install manifest | Line 548: `skills/jira-integration` is part of an install module. |
+
+## 2. Why jira-cli
+
+Sources: product site <https://jira.lupala.com> and repo <https://github.com/LuPaLa-Coder/mcp_jira> (MIT, retrieved 2026-08-15).
+
+- **Dual-mode CLI and MCP server** (stdio, JSON-RPC 2.0), C#/.NET 8, MIT license.
+- **68 MCP tools overall**; 30 core tools documented in `SERVICES.md`: 10 issue management, 4 attachment, 7 project, 2 issue type, 3 status, 1 sprint, 1 user, 1 context, 1 field reference.
+- **Jira Cloud (Basic Auth, REST v3 auto) and Server/Data Center (Bearer PAT, REST v2 auto)** with automatic API version selection per auth mode.
+- **Multi-site**: `sites` map in config, `--site` override on tools, `JIRA_SITE` env var, `defaultSite`.
+- **Single self-contained binary** per platform (`publish/mac/`, `publish/linux/`, `publish/windows/`) — zero runtime dependencies.
+- **Compact, LLM-optimized output**; debug mode `jira --debug mcp serve` logs every HTTP call to stderr.
+
+Advantages over `mcp-atlassian`: no Python/uvx runtime, static binary, larger tool surface (projects, attachments, sprints, fields, webhooks, admin), first-class Server/Data Center support, and multi-site switching.
+
+## 3. Proposed changes
+
+### 3.1 `mcp-configs/mcp-servers.json` — replace the `jira` entry
+
+```json
+{
+  "jira": {
+    "command": "jira",
+    "args": ["mcp", "serve"],
+    "description": "jira-cli MCP server — issues, projects, boards, sprints, users, fields, webhooks"
+  }
+}
+```
+
+> The binary is installed as `jira` on PATH (see install below); adapt the command to the platform binary path if needed. Credentials are NOT part of the server config — jira-cli reads them from `~/.config/jira-cli/config.json`.
+
+### 3.2 `commands/jira.md`
+
+- Update "Prerequisites → Option A (MCP Server)": point to jira-cli setup (install binary → `jira config add` → verify with `jira context` → `jira mcp serve`) instead of the `mcp-atlassian` template.
+- Keep "Option B — Environment variables" (REST fallback) as-is.
+
+### 3.3 `skills/jira-integration/SKILL.md`
+
+- Rewrite the "Option A: MCP Server" section around jira-cli.
+- Document installation (per-platform self-contained binaries, build from source, Docker).
+- Document instance registration:
+
+  ```bash
+  # Jira Cloud (Basic Auth → REST v3 auto)
+  jira config add --site myco \
+    --url https://myco.atlassian.net \
+    --email me@myco.com \
+    --token ATATT3xFfGF0...
+
+  # Jira Server/Data Center (Bearer PAT → REST v2 auto)
+  jira config add --site eng \
+    --url https://jira.eng.com/jira \
+    --token <PersonalAccessToken> \
+    --auth-mode bearer
+
+  # Verify
+  jira config list
+  jira context
+  ```
+
+- Document the config file (`~/.config/jira-cli/config.json`, or `XDG_CONFIG_HOME`-relative; `jira config path` prints the location) with the schema: `sites`, `defaultSite`, `defaultApiVersion`, per-site `authMode` (`basic` | `bearer`), `apiVersion`, `defaultProjectKey`.
+- Replace the "MCP Tools Reference" table with the jira-cli tool names (mapping below).
+- Keep the direct REST API reference and the ticket-analysis workflow unchanged.
+
+### 3.4 MCP tool mapping (`mcp-atlassian` → `jira-cli`)
+
+| mcp-atlassian tool | jira-cli tool | Notes |
+|---|---|---|
+| `jira_search` | `search_issues_jql` (GET) / `search_issues_jql_post` (POST, cursor-based pagination) | `max_results` supported |
+| `jira_get_issue` | `get_issue` | |
+| `jira_create_issue` | `create_issue` | |
+| `jira_update_issue` | `update_issue` | |
+| `jira_transition_issue` | `transition_issue` | Check `get_issue_transitions` first (same guidance as today) |
+| `jira_add_comment` | `add_comment` | |
+| `jira_get_sprint_issues` | `get_sprint` + `search_issues_jql` | No exact equivalent among the 30 core tools — fetch sprint details, then issues by JQL (`sprint = X`) |
+| `jira_create_issue_link` | `create_issue_link` | Part of the full 68-tool surface (not among the 30 core documented) |
+| `jira_get_issue_development_info` | `get_remote_links` | Partial equivalent (remote links only, no branch/PR info) |
+| (transitions lookup tip) | `get_issue_transitions` | Now a first-class tool instead of a tip |
+
+Additional capabilities available after the switch (30 core): `add_worklog`, `get_issue_worklog`, `add_attachment`, `list_attachments`, `download_attachment`, `download_all_attachments`, `get_attachment_metadata`, `get_all_projects`, `get_project_statuses`, `get_project_types`, `get_project_roles`, `get_project_role`, `get_project_properties`, `get_project_features`, `get_issue_types`, `get_issue_type`, `get_statuses`, `get_status`, `get_status_categories`, `get_sprint`, `get_current_user`, `jira_context`, `get_fields`.
+
+## 4. Client config examples (for users)
+
+Server registration is the same shape everywhere (documented in `MCP-SETUP.md`):
+
+```json
+{
+  "mcpServers": {
+    "jira": {
+      "command": "jira",
+      "args": ["mcp", "serve"]
+    }
+  }
+}
+```
+
+- **Claude Code**: project `.mcp.json` or `~/.claude.json` → `mcpServers`.
+- **Claude Desktop**: `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) / `%APPDATA%\Claude\claude_desktop_config.json` (Windows).
+- **GitHub Copilot CLI**: `~/.config/github-copilot/mcp-servers.json`.
+
+## 5. Test plan
+
+- [ ] TODO: install the binary (`chmod +x publish/mac/jira && sudo cp publish/mac/jira /usr/local/bin/` or equivalent platform) and verify `jira --version`.
+- [ ] TODO: register the instance — `jira config add --site <name> --url <instance-url> ...` (Cloud) or `--auth-mode bearer` (Server/DC); verify with `jira context`.
+- [ ] TODO: `/ecc:jira search "project = PROJ"` — summary table via `search_issues_jql`.
+- [ ] TODO: `/ecc:jira get PROJ-123` — structured analysis (summary, acceptance criteria, dependencies) via `get_issue`.
+- [ ] TODO: `/ecc:jira comment PROJ-123` — comment posted via `add_comment`.
+- [ ] TODO: `/ecc:jira transition PROJ-123` — `get_issue_transitions`, then `transition_issue`.
+- [ ] TODO: multi-site — same commands against a second site using `--site` / `JIRA_SITE` / `defaultSite`.
+- [ ] TODO: Server/Data Center instance — Bearer PAT flow with automatic API version selection (v2).
+- [ ] TODO: negative case — missing credentials → command stops and instructs the user (fail fast).
+- [ ] TODO: REST fallback (Option B, `curl`) still works unchanged.
+
+## 6. Security
+
+- Credentials live in `~/.config/jira-cli/config.json` (local user config), never in the repo, `mcpServers` entries, or skill files.
+- Least-privilege tokens: Cloud API token scoped to required projects; Server/DC PAT with minimal permissions and expiry.
+- Rotate immediately if a token lands in git history.
+- For self-hosted instances: verify TLS certificates and network exposure (VPN/allowlist).
+
+## 7. Out of scope
+
+- No real instance URLs or tokens committed.
+- No changes to `manifests/install-modules.json` (the skill stays in its module).
+- No removal of the REST API fallback.
+
+## 8. Reviewer checklist
+
+- [ ] No secrets or company URLs in the diff.
+- [ ] `mcp-servers.json` `jira` entry replaced with `jira mcp serve` (no `uvx`/Python dependency).
+- [ ] Skill MCP section rewritten with jira-cli install, config schema, multi-site, and Cloud/Server-DC auth.
+- [ ] Tool mapping table covers every `jira_*` tool referenced by the command and skill.
+- [ ] Test plan is executable (TODOs can be checked off during functional review).
+- [ ] Existing Cloud users can keep their current setup (documented migration path).

--- a/manifests/install-modules.json
+++ b/manifests/install-modules.json
@@ -930,6 +930,7 @@
         "skills/energy-procurement",
         "skills/inventory-demand-planning",
         "skills/logistics-exception-management",
+        "skills/otif-analysis",
         "skills/production-scheduling",
         "skills/quality-nonconformance",
         "skills/returns-reverse-logistics"

--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -11,14 +11,9 @@
       "description": "Opt-in local Itô compute MCP. The canonical package is unpublished and must be built from Ito-Markets/ito-cloud-runtime/cli/ito-compute-cli. Exposes only ito_auth, ito_find, and ito_status. ito_auth validates existing credentials; it does not start device login. Use ecc ito login [--no-browser] for device authorization, which stores tokens in macOS Keychain by default; explicit file fallback must retain owner-only settings. ECC itself performs no browser automation. ITO_API_KEY is forwarded directly to auth, find, and status when configured; ITO_AUTH_MODE=legacy is not required."
     },
     "jira": {
-      "command": "uvx",
-      "args": ["mcp-atlassian==0.21.0"],
-      "env": {
-        "JIRA_URL": "YOUR_JIRA_URL_HERE",
-        "JIRA_EMAIL": "YOUR_JIRA_EMAIL_HERE",
-        "JIRA_API_TOKEN": "YOUR_JIRA_API_TOKEN_HERE"
-      },
-      "description": "Jira issue tracking — search, create, update, comment, transition issues"
+      "command": "jira",
+      "args": ["mcp", "serve"],
+      "description": "jira-cli MCP server — issues, projects, boards, sprints, users, fields, webhooks. Install the binary from https://github.com/LuPaLa-Coder/mcp_jira and register instances with `jira config add` (credentials live in ~/.config/jira-cli/config.json, never here)"
     },
     "github": {
       "command": "npx",

--- a/package.json
+++ b/package.json
@@ -273,6 +273,7 @@
     "skills/nodejs-keccak256/",
     "skills/nutrient-document-processing/",
     "skills/latency-critical-systems/",
+    "skills/otif-analysis/",
     "skills/perl-patterns/",
     "skills/perl-security/",
     "skills/perl-testing/",

--- a/scripts/lib/control-pane/state.js
+++ b/scripts/lib/control-pane/state.js
@@ -563,14 +563,84 @@ function summarizeWorkItems(items) {
   return summary;
 }
 
-async function readWorkItemsSnapshot(stateDbPath) {
+const SKILL_RUN_LIMIT = 50;
+
+function normalizeSkillRunOutcome(outcome) {
+  const normalized = String(outcome || '')
+    .trim()
+    .toLowerCase();
+  if (['success', 'succeeded', 'pass', 'passed', 'ok'].includes(normalized)) return 'success';
+  if (['failure', 'failed', 'fail', 'error'].includes(normalized)) return 'failure';
+  return 'unknown';
+}
+
+function normalizeSkillRun(row) {
+  const optionalNumber = (value) => (value === null || value === undefined || value === '' ? null : toNumber(value, 0));
+  return {
+    id: String(row.id || ''),
+    skillId: String(row.skill_id || ''),
+    skillVersion: row.skill_version ? String(row.skill_version) : null,
+    sessionId: row.session_id ? String(row.session_id) : null,
+    taskDescription: String(row.task_description || ''),
+    outcome: normalizeSkillRunOutcome(row.outcome),
+    rawOutcome: String(row.outcome || ''),
+    failureReason: row.failure_reason ? String(row.failure_reason) : null,
+    tokensUsed: optionalNumber(row.tokens_used),
+    durationMs: optionalNumber(row.duration_ms),
+    userFeedback: row.user_feedback ? String(row.user_feedback) : null,
+    createdAt: String(row.created_at || '')
+  };
+}
+
+function readSkillRuns(db) {
+  if (!tableExists(db, 'skill_runs')) return [];
+  return execRows(
+    db,
+    `SELECT *
+     FROM skill_runs
+     ORDER BY created_at DESC, id DESC
+     LIMIT ?`,
+    [SKILL_RUN_LIMIT]
+  ).map(normalizeSkillRun);
+}
+
+function summarizeSkillRuns(runs) {
+  const summary = {
+    totalCount: runs.length,
+    successCount: 0,
+    failureCount: 0,
+    unknownCount: 0,
+    successRate: null,
+    windowSize: SKILL_RUN_LIMIT,
+    items: runs
+  };
+
+  for (const run of runs) {
+    if (run.outcome === 'success') summary.successCount += 1;
+    else if (run.outcome === 'failure') summary.failureCount += 1;
+    else summary.unknownCount += 1;
+  }
+
+  // Unknown outcomes are excluded from the rate so a partially instrumented
+  // harness does not read as a drop in skill reliability.
+  const decided = summary.successCount + summary.failureCount;
+  if (decided > 0) summary.successRate = summary.successCount / decided;
+
+  return summary;
+}
+
+async function readStateStoreSnapshot(stateDbPath) {
+  const empty = { workItems: summarizeWorkItems([]), skillRuns: summarizeSkillRuns([]) };
   let db = null;
   try {
     db = await openSqlDatabase(stateDbPath);
-    if (!db) return summarizeWorkItems([]);
-    return summarizeWorkItems(readWorkItems(db));
+    if (!db) return empty;
+    return {
+      workItems: summarizeWorkItems(readWorkItems(db)),
+      skillRuns: summarizeSkillRuns(readSkillRuns(db))
+    };
   } catch {
-    return summarizeWorkItems([]);
+    return empty;
   } finally {
     if (db) db.close();
   }
@@ -590,7 +660,7 @@ async function buildControlPaneSnapshot(options = {}) {
   const query = String(options.query || '').trim();
   const limit = Math.max(1, Math.min(Number.parseInt(String(options.limit || 12), 10) || 12, 50));
   const generatedAt = new Date().toISOString();
-  const workItems = await readWorkItemsSnapshot(stateDbPath);
+  const { workItems, skillRuns } = await readStateStoreSnapshot(stateDbPath);
   const base = {
     schemaVersion: SNAPSHOT_SCHEMA_VERSION,
     generatedAt,
@@ -620,6 +690,7 @@ async function buildControlPaneSnapshot(options = {}) {
     },
     connectors: connectorStatus(config, null),
     workItems,
+    skillRuns,
     actions: buildControlPaneActions({ repoRoot, query, limit })
   };
 

--- a/skills/i18n-sync/SKILL.md
+++ b/skills/i18n-sync/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: i18n-sync
+description: >
+  Context-aware localization workflow for JSON locale files. Detects missing or
+  stale translation keys with the locakit CLI, reads how each key is used in the
+  codebase to infer real UI context, translates in the project's tone, and writes
+  results back with placeholder/glossary validation. No translation API keys —
+  the agent itself is the translator. Use when adding locale keys, adding a new
+  language, or when the user asks to sync/translate i18n files.
+metadata:
+  origin: community
+---
+
+# i18n Sync
+
+Translate application locale files the way a human localizer would: by looking
+at where each string appears in the product, not just the string itself. The
+deterministic parts (diffing, lockfile tracking, validation, safe JSON writes)
+are delegated to [locakit](https://www.npmjs.com/package/locakit); this skill
+supplies the judgment.
+
+## When to Activate
+
+- New keys were added to the source locale and target languages need catching up
+- A new target language is being introduced
+- Source copy changed and existing translations may be stale
+- The user asks to "translate", "localize" or "sync" locale/i18n JSON files
+- CI failed on `locakit check`
+
+## Requirements
+
+- `locakit.config.json` in the project root (run `npx locakit init` if absent)
+- Locale files matching the config's `files` template, e.g. `locales/{locale}.json`
+
+## Workflow
+
+### 1. Discover pending work
+
+```bash
+npx locakit diff --json
+```
+
+Returns, per target language, every `missing` and `stale` key with its source
+text, plus the project `context` and `glossary` from the config. If empty,
+report that locales are in sync and stop.
+
+### 2. Gather real usage context — the step generic tools skip
+
+For each pending key (batch by feature prefix, e.g. `auth.*`):
+
+- Grep the codebase for the key (`t("auth.welcome.title")`, `$t('auth...')`,
+  `i18nKey="auth..."` and similar forms).
+- Read the surrounding component: is it a button label, a page title, an error
+  toast, an aria-label? Length constraints? Sentence or fragment?
+- Note interpolated values: what will `{name}` actually contain at runtime?
+
+This is what makes "Home" become the navigation label ("Ana Sayfa" in Turkish),
+not the building ("Ev").
+
+### 3. Translate with project tone
+
+Apply, in order of precedence:
+
+1. `glossary` terms from the config — never translate these
+2. `context` from the config — product domain, audience, register (formal
+   "Sie/siz" vs casual "du/sen"); keep the choice consistent across every key
+3. The usage context gathered in step 2 — match UI element type and length
+4. Target-language conventions: preserve all placeholders exactly (`{name}`,
+   `{{count}}`, `%s`, `$t(...)`); keep HTML/Markdown markup intact; follow the
+   language's own punctuation and capitalization rules, not the source's
+
+Language-specific care (examples):
+
+- **Turkish**: avoid apostrophe suffixes after placeholders (`{name}'in` breaks
+  when the value's vowel harmony differs) — rephrase to avoid the suffix.
+  Dotted capital: `i → İ` (GİRİŞ, not GIRIS).
+- **German**: compound nouns can overflow buttons — prefer shorter synonyms for
+  UI controls.
+- **Right-to-left targets** (ar, he, fa): keep placeholders logically ordered;
+  never manually reorder for visual direction.
+
+### 4. Apply and validate
+
+Write the patch as `{ "<lang>": { "<key>": "<translation>" } }` and pipe it in:
+
+```bash
+echo '<patch-json>' | npx locakit apply -
+npx locakit check
+```
+
+`apply` refuses keys that do not exist in the source locale, so a mistyped key
+fails loudly instead of polluting files. `check` enforces placeholder parity,
+glossary retention and language-specific rules; fix any errors it reports and
+re-apply before finishing.
+
+### 5. Report
+
+Summarize per language: how many keys translated, notable tone/terminology
+decisions, and any strings flagged for human review (legal text, marketing
+slogans, culturally sensitive copy — translate them, but say they deserve a
+native speaker's eye).
+
+## Hook Integration (optional)
+
+Trigger a sync reminder whenever the source locale changes:
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "command": "node -e \"const p=process.env.CLAUDE_FILE_PATH||'';if(/locales[\\\\/].*\\.json$/.test(p)){console.log('[i18n-sync] Locale file changed — run locakit diff to check for pending translations.')}\"",
+        "description": "Remind about pending translations after locale edits"
+      }
+    ]
+  }
+}
+```
+
+## Out of Scope
+
+- Extracting hardcoded strings into locale files (separate refactoring task)
+- Non-JSON formats (gettext .po, .strings) — planned in locakit, not yet supported
+- Visual/layout QA of translated UI — see the web testing rules
+
+## Related
+
+- CLI: [locakit on npm](https://www.npmjs.com/package/locakit) — deterministic
+  engine (diff/apply/check/lock); this skill is its intelligence layer
+- Skills: frontend-patterns (UI copy conventions), seo (localized metadata)

--- a/skills/jira-integration/SKILL.md
+++ b/skills/jira-integration/SKILL.md
@@ -22,35 +22,51 @@ Retrieve, analyze, and update Jira tickets directly from your AI coding workflow
 
 ### Option A: MCP Server (Recommended)
 
-Install the `mcp-atlassian` MCP server. This exposes Jira tools directly to your AI agent.
+Use **jira-cli** (<https://github.com/LuPaLa-Coder/mcp_jira>) — a dual-mode CLI and MCP server in C#/.NET 8 exposing 68 MCP tools (30 core documented in the repo's `SERVICES.md`). Single self-contained binary; no Python/uvx runtime required.
 
 **Requirements:**
-- Python 3.10+
-- `uvx` (from `uv`), installed via your package manager or the official `uv` installation documentation
+- The `jira` binary on PATH (per-platform binaries in the repo's `publish/` folder, or build from source with `dotnet publish`)
 
 **Add to your MCP config** (e.g., `~/.claude.json` → `mcpServers`):
 
 ```json
 {
   "jira": {
-    "command": "uvx",
-    "args": ["mcp-atlassian==0.21.0"],
-    "env": {
-      "JIRA_URL": "https://YOUR_ORG.atlassian.net",
-      "JIRA_EMAIL": "your.email@example.com",
-      "JIRA_API_TOKEN": "your-api-token"
-    },
-    "description": "Jira issue tracking — search, create, update, comment, transition"
+    "command": "jira",
+    "args": ["mcp", "serve"]
   }
 }
 ```
 
-> **Security:** Never hardcode secrets. Prefer setting `JIRA_URL`, `JIRA_EMAIL`, and `JIRA_API_TOKEN` in your system environment (or a secrets manager). Only use the MCP `env` block for local, uncommitted config files.
+> **Security:** Credentials never go in the MCP config. jira-cli reads them from its own local config (`~/.config/jira-cli/config.json`; `jira config path` prints the location). Never hardcode tokens in source code or committed files.
+
+**Register your Jira instance:**
+
+```bash
+# Jira Cloud (Basic Auth → REST v3 auto)
+jira config add --site myco \
+  --url https://YOUR_ORG.atlassian.net \
+  --email your.email@example.com \
+  --token <api-token>
+
+# Jira Server / Data Center (Bearer PAT → REST v2 auto)
+jira config add --site eng \
+  --url https://jira.yourcompany.com/jira \
+  --token <personal-access-token> \
+  --auth-mode bearer
+
+# Verify
+jira context
+```
+
+Multi-site: configure several sites and switch with `--site` on any tool, the `JIRA_SITE` env var, or the `defaultSite` config key.
 
 **To get a Jira API token:**
 1. Go to <https://id.atlassian.com/manage-profile/security/api-tokens>
 2. Click **Create API token**
-3. Copy the token — store it in your environment, never in source code
+3. Copy the token — store it in jira-cli's local config, never in source code
+
+For Jira Server/Data Center, create a Personal Access Token from your instance profile (Profile → Personal Access Tokens) instead.
 
 ### Option B: Direct REST API
 
@@ -77,21 +93,25 @@ jira_curl() {
 
 ## MCP Tools Reference
 
-When the `mcp-atlassian` MCP server is configured, these tools are available:
+When the jira-cli MCP server is configured, these core tools are available (30 core of 68 total; the full surface is documented in the jira-cli repo's `SERVICES.md`):
 
 | Tool | Purpose | Example |
 |------|---------|---------|
-| `jira_search` | JQL queries | `project = PROJ AND status = "In Progress"` |
-| `jira_get_issue` | Fetch full issue details by key | `PROJ-1234` |
-| `jira_create_issue` | Create issues (Task, Bug, Story, Epic) | New bug report |
-| `jira_update_issue` | Update fields (summary, description, assignee) | Change assignee |
-| `jira_transition_issue` | Change status | Move to "In Review" |
-| `jira_add_comment` | Add comments | Progress update |
-| `jira_get_sprint_issues` | List issues in a sprint | Active sprint review |
-| `jira_create_issue_link` | Link issues (Blocks, Relates to) | Dependency tracking |
-| `jira_get_issue_development_info` | See linked PRs, branches, commits | Dev context |
+| `get_issue` | Fetch full issue details by key | `PROJ-1234` |
+| `create_issue` | Create issues (Task, Bug, Story) | New bug report |
+| `update_issue` | Update fields (summary, description, assignee) | Change assignee |
+| `search_issues_jql` | JQL queries (GET, classic pagination) | `project = PROJ AND status = "In Progress"` |
+| `search_issues_jql_post` | JQL queries (POST, cursor-based pagination) | Large result sets |
+| `transition_issue` | Change status | Move to "In Review" |
+| `get_issue_transitions` | List available transitions | Before transitioning |
+| `add_comment` | Add comments | Progress update |
+| `add_worklog` | Log work time | `2h 30m` |
+| `get_sprint` | Sprint details | Active sprint review |
+| `get_board_issues` | Issues on a board | Board review |
+| `create_issue_link` | Link issues (Blocks, Relates to) | Dependency tracking |
+| `get_remote_links` | Linked remote resources | Dev context |
 
-> **Tip:** Always call `jira_get_transitions` before transitioning — transition IDs vary per project workflow.
+> **Tip:** Always call `get_issue_transitions` before transitioning — transition IDs vary per project workflow.
 
 ## Direct REST API Reference
 
@@ -290,7 +310,7 @@ Coverage: XX%
 | `401 Unauthorized` | Invalid or expired API token | Regenerate at id.atlassian.com |
 | `403 Forbidden` | Token lacks project permissions | Check token scopes and project access |
 | `404 Not Found` | Wrong ticket key or base URL | Verify `JIRA_URL` and ticket key |
-| `spawn uvx ENOENT` | IDE cannot find `uvx` on PATH | Use full path (e.g., `~/.local/bin/uvx`) or set PATH in `~/.zprofile` |
+| `jira: command not found` | jira-cli binary not on PATH | Install from the repo `publish/` folder (or build from source) and add it to PATH |
 | Connection timeout | Network/VPN issue | Check VPN connection and firewall rules |
 
 ## Best Practices

--- a/skills/otif-analysis/SKILL.md
+++ b/skills/otif-analysis/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: otif-analysis
+description: >
+  Audit delivery performance from order-level data: compute the OTIF metric
+  ladder from the tolerant reported KPI down to strict on-time-in-full, expose
+  the definition choices that quietly inflate on-time numbers (date anchor,
+  tolerance window, partial shipments, cancellations), find where lateness
+  concentrates, and reconcile the headline number against raw rows. Use for
+  OTIF, on-time delivery, service level, late orders, delivery performance
+  reviews, or "customers complain but our on-time score is high".
+metadata:
+  origin: ECC
+---
+
+# OTIF Analysis
+
+Most companies don't have a delivery problem *and* a measurement problem — they have a measurement problem that hides the delivery problem. Before recommending any operational fix, establish the honest number and show which definition choices inflate the reported one.
+
+## When to Activate
+
+- computing or auditing on-time delivery, OTIF, or service-level KPIs
+- order-level delivery data is available (requested/promised/actual dates)
+- "customers complain but our on-time is 95%+"
+- preparing delivery performance for a management review or customer QBR
+- drafting delivery metrics for a contract or SLA
+
+## Required Data
+
+Order-level rows with: `order_id`, `requested_delivery_date` (what the customer asked for), `promised_delivery_date` (what was confirmed), `actual_delivery_date`, completeness info (lines or quantities ordered vs delivered), and a status/cancelled flag. Useful cuts: carrier, region, customer, product family.
+
+If `requested_delivery_date` is missing, say so explicitly: only the promised-date rungs are computable and the analysis cannot see sales padding. Recommend capturing the requested date going forward.
+
+## Core Workflow
+
+1. **Validate before computing.** Count duplicated rows; flag impossible dates (actual before order date); count cancelled orders and state how they will be treated. Report these counts in the output — an audit that silently cleans data is not an audit.
+2. **Compute the metric ladder** on the same population, strictest last (table below). Present it with the delta and the cause of each drop.
+3. **Decompose the gap.** For the dimension with the largest spread (carrier, region, month, customer), show OTIF per segment and name the concentrated driver, not just the average.
+4. **Analyze the tail, not the mean.** Report the share of orders 4+ days late and the worst decile — those are the orders customers remember.
+5. **Reconcile before reporting.** Recompute the headline OTIF once more directly from raw rows and confirm it matches. If it does not, stop and find out why.
+
+## The Metric Ladder
+
+| Rung | Definition | What changes |
+|------|------------|--------------|
+| 1 | Promised date, +N-day tolerance | The typically reported KPI |
+| 2 | Promised date, strict | Tolerance window removed |
+| 3 | *Requested* date, strict | Sales padding vs customer request exposed |
+| 4 | **OTIF** — requested date AND order complete | Partial shipments counted; in-full is judged at order level (9-of-10 lines is one incomplete order, not 90% on-time) |
+| 5 | OTIF with cancellations in the denominator | Cancelled orders stop hiding |
+
+## Code Example
+
+```python
+import pandas as pd
+
+df = pd.read_csv(
+    "orders.csv",
+    parse_dates=["requested_delivery_date", "promised_delivery_date", "actual_delivery_date"],
+)
+d = df[df.status == "delivered"]
+late_prom = (d.actual_delivery_date - d.promised_delivery_date).dt.days
+late_req = (d.actual_delivery_date - d.requested_delivery_date).dt.days
+in_full = d.lines_delivered_complete >= d.lines_total
+
+ladder = {
+    "1 promised +3d (reported)": (late_prom <= 3).mean(),
+    "2 promised, strict": (late_prom <= 0).mean(),
+    "3 requested, strict": (late_req <= 0).mean(),
+    "4 OTIF (requested + in-full)": ((late_req <= 0) & in_full).mean(),
+    "5 OTIF incl. cancellations": ((late_req <= 0) & in_full).sum() / len(df),
+}
+print({k: f"{v:.1%}" for k, v in ladder.items()})
+```
+
+## Anti-Patterns
+
+- **Anchoring to the promised date without disclosure.** It hides sales padding; compute average (promised − requested) days and quantify the KPI effect.
+- **Tolerance windows as dashboard defaults.** Tolerance is a contract term; if used, publish it next to the number. Every extra day buys free KPI points.
+- **Line-level averaging.** Overstates performance versus order-level in-full; the customer's production line is still stopped.
+- **Silently excluding cancellations.** Orders that quietly leave the denominator flatter the metric — show rung 5.
+- **Reporting the mean lateness.** An average of 0.5 days can hide a 5% tail of week-late orders; show the distribution share above a threshold.
+- **Shipping a percentage without its definition footnote.** An unlabeled "94% on-time" is a rumor, not a metric.
+
+## Output Format
+
+1. The ladder table (definition, result %, delta, cause of drop)
+2. Three finding sentences, each: what moved / where it concentrates / what decision it needs
+3. A definitions footnote stating anchor date, tolerance, in-full rule and cancellation treatment — so the number cannot be misread
+
+Reference implementation with reproducible numbers and charts: <https://github.com/gulmezeren2-byte/otif-analytics>
+
+## Related Skills
+
+- `inventory-demand-planning` — forecasting and stock policies, once delivery measurement is honest
+- `logistics-exception-management` — handling the individual freight exceptions the ladder surfaces

--- a/tests/scripts/control-pane.test.js
+++ b/tests/scripts/control-pane.test.js
@@ -191,6 +191,10 @@ async function runTests() {
           host: '127.0.0.1',
           port: 0,
           dbPath,
+          // Isolate the state store too, otherwise the assertions below read the
+          // operator's real ~/.claude/ecc/state.db and fail on any machine that
+          // has recorded work items.
+          stateDbPath: path.join(tempDir, 'state.db'),
           repoRoot: REPO_ROOT,
           query: 'control pane',
           allowActions: false
@@ -656,6 +660,82 @@ async function runTests() {
         }
       } finally {
         fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    await test('snapshot exposes skill runs from the state store', async () => {
+      const { createStateStore } = require('../../scripts/lib/state-store');
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-control-pane-skill-runs-'));
+      const stateDbPath = path.join(tempDir, 'state.db');
+
+      try {
+        const store = await createStateStore({ dbPath: stateDbPath });
+        store.upsertSession({ id: 'sid-1', adapterId: 'claude', harness: 'claude-code', state: 'active' });
+        store.insertSkillRun({
+          id: 'run-1',
+          skillId: 'security-review',
+          skillVersion: '1.0.0',
+          sessionId: 'sid-1',
+          taskDescription: 'Audit the auth module',
+          outcome: 'success',
+          durationMs: 1200,
+          createdAt: '2026-01-01T00:00:00.000Z'
+        });
+        store.insertSkillRun({
+          id: 'run-2',
+          skillId: 'security-review',
+          skillVersion: '1.0.0',
+          sessionId: 'sid-1',
+          taskDescription: 'Audit the billing module',
+          outcome: 'failure',
+          failureReason: 'missing test fixtures',
+          createdAt: '2026-01-02T00:00:00.000Z'
+        });
+        store.close();
+
+        const app = await createControlPaneServer({ host: '127.0.0.1', port: 0, stateDbPath, repoRoot: REPO_ROOT, allowActions: false });
+        await app.listen();
+        try {
+          const snapshot = await fetchLocal(`${app.url}/api/snapshot`).then(r => r.json());
+          assert.strictEqual(snapshot.skillRuns.totalCount, 2);
+          assert.strictEqual(snapshot.skillRuns.successCount, 1);
+          assert.strictEqual(snapshot.skillRuns.failureCount, 1);
+          assert.strictEqual(snapshot.skillRuns.successRate, 0.5);
+          // Newest first.
+          assert.strictEqual(snapshot.skillRuns.items[0].id, 'run-2');
+          assert.strictEqual(snapshot.skillRuns.items[0].outcome, 'failure');
+          assert.strictEqual(snapshot.skillRuns.items[0].failureReason, 'missing test fixtures');
+          assert.strictEqual(snapshot.skillRuns.items[1].skillId, 'security-review');
+          assert.strictEqual(snapshot.skillRuns.items[1].durationMs, 1200);
+        } finally {
+          await app.close();
+        }
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    await test('snapshot returns an empty skill-run summary without a state store', async () => {
+      // Point at a path that does not exist so the test never reads the
+      // operator's real state store.
+      const stateDbPath = path.join(os.tmpdir(), 'ecc-control-pane-missing-state', 'state.db');
+      const app = await createControlPaneServer({ host: '127.0.0.1', port: 0, stateDbPath, repoRoot: REPO_ROOT, allowActions: false });
+      await app.listen();
+      try {
+        const snapshot = await fetchLocal(`${app.url}/api/snapshot`).then(r => r.json());
+        assert.strictEqual(snapshot.skillRuns.totalCount, 0);
+        assert.strictEqual(snapshot.skillRuns.successRate, null);
+        assert.deepStrictEqual(snapshot.skillRuns.items, []);
+      } finally {
+        await app.close();
       }
     })
   )

--- a/tests/scripts/uninstall.test.js
+++ b/tests/scripts/uninstall.test.js
@@ -18,7 +18,10 @@ const CURRENT_PACKAGE_VERSION = JSON.parse(
 const CURRENT_MANIFEST_VERSION = JSON.parse(
   fs.readFileSync(path.join(REPO_ROOT, 'manifests', 'install-modules.json'), 'utf8')
 ).version;
-const CLI_TIMEOUT_MS = 30000;
+// Windows CI file I/O is several times slower, and these cases run two full
+// CLI passes (install, then uninstall) over hundreds of files. install-apply
+// tests already scale their timeout the same way.
+const CLI_TIMEOUT_MS = process.platform === 'win32' ? 90000 : 30000;
 const {
   createInstallState,
   writeInstallState,


### PR DESCRIPTION
## Summary

Consolidates new features (skills, hooks, control-pane, providers) into a single PR.

### Merged (5)
- #2715 — feat(install): require explicit hook decision at apply layer
- #2795 — Use jira-cli MCP server for /ecc:jira
- #2578 — feat(control-pane): expose skill runs in snapshot feed
- #2444 — feat(skills): add i18n-sync skill
- #2519 — feat(skills): add otif-analysis skill

### Conflicts — need rebase by branch owners (10)
- #2856 — feat: add Grok Build plugin and marketplace support
- #2844 — feat(skills): add skill profile selection
- #2778 — feat(skills): add repo-mastery v3.2.0
- #2819 — feat(skills): context-budget reconnect scaffolding
- #2814 — feat(skills): add product-specific UI quality gate
- #2766 — feat(workflows): add documentation governance system
- #2788 — feat: slim profile plugins + offline skill router
- #2716 — feat(statusline): add ECC usage bar
- #2575 — feat(skills): add Solana x402
- #2761 — feat: add orchestration efficiency evidence

Closes #2715
Closes #2795
Closes #2578
Closes #2444
Closes #2519
