### PR TITLE
fix(continuous-learning-v2): count every instinct extension in observer status (#2859)

### DIFF
--- a/skills/continuous-learning-v2/agents/start-observer.sh
+++ b/skills/continuous-learning-v2/agents/start-observer.sh
@@ -156,8 +156,14 @@ case "$ACTION" in
         echo "Observer is running (PID: $pid)"
         echo "Log: $LOG_FILE"
         echo "Observations: $(wc -l < "$OBSERVATIONS_FILE" 2>/dev/null || echo 0) lines"
-        # Also show instinct count
-        instinct_count=$(find "$INSTINCTS_DIR" -name "*.yaml" 2>/dev/null | wc -l)
+        # Also show instinct count. Count every extension the loader accepts
+        # (ALLOWED_INSTINCT_EXTENSIONS in scripts/instinct-cli.py) - the
+        # observer prompt tells the analyzer to write "<id>.md", so a
+        # *.yaml-only count reports 0 on a working install. Depth and case
+        # match the loader's iterdir() + suffix.lower(): top level only,
+        # case-insensitive. tr strips the padding BSD wc emits.
+        instinct_find_expr=( \( -iname "*.yaml" -o -iname "*.yml" -o -iname "*.md" \) )
+        instinct_count=$(find "$INSTINCTS_DIR" -maxdepth 1 -type f "${instinct_find_expr[@]}" 2>/dev/null | wc -l | tr -d "[:space:]")
         echo "Instincts: $instinct_count"
         exit 0
       else

--- a/tests/skills/observer-status-instinct-count.test.js
+++ b/tests/skills/observer-status-instinct-count.test.js
@@ -1,0 +1,145 @@
+/**
+ * Regression tests for #2859: `start-observer.sh status` counted only *.yaml.
+ *
+ * The producer writes `<id>.md` (agents/observer-loop.sh instructs the analyzer
+ * to) and the loader accepts .yaml/.yml/.md (ALLOWED_INSTINCT_EXTENSIONS in
+ * scripts/instinct-cli.py), so the one command an operator runs to confirm that
+ * learning works reported `Instincts: 0` on a working install — and an operator
+ * cannot tell that apart from a silently dead observer.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const skillRoot = path.join(repoRoot, 'skills', 'continuous-learning-v2');
+const observerScript = path.join(skillRoot, 'agents', 'start-observer.sh');
+const detectProject = path.join(skillRoot, 'scripts', 'detect-project.sh');
+const instinctCli = path.join(skillRoot, 'scripts', 'instinct-cli.py');
+const bashBinary = process.env.ECC_TEST_BASH || (process.platform === 'win32' ? null : 'bash');
+
+let passed = 0;
+
+function toShellPath(filePath) {
+  const normalized = filePath.split(path.sep).join('/');
+  return normalized.replace(/^([A-Za-z]):\//, (_, drive) => `/${drive.toLowerCase()}/`);
+}
+
+// ── The counter must accept every extension the loader accepts ──
+
+const cliSource = fs.readFileSync(instinctCli, 'utf8');
+const allowedMatch = cliSource.match(/ALLOWED_INSTINCT_EXTENSIONS\s*=\s*\(([^)]*)\)/);
+assert.ok(allowedMatch, 'ALLOWED_INSTINCT_EXTENSIONS not found in instinct-cli.py');
+const allowedExtensions = allowedMatch[1]
+  .split(',')
+  .map(part => part.trim().replace(/^["']|["']$/g, ''))
+  .filter(Boolean);
+assert.ok(allowedExtensions.length >= 3, `expected several extensions, got ${allowedExtensions}`);
+passed++;
+
+const observerSource = fs.readFileSync(observerScript, 'utf8');
+const statusCount = observerSource
+  .split('\n')
+  .filter(line => line.includes('instinct_count=') || line.includes('instinct_find_expr='))
+  .join('\n');
+assert.ok(statusCount, 'status branch no longer computes an instinct count');
+
+for (const ext of allowedExtensions) {
+  assert.ok(
+    statusCount.includes(`*${ext}"`) || statusCount.includes(`*${ext}'`),
+    `status count must match ${ext} — the loader accepts it (ALLOWED_INSTINCT_EXTENSIONS)`
+  );
+  passed++;
+}
+
+// Depth and case must match the loader: Path.iterdir() is top-level only and
+// is_file() skips directories; suffix.lower() makes the match case-insensitive.
+assert.ok(statusCount.includes('-maxdepth 1'), 'status count must not recurse — the loader does not');
+assert.ok(statusCount.includes('-type f'), 'status count must skip directories');
+assert.ok(!/-name\s+["']\*/.test(statusCount), 'status count must use case-insensitive -iname');
+passed += 3;
+
+// ── The shipped script, run for real ──
+
+function resolvePython() {
+  for (const candidate of [process.env.ECC_TEST_PYTHON, 'python3', 'python']) {
+    if (!candidate) continue;
+    const probe = spawnSync(candidate, ['-c', 'print(1)'], { encoding: 'utf8' });
+    if (probe.status === 0) return candidate;
+  }
+  return null;
+}
+
+const pythonCmd = bashBinary ? resolvePython() : null;
+
+function runStatus(files) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-observer-'));
+  try {
+    const projectDir = path.join(tmp, 'proj');
+    fs.mkdirSync(projectDir, { recursive: true });
+    const writes = files
+      .map(name => `printf 'id: x' > "$INST/${name}"`)
+      .join('\n      ');
+    const script = [
+      `source "${toShellPath(detectProject)}"`,
+      'INST="$PROJECT_DIR/instincts/personal"',
+      'mkdir -p "$INST/nested"',
+      writes,
+      ': > "$PROJECT_DIR/observations.jsonl"',
+      'sleep 10 &',
+      'OBSERVER_PID=$!',
+      'echo "$OBSERVER_PID" > "$PROJECT_DIR/.observer.pid"',
+      `bash "${toShellPath(observerScript)}" status`,
+      'status=$?',
+      'kill "$OBSERVER_PID" 2>/dev/null || true',
+      'exit $status',
+    ].join('\n');
+    const result = spawnSync(bashBinary, ['-c', script], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CLV2_HOMUNCULUS_DIR: toShellPath(path.join(tmp, 'homunculus')),
+        CLAUDE_PROJECT_DIR: toShellPath(projectDir),
+        CLV2_PYTHON_CMD: pythonCmd,
+      },
+    });
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+    const line = (result.stdout || '').split('\n').find(l => l.startsWith('Instincts:'));
+    assert.ok(line, `no "Instincts:" line in status output:\n${result.stdout}`);
+    return Number(line.split(':')[1].trim());
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+if (bashBinary && pythonCmd) {
+  const syntax = spawnSync(bashBinary, ['-n', toShellPath(observerScript)], { encoding: 'utf8' });
+  assert.strictEqual(syntax.status, 0, syntax.stderr);
+  passed++;
+
+  // The reported shape: every instinct on disk is a .md file.
+  assert.strictEqual(runStatus(['a.md', 'b.md', 'c.md']), 3, 'markdown instincts must be counted');
+  passed++;
+
+  // Every accepted extension, mixed case, plus the two things the loader skips:
+  // a non-instinct file and a nested directory.
+  assert.strictEqual(
+    runStatus(['a.md', 'b.yaml', 'c.yml', 'd.YAML', 'notes.txt', 'nested/deep.md']),
+    4,
+    'count must match the loader: every allowed extension, case-insensitive, top level only'
+  );
+  passed++;
+
+  assert.strictEqual(runStatus([]), 0, 'an empty instincts directory must still report 0');
+  passed++;
+} else {
+  console.log('  Integration coverage skipped (needs bash + python; set ECC_TEST_BASH/ECC_TEST_PYTHON)');
+}
+
+console.log(`  Passed: ${passed}`);
+console.log('  Failed: 0');

