### PR TITLE
docs(ito-compute): document ito accept and ito_accept MCP workflow

### DIFF
--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -8,7 +8,7 @@
     "ito-compute": {
       "command": "node",
       "args": ["/absolute/path/to/ito-cloud-runtime/cli/ito-compute-cli/dist/bin/ito-mcp.js"],
-      "description": "Opt-in local Itô compute MCP. The canonical package is unpublished and must be built from Ito-Markets/ito-cloud-runtime/cli/ito-compute-cli. Exposes only ito_auth, ito_find, and ito_status. ito_auth validates existing credentials; it does not start device login. Use ecc ito login [--no-browser] for device authorization, which stores tokens in macOS Keychain by default; explicit file fallback must retain owner-only settings. ECC itself performs no browser automation. ITO_API_KEY is forwarded directly to auth, find, and status when configured; ITO_AUTH_MODE=legacy is not required."
+      "description": "Opt-in local Itô compute MCP. The canonical package is unpublished and must be built from Ito-Markets/ito-cloud-runtime/cli/ito-compute-cli. Exposes ito_auth, ito_find, ito_status, and ito_accept. ito_auth validates existing credentials; it does not start device login. Use ecc ito login [--no-browser] for device authorization, which stores tokens in macOS Keychain by default; explicit file fallback must retain owner-only settings. ECC itself performs no browser automation. ITO_API_KEY is forwarded directly to auth, find, status, and accept when configured; ITO_AUTH_MODE=legacy is not required."
     },
     "jira": {
       "command": "uvx",

--- a/skills/ito-compute/SKILL.md
+++ b/skills/ito-compute/SKILL.md
@@ -73,7 +73,15 @@ key or token in arguments, tracked files, MCP results, logs, or chat.
 
 5. Run `ecc ito status` to inspect RFQs and procurement orders.
    After an ambiguous transport failure, check status before repeating `find`.
-6. Run `ecc ito logout` when the user explicitly asks to revoke this device.
+6. When a quote is ready and the buyer explicitly approves, accept it:
+
+   ```sh
+   ecc ito accept rfq_<ticket-id>
+   ```
+
+   This routes the ticket to the desk for human review. It does not move funds
+   or reserve capacity. Do not accept without explicit buyer authority.
+7. Run `ecc ito logout` when the user explicitly asks to revoke this device.
    The canonical CLI keeps the local credential when remote revocation fails so
    the operator can retry; never delete the token manually as a substitute.
 
@@ -129,23 +137,27 @@ The server exposes only:
 - `ito_auth`
 - `ito_find`
 - `ito_status`
+- `ito_accept`
 
 `ito_auth` validates existing credentials; it does not start device login. Use
 `ito_auth`, gather explicit buyer authority and every hard constraint, call
-`ito_find`, then poll with `ito_status` when needed.
+`ito_find`, then poll with `ito_status` when needed. When a firm quote is ready
+and the buyer explicitly approves, call `ito_accept` with the ticket id.
 
 ## Rent or purchase semantics
 
 `find` submits an RFQ and may return a firm quote, but it does not rent,
-purchase, reserve, provision, or move funds. `status` is read-oriented, though
-the provider endpoint may reconcile an existing procurement order. The passive
-dashboard link in ECC help is a separate user-operated web route; do not open or
-operate it as a substitute for a missing CLI capability.
+purchase, reserve, provision, or move funds. `accept` routes a quote to the desk
+for human review; it does not move funds or reserve capacity. `status` is
+read-oriented, though the provider endpoint may reconcile an existing procurement
+order. The passive dashboard link in ECC help is a separate user-operated web
+route; do not open or operate it as a substitute for a missing CLI capability.
 
 ## Unsupported operations
 
 The supported client surface cannot lock quotes, reserve capacity, execute
-workloads, or serve inference. The MCP server does not expose qualification;
-use the explicit CLI command above. Do not invent additional tools or a
-purchase path. Do not substitute a browser or fixture when the local CLI is
-missing or a live operation fails. Report the missing capability and stop.
+workloads, or serve inference. `accept` is a desk handoff, not a purchase. The
+MCP server does not expose qualification; use the explicit CLI command above. Do
+not invent additional tools or a purchase path. Do not substitute a browser or
+fixture when the local CLI is missing or a live operation fails. Report the
+missing capability and stop.

--- a/skills/ito-compute/SKILL.md
+++ b/skills/ito-compute/SKILL.md
@@ -141,8 +141,10 @@ The server exposes only:
 
 `ito_auth` validates existing credentials; it does not start device login. Use
 `ito_auth`, gather explicit buyer authority and every hard constraint, call
-`ito_find`, then poll with `ito_status` when needed. When a firm quote is ready
-and the buyer explicitly approves, call `ito_accept` with the ticket id.
+`ito_find`, then poll with `ito_status` when needed. When a quote is ready and
+the buyer explicitly approves, call `ito_accept` with the ticket id. Desk
+quotes are usually indicative and nonbinding until the desk confirms; the
+result carries `quote_class`.
 
 ## Rent or purchase semantics
 

--- a/skills/ito-compute/agents/openai.yaml
+++ b/skills/ito-compute/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Itô Compute"
-  short_description: "GPU inventory, RFQs, status, and revocation"
-  default_prompt: "Use $ito-compute to request a live GPU RFQ, inspect status, or revoke this device safely."
+  short_description: "GPU inventory, RFQs, status, quote acceptance, and revocation"
+  default_prompt: "Use $ito-compute to request a live GPU RFQ, inspect status, accept a quote, or revoke this device safely."

--- a/tests/ci/ito-compute-skill.test.js
+++ b/tests/ci/ito-compute-skill.test.js
@@ -45,7 +45,7 @@ function main() {
         assert.match(skill, new RegExp(command.replace(" ", "\\s+")));
       }
       assert.doesNotMatch(skill, /^\s*ito (?:auth|find|status|evals)\b/m);
-      for (const tool of ["ito_auth", "ito_find", "ito_status"]) {
+      for (const tool of ["ito_auth", "ito_find", "ito_status", "ito_accept"]) {
         assert.match(skill, new RegExp(`\\b${tool}\\b`));
       }
       assert.doesNotMatch(
@@ -142,7 +142,7 @@ function main() {
         "/absolute/path/to/ito-cloud-runtime/cli/ito-compute-cli/dist/bin/ito-mcp.js",
       ]);
       assert.doesNotMatch(JSON.stringify(server), /npx|ito_lock|ito_run|paper|simulat/i);
-      assert.match(server.description, /ito_auth, ito_find, and ito_status/);
+      assert.match(server.description, /ito_auth, ito_find, ito_status, and ito_accept/);
       assert.match(server.description, /unpublished/i);
       assert.match(server.description, /ito_auth.*validat/i);
       assert.match(server.description, /macOS Keychain/i);


### PR DESCRIPTION
Updates the canonical ECC `ito-compute` skill to cover the new quote acceptance path.

**What**
- Documents `ecc ito accept <ticket-id>` CLI command
- Documents `ito_accept` MCP tool
- Adds explicit buyer-authority guard before accepting
- Clarifies that accept routes to desk, does not purchase

**Related**
- ito-cloud-runtime PR: Ito-Markets/ito-cloud-runtime#1453
