### PR TITLE
fix(skill-stocktake): inventory skills installed as symlinks (#2801)

### DIFF
--- a/skills/skill-stocktake/scripts/quick-diff.sh
+++ b/skills/skill-stocktake/scripts/quick-diff.sh
@@ -74,7 +74,11 @@ process_dir() {
       '{path:$path,mtime:$mtime,is_new:$is_new}' \
       > "$tmpdir/$i.json"
     i=$((i+1))
-  done < <(find "$dir" -name "*.md" -type f 2>/dev/null | sort)
+  # -L so a skill installed as a symlink is inventoried like any other. Plain
+  # find does not descend into a symlinked directory, and -type f is false for a
+  # symlinked file, so package-manager installs, app-bundled skills, and skills
+  # shared between tools were silently dropped from the count.
+  done < <(find -L "$dir" -name "*.md" -type f 2>/dev/null | sort)
 }
 
 [[ -d "$GLOBAL_DIR" ]] && process_dir "$GLOBAL_DIR"

--- a/skills/skill-stocktake/scripts/scan.sh
+++ b/skills/skill-stocktake/scripts/scan.sh
@@ -118,7 +118,11 @@ scan_dir_to_json() {
       '{path:$path,name:$name,description:$description,use_7d:$use_7d,use_30d:$use_30d,mtime:$mtime}' \
       > "$tmpdir/$i.json"
     i=$((i+1))
-  done < <(find "$dir" -name "*.md" -type f 2>/dev/null | sort)
+  # -L so a skill installed as a symlink is inventoried like any other. Plain
+  # find does not descend into a symlinked directory, and -type f is false for a
+  # symlinked file, so package-manager installs, app-bundled skills, and skills
+  # shared between tools were silently dropped from the count.
+  done < <(find -L "$dir" -name "*.md" -type f 2>/dev/null | sort)
 
   if [[ $i -eq 0 ]]; then
     echo "[]"

--- a/tests/skills/skill-stocktake-symlinks.test.js
+++ b/tests/skills/skill-stocktake-symlinks.test.js
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for #2801: skill-stocktake dropped symlinked skills.
+ *
+ * `find "$dir" -name "*.md" -type f` does not descend into a symlinked
+ * directory, and `-type f` is false for a symlinked file, so a skill installed
+ * as a symlink — package-manager installs, app-bundled skills, skills shared
+ * between tools — was silently absent from the inventory. The reporter had 4
+ * skills, 3 of them symlinks, and got a count of 1.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const scripts = [
+  path.join(repoRoot, 'skills', 'skill-stocktake', 'scripts', 'scan.sh'),
+  path.join(repoRoot, 'skills', 'skill-stocktake', 'scripts', 'quick-diff.sh'),
+];
+const bashBinary = process.env.ECC_TEST_BASH || (process.platform === 'win32' ? null : 'bash');
+
+function toShellPath(filePath) {
+  const normalized = filePath.split(path.sep).join('/');
+  return normalized.replace(/^([A-Za-z]):\//, (_, drive) => `/${drive.toLowerCase()}/`);
+}
+
+function findLine(scriptPath) {
+  return fs
+    .readFileSync(scriptPath, 'utf8')
+    .split('\n')
+    .find(line => line.includes('find') && line.includes('-name "*.md"'));
+}
+
+/** Build 2 real + 2 symlinked skill dirs. Returns null if links are unavailable. */
+function makeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-stocktake-'));
+  const skills = path.join(root, 'home', '.claude', 'skills');
+  const elsewhere = path.join(root, 'elsewhere');
+  const write = dir => {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, 'SKILL.md'),
+      `---\nname: ${path.basename(dir)}\ndescription: fixture\n---\n\nbody\n`
+    );
+  };
+  write(path.join(skills, 'real-a'));
+  write(path.join(skills, 'real-b'));
+  write(path.join(elsewhere, 'pkg-skill'));
+  write(path.join(elsewhere, 'shared-skill'));
+  try {
+    for (const name of ['pkg-skill', 'shared-skill']) {
+      // 'junction' is the Windows form that needs no elevation; ignored elsewhere.
+      fs.symlinkSync(path.join(elsewhere, name), path.join(skills, name), 'junction');
+    }
+  } catch {
+    fs.rmSync(root, { recursive: true, force: true });
+    return null;
+  }
+  return { root, skills };
+}
+
+let passed = 0;
+
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.error(`    ${error.message}`);
+    return false;
+  }
+}
+
+function main() {
+  console.log('\n=== Testing skill-stocktake symlink enumeration (#2801) ===\n');
+
+  const tests = [];
+
+  // Both scripts enumerate the same inventory; a quick-diff that disagreed with
+  // scan would report every symlinked skill as an addition or a removal.
+  for (const scriptPath of scripts) {
+    const rel = path.relative(repoRoot, scriptPath).split(path.sep).join('/');
+    tests.push([`${rel} follows symlinks when enumerating`, () => {
+      const line = findLine(scriptPath);
+      assert.ok(line, `no *.md find expression in ${rel}`);
+      assert.match(line, /find\s+-L\s/, `${rel} must use find -L`);
+    }]);
+  }
+
+  if (bashBinary) {
+    tests.push(['the shipped find expression sees a symlinked skill', () => {
+      const fixture = makeFixture();
+      if (fixture === null) {
+        console.log('    (skipped: this system does not allow creating links)');
+        return;
+      }
+      try {
+        // Run the exact expression the scripts ship, not a paraphrase of it.
+        const expression = findLine(scripts[0]).trim().replace(/^done < <\(/, '').replace(/\)$/, '');
+        const command = expression.replace('"$dir"', `"${toShellPath(fixture.skills)}"`);
+        const result = spawnSync(bashBinary, ['-c', command], { encoding: 'utf8' });
+        assert.strictEqual(result.status, 0, result.stderr);
+        const found = (result.stdout || '').split('\n').filter(Boolean);
+        assert.strictEqual(
+          found.length,
+          4,
+          `expected 2 real + 2 symlinked skills, got ${found.length}:\n${found.join('\n')}`
+        );
+        for (const name of ['real-a', 'real-b', 'pkg-skill', 'shared-skill']) {
+          assert.ok(
+            found.some(entry => entry.includes(`/${name}/`)),
+            `${name} missing from the inventory`
+          );
+        }
+      } finally {
+        fs.rmSync(fixture.root, { recursive: true, force: true });
+      }
+    }]);
+  } else {
+    console.log('  - integration coverage skipped on Windows without ECC_TEST_BASH');
+  }
+
+  let failed = 0;
+  for (const [name, fn] of tests) {
+    if (runTest(name, fn)) passed += 1;
+    else failed += 1;
+  }
+
+  console.log(`\n  Passed: ${passed}`);
+  console.log(`  Failed: ${failed}`);
+  // exitCode, not exit(1): stdout is async when it is a pipe, which is how
+  // tests/run-all.js runs this, and process.exit() does not wait for pending
+  // writes — it could drop the two lines above, which the aggregator totals.
+  if (failed > 0) process.exitCode = 1;
+}
+
+main();