--- a/tests/skills/observer-status-instinct-count.test.js
+++ b/tests/skills/observer-status-instinct-count.test.js
@@ -23,48 +23,30 @@ const detectProject = path.join(skillRoot, 'scripts', 'detect-project.sh');
 const instinctCli = path.join(skillRoot, 'scripts', 'instinct-cli.py');
 const bashBinary = process.env.ECC_TEST_BASH || (process.platform === 'win32' ? null : 'bash');
 
-let passed = 0;
-
 function toShellPath(filePath) {
   const normalized = filePath.split(path.sep).join('/');
   return normalized.replace(/^([A-Za-z]):\//, (_, drive) => `/${drive.toLowerCase()}/`);
 }
 
-// ── The counter must accept every extension the loader accepts ──
-
-const cliSource = fs.readFileSync(instinctCli, 'utf8');
-const allowedMatch = cliSource.match(/ALLOWED_INSTINCT_EXTENSIONS\s*=\s*\(([^)]*)\)/);
-assert.ok(allowedMatch, 'ALLOWED_INSTINCT_EXTENSIONS not found in instinct-cli.py');
-const allowedExtensions = allowedMatch[1]
-  .split(',')
-  .map(part => part.trim().replace(/^["']|["']$/g, ''))
-  .filter(Boolean);
-assert.ok(allowedExtensions.length >= 3, `expected several extensions, got ${allowedExtensions}`);
-passed++;
-
-const observerSource = fs.readFileSync(observerScript, 'utf8');
-const statusCount = observerSource
-  .split('\n')
-  .filter(line => line.includes('instinct_count=') || line.includes('instinct_find_expr='))
-  .join('\n');
-assert.ok(statusCount, 'status branch no longer computes an instinct count');
-
-for (const ext of allowedExtensions) {
-  assert.ok(
-    statusCount.includes(`*${ext}"`) || statusCount.includes(`*${ext}'`),
-    `status count must match ${ext} — the loader accepts it (ALLOWED_INSTINCT_EXTENSIONS)`
-  );
-  passed++;
+function readAllowedExtensions() {
+  const cliSource = fs.readFileSync(instinctCli, 'utf8');
+  const match = cliSource.match(/ALLOWED_INSTINCT_EXTENSIONS\s*=\s*\(([^)]*)\)/);
+  assert.ok(match, 'ALLOWED_INSTINCT_EXTENSIONS not found in instinct-cli.py');
+  return match[1]
+    .split(',')
+    .map(part => part.trim().replace(/^["']|["']$/g, ''))
+    .filter(Boolean);
 }
 
-// Depth and case must match the loader: Path.iterdir() is top-level only and
-// is_file() skips directories; suffix.lower() makes the match case-insensitive.
-assert.ok(statusCount.includes('-maxdepth 1'), 'status count must not recurse — the loader does not');
-assert.ok(statusCount.includes('-type f'), 'status count must skip directories');
-assert.ok(!/-name\s+["']\*/.test(statusCount), 'status count must use case-insensitive -iname');
-passed += 3;
-
-// ── The shipped script, run for real ──
+function readStatusCounter() {
+  const observerSource = fs.readFileSync(observerScript, 'utf8');
+  const counter = observerSource
+    .split('\n')
+    .filter(line => line.includes('instinct_count=') || line.includes('instinct_find_expr='))
+    .join('\n');
+  assert.ok(counter, 'status branch no longer computes an instinct count');
+  return counter;
+}
 
 function resolvePython() {
   for (const candidate of [process.env.ECC_TEST_PYTHON, 'python3', 'python']) {
@@ -117,29 +99,112 @@ function runStatus(files) {
   }
 }
 
-if (bashBinary && pythonCmd) {
-  const syntax = spawnSync(bashBinary, ['-n', toShellPath(observerScript)], { encoding: 'utf8' });
-  assert.strictEqual(syntax.status, 0, syntax.stderr);
-  passed++;
+function buildTests() {
+  const tests = [];
+
+  // ── The counter must accept every extension the loader accepts ──
+
+  tests.push(['the loader still declares several instinct extensions', () => {
+    const allowed = readAllowedExtensions();
+    assert.ok(allowed.length >= 3, `expected several extensions, got ${allowed}`);
+  }]);
+
+  for (const ext of readAllowedExtensions()) {
+    tests.push([`status counts ${ext} — the loader accepts it`, () => {
+      const counter = readStatusCounter();
+      assert.ok(
+        counter.includes(`*${ext}"`) || counter.includes(`*${ext}'`),
+        `status count must match ${ext} (ALLOWED_INSTINCT_EXTENSIONS)`
+      );
+    }]);
+  }
+
+  // Depth and case must match the loader: Path.iterdir() is top-level only and
+  // is_file() skips directories; suffix.lower() makes the match case-insensitive.
+  tests.push(['status does not recurse — the loader does not', () => {
+    assert.ok(readStatusCounter().includes('-maxdepth 1'));
+  }]);
+  tests.push(['status skips directories', () => {
+    assert.ok(readStatusCounter().includes('-type f'));
+  }]);
+  tests.push(['status matches case-insensitively', () => {
+    assert.ok(!/-name\s+["']\*/.test(readStatusCounter()),
+      'status count must use -iname, not -name');
+  }]);
+
+  // ── The shipped script, run for real ──
+
+  if (!(bashBinary && pythonCmd)) return tests;
+
+  tests.push(['start-observer.sh parses', () => {
+    const syntax = spawnSync(bashBinary, ['-n', toShellPath(observerScript)], { encoding: 'utf8' });
+    assert.strictEqual(syntax.status, 0, syntax.stderr);
+  }]);
 
   // The reported shape: every instinct on disk is a .md file.
-  assert.strictEqual(runStatus(['a.md', 'b.md', 'c.md']), 3, 'markdown instincts must be counted');
-  passed++;
+  tests.push(['markdown instincts are counted', () => {
+    assert.strictEqual(runStatus(['a.md', 'b.md', 'c.md']), 3);
+  }]);
 
   // Every accepted extension, mixed case, plus the two things the loader skips:
   // a non-instinct file and a nested directory.
-  assert.strictEqual(
-    runStatus(['a.md', 'b.yaml', 'c.yml', 'd.YAML', 'notes.txt', 'nested/deep.md']),
-    4,
-    'count must match the loader: every allowed extension, case-insensitive, top level only'
-  );
-  passed++;
+  tests.push(['the count matches the loader exactly', () => {
+    assert.strictEqual(
+      runStatus(['a.md', 'b.yaml', 'c.yml', 'd.YAML', 'notes.txt', 'nested/deep.md']),
+      4
+    );
+  }]);
 
-  assert.strictEqual(runStatus([]), 0, 'an empty instincts directory must still report 0');
-  passed++;
-} else {
-  console.log('  Integration coverage skipped (needs bash + python; set ECC_TEST_BASH/ECC_TEST_PYTHON)');
+  tests.push(['an empty instincts directory reports 0', () => {
+    assert.strictEqual(runStatus([]), 0);
+  }]);
+
+  return tests;
 }
 
-console.log(`  Passed: ${passed}`);
-console.log('  Failed: 0');
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.error(`    ${error.message}`);
+    return false;
+  }
+}
+
+function main() {
+  console.log('\n=== Testing observer status instinct count (#2859) ===\n');
+
+  let passed = 0;
+  let failed = 0;
+  let tests;
+
+  // Collecting the cases reads instinct-cli.py and start-observer.sh, so a
+  // missing or renamed file has to be reported as a failure rather than crash
+  // the process — tests/run-all.js totals the "Passed:"/"Failed:" tokens below.
+  try {
+    tests = buildTests();
+  } catch (error) {
+    console.log('  ✗ could not build the test list');
+    console.error(`    ${error.message}`);
+    tests = [];
+    failed += 1;
+  }
+
+  for (const [name, fn] of tests) {
+    if (runTest(name, fn)) passed += 1;
+    else failed += 1;
+  }
+
+  if (!(bashBinary && pythonCmd)) {
+    console.log('  - integration coverage skipped (needs bash + python; set ECC_TEST_BASH/ECC_TEST_PYTHON)');
+  }
+
+  console.log(`\n  Passed: ${passed}`);
+  console.log(`  Failed: ${failed}`);
+  if (failed > 0) process.exit(1);
+}
+
+main();

--- a/tests/skills/observer-status-instinct-count.test.js
+++ b/tests/skills/observer-status-instinct-count.test.js
@@ -204,7 +204,10 @@ function main() {
 
   console.log(`\n  Passed: ${passed}`);
   console.log(`  Failed: ${failed}`);
-  if (failed > 0) process.exit(1);
+  // exitCode, not exit(1): stdout is async when it is a pipe, which is how
+  // tests/run-all.js runs this, and process.exit() does not wait for pending
+  // writes — it could drop the two lines above, which the aggregator totals.
+  if (failed > 0) process.exitCode = 1;
 }
 
 main();


### PR DESCRIPTION
Fixes #2859.

## What Changed

`start-observer.sh status` counted instinct files with `find "$INSTINCTS_DIR" -name "*.yaml"`. It now counts every extension the loader accepts, the same way the loader enumerates them:

```sh
instinct_find_expr=( \( -iname "*.yaml" -o -iname "*.yml" -o -iname "*.md" \) )
instinct_count=$(find "$INSTINCTS_DIR" -maxdepth 1 -type f "${instinct_find_expr[@]}" 2>/dev/null | wc -l | tr -d "[:space:]")
```

Three things had to match `_load_instincts_from_dir` in `scripts/instinct-cli.py`, not one:

| loader | counter |
| :-- | :-- |
| `suffix.lower() in ALLOWED_INSTINCT_EXTENSIONS` → `.yaml`, `.yml`, `.md` | all three, and `-iname` for the case-insensitive compare |
| `Path.iterdir()` → top level only | `-maxdepth 1` (plain `find` recurses) |
| `file.is_file()` → directories skipped | `-type f` |

`tr` drops the column padding BSD `wc` emits, which is why the reported output read `Instincts:        0` with that gap.

## Why This Change

The producer writes `.md` **by explicit instruction** — `agents/observer-loop.sh:166` tells the analyzer to write `${INSTINCTS_DIR}/<id>.md` — and the consumer accepts three extensions. Only the status counter accepted one, so the single command an operator runs to confirm that learning is working reported `Instincts: 0` on a perfectly healthy install.

That matters beyond the wrong number: `Instincts: 0` is exactly what a silently dead observer looks like (#2673). An operator who checks `status` cannot tell "nothing has been learned" from "instincts exist and are not being counted", which removes the signal the status check exists to provide.

## Testing Done

- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`) — see the note below
- [x] Edge cases considered and tested

**End to end against the shipped script.** A temp homunculus dir (`CLV2_HOMUNCULUS_DIR` + `CLAUDE_PROJECT_DIR`), a live PID in `.observer.pid`, and an instincts dir holding 3 × `.md`, `a.yaml`, `b.yml`, `c.YAML`, a `notes.txt`, and `nested/deep.md`:

```
before:  Instincts: 1     # only a.yaml
after:   Instincts: 6     # the same six files instinct-cli.py loads
```

`notes.txt` and `nested/deep.md` are correctly excluded — the loader skips both.

**New test: `tests/skills/observer-status-instinct-count.test.js`, 11 assertions.** It parses `ALLOWED_INSTINCT_EXTENSIONS` out of `instinct-cli.py` and requires the counter to match *whatever it says*, so adding a fourth extension to the loader fails this test instead of silently under-reporting again. Then it runs the real `start-observer.sh status` for the three scenarios above. Integration coverage skips cleanly on Windows without `ECC_TEST_BASH`, following `tests/skills/repo-scan-install.test.js`.

Mutation-tested:

- restore `-name "*.yaml"` → **fails** (`status count must match .yml`)
- drop `-maxdepth 1` → **fails** (`status count must not recurse — the loader does not`)
- the script exits `1` on drift and `0` when clean, so `run-all.js` picks it up correctly

**On `node tests/run-all.js`:** run twice, same command, same machine — once on a clean `origin/main` and once on this branch:

| | tests | passed | failed |
| :-- | --: | --: | --: |
| `origin/main` | 3869 | 3816 | 53 |
| this branch | 3880 | 3827 | 53 |
| delta | **+11** | **+11** | **0** |

The +11 is exactly this file. The 53 failures are byte-identical between the two runs — the same eight groups (`lib/claude-plugin-setup`, `lib/claude-scope-migration`, `lib/codex-legacy-sync`, `lib/memory-vault`, `lib/state-store`, `scripts/ecc-universal-bin`, `scripts/memory-mcp`, `scripts/setup`), none of which read `skills/continuous-learning-v2/`. They are pre-existing on this machine, so I have left the "tests pass locally" box unticked rather than tick it on a suite that is not green — but this PR adds nothing to that number. `npx eslint` is clean on the new file.

**Review follow-up (second commit).** The static assertions originally ran at the top level, so a failure exited before the `Passed:`/`Failed:` tokens `run-all.js` totals — it still went red via the exit code, but the per-case counts were lost and you only ever saw the first broken expectation. Every case now goes through the same `runTest()` wrapper the integration cases already used, and the case list is built inside a try so a renamed `instinct-cli.py` is a reported failure rather than a crash. Reverting the fix now prints `Passed: 4, Failed: 7` and exits 1, naming all seven.

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] JSON files validate cleanly (none changed)
- [x] Shell scripts pass shellcheck (if applicable) — `bash -n` clean; the change is one `find` expression
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## If you added a skill, command, agent, hook, or CLI tool

Not applicable — no new component. One line changed in an existing skill script, plus one test file under `tests/skills/`, which `run-all.js` discovers by glob.

## Documentation
- [x] Updated relevant documentation — the comment above the counter records *why* the three extensions and the depth/case flags have to match the loader, so the next person editing it does not narrow it back.
- [x] Added comments for complex logic
- [ ] README updated (if needed) — not needed

