### PR TITLE
fix(tests): preserve session alias HOME isolation

### DIFF
--- a/tests/lib/session-aliases.test.js
+++ b/tests/lib/session-aliases.test.js
@@ -826,19 +826,6 @@ function runTests() {
     aliases.deleteAlias('atomic-test-2');
   })) passed++; else failed++;
 
-  // Cleanup — restore both HOME and USERPROFILE (Windows)
-  process.env.HOME = origHome;
-  if (origUserProfile !== undefined) {
-    process.env.USERPROFILE = origUserProfile;
-  } else {
-    delete process.env.USERPROFILE;
-  }
-  try {
-    fs.rmSync(tmpHome, { recursive: true, force: true });
-  } catch {
-    // best-effort
-  }
-
   // ── Round 48: rapid sequential saves data integrity ──
   console.log('\nRound 48: rapid sequential saves:');
 
@@ -1821,6 +1808,19 @@ function runTests() {
     assert.ok(keys.includes('normal'),
       'Object.keys includes normal alias');
   })) passed++; else failed++;
+
+  // Cleanup — restore both HOME and USERPROFILE (Windows)
+  process.env.HOME = origHome;
+  if (origUserProfile !== undefined) {
+    process.env.USERPROFILE = origUserProfile;
+  } else {
+    delete process.env.USERPROFILE;
+  }
+  try {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
 
   // Summary
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);


### PR DESCRIPTION
## Summary

- keep the temporary HOME/USERPROFILE active through every session-alias test round
- restore the original environment and remove the temporary home only after the final test
- prevent later fixtures from reading, truncating, or overwriting the user's real `~/.claude/session-aliases.json`

Fixes #2876.

## Validation

- Before the change: `node tests/lib/session-aliases.test.js` reported 105 passed / 0 failed but left the 411-byte Round 125 fixture in an externally supplied HOME.
- After the change: the same command reports 105 passed / 0 failed and leaves the external HOME's `.claude` directory empty.
- `git diff --check`
- `npm test`: 3815 passed / 25 failed. The failures are unrelated Windows environment limitations on current `main` (symlink privilege, missing `/bin/bash`/WSL bash, and an 8.3 temp-path assertion); the focused suite above passes.

The change is a pure relocation of the existing cleanup block; no test behavior or production code is otherwise changed.