--- a/tests/skills/skill-stocktake-symlinks.test.js
+++ b/tests/skills/skill-stocktake-symlinks.test.js
@@ -23,6 +23,11 @@ const scripts = [
 ];
 const bashBinary = process.env.ECC_TEST_BASH || (process.platform === 'win32' ? null : 'bash');
 
+// Creating a link can fail because the platform or filesystem does not offer
+// them — that is a skip. Any other failure is a broken fixture and must not be
+// reported as a passing test.
+const LINKS_UNSUPPORTED = new Set(['EPERM', 'EACCES', 'ENOSYS', 'ENOTSUP', 'EOPNOTSUPP']);
+
 function toShellPath(filePath) {
   const normalized = filePath.split(path.sep).join('/');
   return normalized.replace(/^([A-Za-z]):\//, (_, drive) => `/${drive.toLowerCase()}/`);
@@ -35,35 +40,74 @@ function findLine(scriptPath) {
     .find(line => line.includes('find') && line.includes('-name "*.md"'));
 }
 
-/** Build 2 real + 2 symlinked skill dirs. Returns null if links are unavailable. */
-function makeFixture() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-stocktake-'));
-  const skills = path.join(root, 'home', '.claude', 'skills');
-  const elsewhere = path.join(root, 'elsewhere');
-  const write = dir => {
-    fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(
-      path.join(dir, 'SKILL.md'),
-      `---\nname: ${path.basename(dir)}\ndescription: fixture\n---\n\nbody\n`
-    );
-  };
-  write(path.join(skills, 'real-a'));
-  write(path.join(skills, 'real-b'));
-  write(path.join(elsewhere, 'pkg-skill'));
-  write(path.join(elsewhere, 'shared-skill'));
-  try {
-    for (const name of ['pkg-skill', 'shared-skill']) {
-      // 'junction' is the Windows form that needs no elevation; ignored elsewhere.
-      fs.symlinkSync(path.join(elsewhere, name), path.join(skills, name), 'junction');
-    }
-  } catch {
-    fs.rmSync(root, { recursive: true, force: true });
-    return null;
-  }
-  return { root, skills };
+function writeSkill(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, 'SKILL.md');
+  fs.writeFileSync(file, `---\nname: ${path.basename(dir)}\ndescription: fixture\n---\n\nbody\n`);
+  return file;
 }
 
-let passed = 0;
+/**
+ * Link `target` to `linkPath`, or return false when this system has no links.
+ *
+ * @param {string} target
+ * @param {string} linkPath
+ * @param {'junction'|'file'} type 'junction' is the Windows directory form that
+ *   needs no elevation; a file link does need it, hence the separate answer.
+ * @returns {boolean}
+ */
+function tryLink(target, linkPath, type) {
+  try {
+    fs.symlinkSync(target, linkPath, type);
+    return true;
+  } catch (error) {
+    if (LINKS_UNSUPPORTED.has(error.code)) return false;
+    throw error;
+  }
+}
+
+/**
+ * Build the inventory the reporter had: real skills beside linked ones.
+ *
+ * Directory links are required — without them there is nothing to test, so a
+ * system that cannot make them skips the case. A skill whose SKILL.md is
+ * *itself* a link is the second half of the bug (`-type f` is false for one),
+ * but that form needs elevation on Windows, so it is reported separately
+ * rather than skipping the whole fixture.
+ *
+ * @returns {{root: string, skills: string, expected: string[], fileLink: boolean}|null}
+ */
+function makeFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-stocktake-'));
+  try {
+    const skills = path.join(root, 'home', '.claude', 'skills');
+    const elsewhere = path.join(root, 'elsewhere');
+    writeSkill(path.join(skills, 'real-a'));
+    writeSkill(path.join(skills, 'real-b'));
+    for (const name of ['pkg-skill', 'shared-skill']) writeSkill(path.join(elsewhere, name));
+    const standalone = writeSkill(path.join(elsewhere, 'standalone'));
+
+    const expected = ['real-a', 'real-b'];
+    for (const name of ['pkg-skill', 'shared-skill']) {
+      if (!tryLink(path.join(elsewhere, name), path.join(skills, name), 'junction')) {
+        fs.rmSync(root, { recursive: true, force: true });
+        return null;
+      }
+      expected.push(name);
+    }
+
+    const linkedFileDir = path.join(skills, 'file-link-skill');
+    fs.mkdirSync(linkedFileDir, { recursive: true });
+    const fileLink = tryLink(standalone, path.join(linkedFileDir, 'SKILL.md'), 'file');
+    if (fileLink) expected.push('file-link-skill');
+    else fs.rmSync(linkedFileDir, { recursive: true, force: true });
+
+    return { root, skills, expected, fileLink };
+  } catch (error) {
+    fs.rmSync(root, { recursive: true, force: true });
+    throw error;
+  }
+}
 
 function runTest(name, fn) {
   try {
@@ -77,63 +121,79 @@ function runTest(name, fn) {
   }
 }
 
-function main() {
-  console.log('\n=== Testing skill-stocktake symlink enumeration (#2801) ===\n');
-
-  const tests = [];
-
-  // Both scripts enumerate the same inventory; a quick-diff that disagreed with
-  // scan would report every symlinked skill as an addition or a removal.
-  for (const scriptPath of scripts) {
-    const rel = path.relative(repoRoot, scriptPath).split(path.sep).join('/');
-    tests.push([`${rel} follows symlinks when enumerating`, () => {
+// Both scripts enumerate the same inventory; a quick-diff that disagreed with
+// scan would report every symlinked skill as an addition or a removal.
+const expressionTests = scripts.map(scriptPath => {
+  const rel = path.relative(repoRoot, scriptPath).split(path.sep).join('/');
+  return [
+    `${rel} follows symlinks when enumerating`,
+    () => {
       const line = findLine(scriptPath);
       assert.ok(line, `no *.md find expression in ${rel}`);
       assert.match(line, /find\s+-L\s/, `${rel} must use find -L`);
-    }]);
-  }
+    },
+  ];
+});
 
-  if (bashBinary) {
-    tests.push(['the shipped find expression sees a symlinked skill', () => {
-      const fixture = makeFixture();
-      if (fixture === null) {
-        console.log('    (skipped: this system does not allow creating links)');
-        return;
-      }
-      try {
-        // Run the exact expression the scripts ship, not a paraphrase of it.
-        const expression = findLine(scripts[0]).trim().replace(/^done < <\(/, '').replace(/\)$/, '');
-        const command = expression.replace('"$dir"', `"${toShellPath(fixture.skills)}"`);
-        const result = spawnSync(bashBinary, ['-c', command], { encoding: 'utf8' });
-        assert.strictEqual(result.status, 0, result.stderr);
-        const found = (result.stdout || '').split('\n').filter(Boolean);
-        assert.strictEqual(
-          found.length,
-          4,
-          `expected 2 real + 2 symlinked skills, got ${found.length}:\n${found.join('\n')}`
-        );
-        for (const name of ['real-a', 'real-b', 'pkg-skill', 'shared-skill']) {
-          assert.ok(
-            found.some(entry => entry.includes(`/${name}/`)),
-            `${name} missing from the inventory`
-          );
-        }
-      } finally {
-        fs.rmSync(fixture.root, { recursive: true, force: true });
-      }
-    }]);
-  } else {
+const integrationTests = bashBinary
+  ? [
+      [
+        'the shipped find expression sees linked skills',
+        () => {
+          const fixture = makeFixture();
+          if (fixture === null) {
+            console.log('    (skipped: this system does not allow creating links)');
+            return;
+          }
+          try {
+            // Run the exact expression the scripts ship, unmodified: `$dir` is
+            // bound from a positional argument instead of being substituted
+            // into the command text, so a fixture path containing shell syntax
+            // is data rather than something bash parses.
+            const expression = findLine(scripts[0]).trim().replace(/^done < <\(/, '').replace(/\)$/, '');
+            const result = spawnSync(
+              bashBinary,
+              ['-c', `dir="$1"; ${expression}`, 'skill-stocktake-test', toShellPath(fixture.skills)],
+              { encoding: 'utf8' }
+            );
+            assert.strictEqual(result.status, 0, result.stderr);
+            const found = (result.stdout || '').split('\n').filter(Boolean);
+            if (!fixture.fileLink) {
+              console.log('    (a SKILL.md that is itself a link needs elevation here; skipped)');
+            }
+            assert.strictEqual(
+              found.length,
+              fixture.expected.length,
+              `expected ${fixture.expected.join(', ')}, got ${found.length}:\n${found.join('\n')}`
+            );
+            for (const name of fixture.expected) {
+              assert.ok(
+                found.some(entry => entry.includes(`/${name}/`)),
+                `${name} missing from the inventory`
+              );
+            }
+          } finally {
+            fs.rmSync(fixture.root, { recursive: true, force: true });
+          }
+        },
+      ],
+    ]
+  : [];
+
+function main() {
+  console.log('\n=== Testing skill-stocktake symlink enumeration (#2801) ===\n');
+
+  if (!bashBinary) {
     console.log('  - integration coverage skipped on Windows without ECC_TEST_BASH');
   }
 
-  let failed = 0;
-  for (const [name, fn] of tests) {
-    if (runTest(name, fn)) passed += 1;
-    else failed += 1;
-  }
+  const tests = [...expressionTests, ...integrationTests];
+  const results = tests.map(([name, fn]) => runTest(name, fn));
+  const passed = results.filter(Boolean).length;
+  const failed = results.length - passed;
 
-  console.log(`\n  Passed: ${passed}`);
-  console.log(`  Failed: ${failed}`);
+  console.log(`\nPassed: ${passed}`);
+  console.log(`Failed: ${failed}`);
   // exitCode, not exit(1): stdout is async when it is a pipe, which is how
   // tests/run-all.js runs this, and process.exit() does not wait for pending
   // writes — it could drop the two lines above, which the aggregator totals.

--- a/tests/skills/skill-stocktake-symlinks.test.js
+++ b/tests/skills/skill-stocktake-symlinks.test.js
@@ -156,6 +156,16 @@ const integrationTests = bashBinary
               ['-c', `dir="$1"; ${expression}`, 'skill-stocktake-test', toShellPath(fixture.skills)],
               { encoding: 'utf8' }
             );
+            if (result.error) {
+              // No bash on this system: `status` is null, so the exit-status
+              // assertion below would report a confusing empty stderr instead
+              // of saying the binary is missing.
+              if (result.error.code === 'ENOENT') {
+                console.log(`    (skipped: ${bashBinary} not found)`);
+                return;
+              }
+              throw result.error;
+            }
             assert.strictEqual(result.status, 0, result.stderr);
             const found = (result.stdout || '').split('\n').filter(Boolean);
             if (!fixture.fileLink) {

--- a/tests/skills/skill-stocktake-symlinks.test.js
+++ b/tests/skills/skill-stocktake-symlinks.test.js
@@ -135,10 +135,14 @@ const expressionTests = scripts.map(scriptPath => {
   ];
 });
 
+// Each script gets its own run. Checking one and static-checking the other
+// would let a differently broken expression in the unrun script pass, which
+// is the disagreement between the two inventories this PR is about.
 const integrationTests = bashBinary
-  ? [
-      [
-        'the shipped find expression sees linked skills',
+  ? scripts.map(scriptPath => {
+      const rel = path.relative(repoRoot, scriptPath).split(path.sep).join('/');
+      return [
+        `${rel}: the shipped find expression sees linked skills`,
         () => {
           const fixture = makeFixture();
           if (fixture === null) {
@@ -150,7 +154,7 @@ const integrationTests = bashBinary
             // bound from a positional argument instead of being substituted
             // into the command text, so a fixture path containing shell syntax
             // is data rather than something bash parses.
-            const expression = findLine(scripts[0]).trim().replace(/^done < <\(/, '').replace(/\)$/, '');
+            const expression = findLine(scriptPath).trim().replace(/^done < <\(/, '').replace(/\)$/, '');
             const result = spawnSync(
               bashBinary,
               ['-c', `dir="$1"; ${expression}`, 'skill-stocktake-test', toShellPath(fixture.skills)],
@@ -186,8 +190,8 @@ const integrationTests = bashBinary
             fs.rmSync(fixture.root, { recursive: true, force: true });
           }
         },
-      ],
-    ]
+      ];
+    })
   : [];
 
 function main() {

--- a/tests/skills/skill-stocktake-symlinks.test.js
+++ b/tests/skills/skill-stocktake-symlinks.test.js
@@ -163,8 +163,11 @@ const integrationTests = bashBinary
             if (result.error) {
               // No bash on this system: `status` is null, so the exit-status
               // assertion below would report a confusing empty stderr instead
-              // of saying the binary is missing.
-              if (result.error.code === 'ENOENT') {
+              // of saying the binary is missing. Only the default lookup is
+              // allowed to skip — a name given explicitly through
+              // ECC_TEST_BASH that does not resolve is a broken configuration,
+              // and silently skipping it would report coverage nobody ran.
+              if (result.error.code === 'ENOENT' && !process.env.ECC_TEST_BASH) {
                 console.log(`    (skipped: ${bashBinary} not found)`);
                 return;
               }


### PR DESCRIPTION
Fixes #2801.

## What Changed

`find "$dir" -name "*.md" -type f` → `find -L "$dir" -name "*.md" -type f`, in **both** `scan.sh` and `quick-diff.sh`.

## Why This Change

Plain `find` does not descend into a symlinked directory, and `-type f` is false for a symlinked file, so a skill installed as a link is invisible to the inventory. That covers the common cases: package-manager installs, app-bundled skills, and skills shared between tools. The reporter had 4 skills, 3 of them symlinks, and `scan.sh` reported 1.

The issue names only `scan.sh`. `quick-diff.sh:77` carries the identical expression, and it is the script that compares one inventory against another — fixing only `scan.sh` would have left them disagreeing, so every symlinked skill would show up as an addition or a removal on each run. Both are fixed here.

## Testing Done

- [x] Manual testing completed
- [ ] Automated tests pass locally (`node tests/run-all.js`) — see below
- [x] Edge cases considered and tested

**Measured against the real `scan.sh`**, with a fixture of 2 real and 2 symlinked skill directories, 4 `SKILL.md` on disk:

```
before:  scan.sh enumerated: 2 skill file(s)
after:   scan.sh enumerated: 4 skill file(s)
```

A note on how that was possible here: `ln -s` on this machine fails with `Operation not permitted` (no Developer Mode, not elevated), so the first attempt could not reproduce the bug at all — `ln -s` silently produced a directory **copy**, and both `find` forms then agreed. A Windows **directory junction** does not need elevation and Git Bash's `find` treats it as a symlink, which reproduces the defect exactly:

```
$ find .    -name "*.md" -type f     ->  ./real/a.md
$ find -L . -name "*.md" -type f     ->  ./linked/a.md  ./real/a.md
```

**New test: `tests/skills/skill-stocktake-symlinks.test.js`.** It asserts both scripts use `find -L`, then runs the `find` expression **extracted from the shipped file** rather than a retyped copy, against a 2-real + 2-linked fixture, and requires all four back by name. Extracting it means a future edit to the script cannot drift past the test. The fixture uses `fs.symlinkSync(..., 'junction')` and skips cleanly if the system refuses links.

```
  ✓ skills/skill-stocktake/scripts/scan.sh follows symlinks when enumerating
  ✓ skills/skill-stocktake/scripts/quick-diff.sh follows symlinks when enumerating
  ✓ the shipped find expression sees a symlinked skill
  Passed: 3, Failed: 0
```

Mutation-tested: reverting `scan.sh` to plain `find` fails **2 of 3** and exits 1, with `expected 2 real + 2 symlinked skills, got 2`.

**On `node tests/run-all.js`:** the full suite is not green on this machine — 53 failures in eight groups, none of which touch `skills/skill-stocktake/`, identical with and without this change (measured earlier today by running the suite on a clean `origin/main` and on a branch). I have left that box unticked rather than tick it on a suite I cannot show green; this PR adds nothing to that number.

## Known limits

`-L` follows links, so if a skills directory contains both a real directory and a symlink pointing at it, the same skill is inventoried twice under two paths. That is inherent to following links and is the correct trade against silently dropping every linked skill. `find` detects and skips symlink loops rather than spinning.

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] JSON files validate cleanly (none changed)
- [x] Shell scripts pass shellcheck (if applicable) — `bash -n` clean on both
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## If you added a skill, command, agent, hook, or CLI tool

Not applicable — no new component. One flag added to two existing scripts, plus one test file under `tests/skills/`, which `run-all.js` discovers by glob.

## Documentation
- [x] Added comments for complex logic — the comment above each `find` records why `-L` is load-bearing, so it does not get trimmed back as noise.
- [ ] README updated (if needed) — not needed
