### PR TITLE
fix(memory-mcp): accept the reserved _meta param on ping

### DIFF
--- a/scripts/memory-mcp.mjs
+++ b/scripts/memory-mcp.mjs
@@ -417,8 +417,18 @@ function createMemoryMcpService(options = {}) {
         return jsonRpcError(message.id, -32002, 'Server is not initialized.');
       }
       if (message.method === 'ping') {
-        if (message.params && Object.keys(message.params).length > 0) {
-          return jsonRpcError(message.id, -32602, 'ping does not accept parameters.');
+        const params = message.params ?? {};
+        // `_meta` is reserved by MCP for request metadata (e.g. progressToken) and
+        // may ride on any request, which is why `tools/list` and `tools/call` below
+        // both admit it. `ping` rejected every parameter, so a client that attaches
+        // `_meta` to everything — Codex does — got -32602 on its keepalive. Present
+        // means it must be a metadata object; nothing else is accepted. (#2810)
+        if (
+          !isRecord(params)
+          || (Object.prototype.hasOwnProperty.call(params, '_meta') && !isRecord(params._meta))
+          || Object.keys(params).some(key => key !== '_meta')
+        ) {
+          return jsonRpcError(message.id, -32602, 'ping accepts no parameters other than _meta.');
         }
         return jsonRpcResult(message.id, {});
       }

--- a/tests/scripts/memory-mcp.test.js
+++ b/tests/scripts/memory-mcp.test.js
@@ -138,6 +138,7 @@ async function withClient(fn, options = {}) {
       { name, arguments: toolArguments }
     ),
     callToolRaw: params => request('tools/call', params),
+    ping: params => request('ping', params),
   };
 
   try {
@@ -224,6 +225,38 @@ async function main() {
         client.listToolsRaw({ unexpected: true }),
         /-32602/
       );
+    });
+  });
+
+  await test('accepts the reserved _meta param on ping and rejects malformed values (#2810)', async () => {
+    await withClient(async client => {
+      // A client that attaches `_meta` to every request — Codex does — got
+      // -32602 on its keepalive, because `ping` refused every parameter while
+      // tools/list and tools/call already admit the reserved member.
+      assert.deepStrictEqual(await client.ping({ _meta: { progressToken: 'progress-1' } }), {});
+
+      // Baselines: params absent and params `{}` are two different wire shapes
+      // and the server decides them on the same branch; both must still work.
+      assert.deepStrictEqual(await client.ping(), {});
+      assert.deepStrictEqual(await client.ping({}), {});
+
+      // Same shape rule as tools/list and tools/call: present means it must be
+      // a metadata object, never null, an array, or a scalar.
+      for (const badMeta of [null, ['not', 'an', 'object'], 'string', 42, true]) {
+        await assert.rejects(
+          client.ping({ _meta: badMeta }),
+          /-32602/,
+          `expected ping _meta=${JSON.stringify(badMeta)} to be rejected`
+        );
+      }
+
+      // `_meta` is an exemption, not an opening.
+      await assert.rejects(client.ping({ unexpected: true }), /-32602/);
+      await assert.rejects(client.ping({ _meta: {}, unexpected: true }), /-32602/);
+      // A non-object `params` never reaches the ping branch: the envelope check
+      // above rejects it with -32600 and `id: null`, which this client cannot
+      // correlate back to a request. The handler still guards it, for the same
+      // reason tools/call does, but it is not observable from out here.
     });
   });
 


### PR DESCRIPTION
Rebased onto current `main` and **narrowed**, because two thirds of it landed upstream while this sat.

## What changed under the branch

When this was written, `_meta` was refused on `tools/list`, `tools/call` and `ping`. On `main` today:

| method | accepts `_meta`? |
|---|---|
| `tools/list` | yes — validated alongside `cursor` |
| `tools/call` | yes — present must be a metadata object |
| `ping` | **no** — `if (message.params && Object.keys(message.params).length > 0) return -32602` |

So the original diff would now fight the landed implementation on two handlers. I rebased, dropped both, and kept only the gap that is still open: `ping` refuses every parameter, so a client that attaches `_meta` to every request — Codex does — gets `-32602` on its keepalive while the same `_meta` sails through the other two methods.

## The fix

The ping branch now mirrors the rule the other two already apply: `_meta` is admitted, and when present it must be a metadata object; every other key is still refused. Nothing else is touched.

```js
const params = message.params ?? {};
if (
  !isRecord(params)
  || (Object.prototype.hasOwnProperty.call(params, '_meta') && !isRecord(params._meta))
  || Object.keys(params).some(key => key !== '_meta')
) {
  return jsonRpcError(message.id, -32602, 'ping accepts no parameters other than _meta.');
}
```

## Tests

`tests/scripts/memory-mcp.test.js` gains a `ping` client helper and one case: `_meta` accepted; `params` absent and `params: {}` both still answer `{}`; `null` / array / string / number / boolean `_meta` rejected; `{unexpected: true}` and `{_meta: {}, unexpected: true}` rejected.

Reverting only `scripts/memory-mcp.mjs` to `origin/main` and re-running:

```
FAIL accepts the reserved _meta param on ping and rejects malformed values (#2810)
Results: Passed: 12, Failed: 2
```

With the fix: `Passed: 13, Failed: 1`.

Two notes on that count, both honest rather than tidy:

- The one remaining failure in both runs is `starts when the npm bin invokes the server through a symlink`, which fails as `EPERM: operation not permitted, symlink` — a Windows privilege limitation on my machine, identical before and after this change.
- I dropped one assertion I first wrote, `ping(['not','an','object'])`. A non-object `params` never reaches the ping branch: the envelope check rejects it with `-32600` and `id: null`, which the test client cannot correlate back to a request, so it times out rather than rejecting. The handler still guards it, for the same reason `tools/call` does, but it is not observable from the harness and I would rather say so than leave a passing-looking assertion that proves nothing.
