### PR TITLE
fix(plan-canvas): prevent loading hangs and add PDF export

### DIFF
--- a/.agents/skills/plan-canvas/SKILL.md
+++ b/.agents/skills/plan-canvas/SKILL.md
@@ -154,6 +154,9 @@ mirror at `ECC_PLAN_CANVAS_MERMAID_URL` for air-gapped use.
   session is refused; pass `--reopen` only when the user asks to resume.
 - Sibling assets (images, CSS) must sit next to the artifact and be
   referenced by relative path.
+- The reviewer can use **Download PDF** in the Canvas header to save the current
+  artifact directly. Export stays local and uses an installed Chrome, Chromium,
+  or Edge renderer; `ECC_PLAN_CANVAS_CHROME_PATH` selects a nonstandard install.
 - The server is loopback-only and exits after 30 idle minutes
   (`ECC_PLAN_CANVAS_IDLE_MS`); `stop` shuts it down explicitly. State lives
   in `~/.claude/plan-canvas/` (`ECC_PLAN_CANVAS_STATE_DIR`).

--- a/docs/design/plan-canvas.md
+++ b/docs/design/plan-canvas.md
@@ -82,7 +82,7 @@ after 30 min, `ECC_PLAN_CANVAS_IDLE_MS`). Feedback is deliver-and-drain: queued 
 handed to exactly one `await` call and persisted to disk until then, so nothing is lost if
 the poll is interrupted.
 
-- `GET /health` — `{ok, app, version, protocolVersion, runtimeId}`; the CLI reuses a detached server only when its package, protocol, and Canvas-module fingerprint match, preventing an older same-version worktree from serving stale browser code. A per-user, port-scoped startup lock serializes compatibility checks and replacement so concurrent opens reuse the winning server instead of racing two detached launches.
+- `GET /health` — `{ok, app, version, protocolVersion, runtimeId}`; the CLI reuses a detached server only when its package, protocol, and Canvas-module fingerprint match, preventing an older same-version worktree from serving stale browser code. An OS-managed, port-scoped startup lock serializes compatibility checks and replacement so concurrent opens reuse the winning server instead of racing two detached launches. The lock is released automatically when its process exits.
 - `GET /` — session list (ECC chrome)
 - `POST /api/sessions` `{file, reopen?}` — open/resume; `409 user-ended` unless `reopen`
 - `GET /canvas/<key>` — editor chrome; `GET /artifact/<key>/` — rendered artifact

--- a/docs/design/plan-canvas.md
+++ b/docs/design/plan-canvas.md
@@ -82,7 +82,7 @@ after 30 min, `ECC_PLAN_CANVAS_IDLE_MS`). Feedback is deliver-and-drain: queued 
 handed to exactly one `await` call and persisted to disk until then, so nothing is lost if
 the poll is interrupted.
 
-- `GET /health` — `{ok, app, version, protocolVersion, runtimeId}`; the CLI reuses a detached server only when its package, protocol, and Canvas-module fingerprint match, preventing an older same-version worktree from serving stale browser code
+- `GET /health` — `{ok, app, version, protocolVersion, runtimeId}`; the CLI reuses a detached server only when its package, protocol, and Canvas-module fingerprint match, preventing an older same-version worktree from serving stale browser code. A per-user, port-scoped startup lock serializes compatibility checks and replacement so concurrent opens reuse the winning server instead of racing two detached launches.
 - `GET /` — session list (ECC chrome)
 - `POST /api/sessions` `{file, reopen?}` — open/resume; `409 user-ended` unless `reopen`
 - `GET /canvas/<key>` — editor chrome; `GET /artifact/<key>/` — rendered artifact
@@ -127,7 +127,11 @@ unavailable, and can be repointed at a local mirror via
 
 PDF export also stays local. The server launches an installed Chrome, Chromium, or Edge
 executable with a new temporary profile, restricts the print target to the loopback Canvas
-origin, waits for a complete `%PDF` document, terminates that private renderer, and removes
-its temporary profile. Set `ECC_PLAN_CANVAS_CHROME_PATH` when auto-discovery cannot find the
-browser. The export endpoint returns an actionable error instead of uploading the plan or
-silently falling back to a remote service.
+origin, applies an export-only CSP that disables scripts and outbound resource classes, and
+routes every non-origin browser request into a local deny proxy. It waits for a complete
+`%PDF` document, terminates that private renderer, closes the deny proxy, and removes its
+temporary profile. One renderer is admitted at a time; overlapping requests receive HTTP 429
+with `Retry-After: 1` instead of launching unbounded browser processes. Set
+`ECC_PLAN_CANVAS_CHROME_PATH` when auto-discovery cannot find the browser. The export endpoint
+returns an actionable error instead of uploading the plan or silently falling back to a
+remote service.

--- a/docs/design/plan-canvas.md
+++ b/docs/design/plan-canvas.md
@@ -42,6 +42,7 @@ A loopback-only web editor for plan artifacts (and any local HTML artifact):
 | Editor chrome | `scripts/lib/plan-canvas/ui.js` | `scripts/lib/control-pane/ui.js`, tokens from `scripts/dashboard-web.js` |
 | Markdown plan renderer | `scripts/lib/plan-canvas/markdown.js` | zero new deps; renders the `commands/plan.md` artifact schema (tables, tasks, code fences, Mermaid blocks) |
 | Mermaid diagrams | `scripts/lib/plan-canvas/ui.js` | ` ```mermaid ` blocks render in the browser after page load, themed to ECC; pinned CDN with non-blocking fallback (`ECC_PLAN_CANVAS_MERMAID_URL` for a local mirror) |
+| PDF export | `scripts/lib/plan-canvas/pdf.js` | local Chrome, Chromium, or Edge print renderer; returns a PDF download without a cloud converter or new npm runtime dependency (`ECC_PLAN_CANVAS_CHROME_PATH` override) |
 | Session state | `scripts/lib/plan-canvas/sessions.js` | file-path-keyed sessions, state under `~/.claude/plan-canvas/` (`ECC_PLAN_CANVAS_STATE_DIR` override) |
 | Skill | `skills/plan-canvas/SKILL.md` | skills-first surface; teaches the open → await → reply loop; defers visual guidance to `frontend-design-direction`, `artifact-design`, `dataviz` |
 | Command shim | `commands/plan-canvas.md` | legacy parity surface, points at the skill |
@@ -87,6 +88,10 @@ the poll is interrupted.
 - `GET /canvas/<key>` — editor chrome; `GET /artifact/<key>/` — rendered artifact
   (markdown → ECC plan template, HTML passthrough) with the annotation SDK injected;
   sibling assets confined to the artifact directory
+- `GET /api/session/<key>/state` — finite browser poll for chat, presence, end state,
+  and artifact revision; replaces one permanent browser connection per Canvas
+- `GET /api/session/<key>/pdf` — render the current loopback artifact with a private
+  temporary Chromium profile and return it as an attachment with a safe filename
 - `POST /api/session/<key>/feedback` `{items[], endSession?}` — browser queues
   chat / annotation / verdict items
 - `GET /api/await?file=<path>[&timeoutMs=n]` — agent long-poll (whitespace heartbeat);
@@ -94,8 +99,8 @@ the poll is interrupted.
 - `POST /api/session/<key>/reply` `{text}` — agent message → canvas chat
 - `POST /api/session/<key>/end` (user) / `POST /api/end` `{file}` (agent) — ender recorded;
   user ends are sticky: plain `open` refuses to reopen without `--reopen`
-- `GET /events/<key>` — SSE to the browser: `chat-sync`, `presence`
-  (waiting/listening/working), `reload` (artifact file changed), `ended`
+- `GET /events/<key>` — returns HTTP 204 so pre-protocol-3 EventSource clients stop
+  reconnecting and release their browser connection slots
 
 ## Deliberate differences from lavish-axi
 
@@ -104,7 +109,7 @@ the poll is interrupted.
 - ECC design tokens and chrome; JSON (not TOON) agent output.
 - Mermaid renders themed to ECC, but without lavish's pan/zoom or node-id capture —
   whole-element annotation covers pointing at a diagram or node.
-- No export/share hosting, no layout-audit gate, no bundled playbooks — ECC's existing
+- Local PDF export without share hosting, no layout-audit gate, no bundled playbooks — ECC's existing
   design skills (`frontend-design-direction`, `artifact-design`, `dataviz`) cover authoring.
 
 ## Security posture
@@ -119,3 +124,10 @@ after an artifact containing a diagram has loaded; it renders with `securityLeve
 cannot hold the Canvas page in a loading state, degrades to showing diagram source if
 unavailable, and can be repointed at a local mirror via
 `ECC_PLAN_CANVAS_MERMAID_URL`. The server itself still makes no network calls.
+
+PDF export also stays local. The server launches an installed Chrome, Chromium, or Edge
+executable with a new temporary profile, restricts the print target to the loopback Canvas
+origin, waits for a complete `%PDF` document, terminates that private renderer, and removes
+its temporary profile. Set `ECC_PLAN_CANVAS_CHROME_PATH` when auto-discovery cannot find the
+browser. The export endpoint returns an actionable error instead of uploading the plan or
+silently falling back to a remote service.

--- a/docs/design/plan-canvas.md
+++ b/docs/design/plan-canvas.md
@@ -41,7 +41,7 @@ A loopback-only web editor for plan artifacts (and any local HTML artifact):
 | Server | `scripts/lib/plan-canvas/server.js` | control-pane loopback server, host-header + Origin allowlist (DNS-rebinding guard) |
 | Editor chrome | `scripts/lib/plan-canvas/ui.js` | `scripts/lib/control-pane/ui.js`, tokens from `scripts/dashboard-web.js` |
 | Markdown plan renderer | `scripts/lib/plan-canvas/markdown.js` | zero new deps; renders the `commands/plan.md` artifact schema (tables, tasks, code fences, Mermaid blocks) |
-| Mermaid diagrams | `scripts/lib/plan-canvas/ui.js` | ` ```mermaid ` blocks render in the browser, themed to ECC; pinned CDN with offline fallback (`ECC_PLAN_CANVAS_MERMAID_URL` for a local mirror) |
+| Mermaid diagrams | `scripts/lib/plan-canvas/ui.js` | ` ```mermaid ` blocks render in the browser after page load, themed to ECC; pinned CDN with non-blocking fallback (`ECC_PLAN_CANVAS_MERMAID_URL` for a local mirror) |
 | Session state | `scripts/lib/plan-canvas/sessions.js` | file-path-keyed sessions, state under `~/.claude/plan-canvas/` (`ECC_PLAN_CANVAS_STATE_DIR` override) |
 | Skill | `skills/plan-canvas/SKILL.md` | skills-first surface; teaches the open → await → reply loop; defers visual guidance to `frontend-design-direction`, `artifact-design`, `dataviz` |
 | Command shim | `commands/plan-canvas.md` | legacy parity surface, points at the skill |
@@ -81,7 +81,7 @@ after 30 min, `ECC_PLAN_CANVAS_IDLE_MS`). Feedback is deliver-and-drain: queued 
 handed to exactly one `await` call and persisted to disk until then, so nothing is lost if
 the poll is interrupted.
 
-- `GET /health` — `{ok, app: "ecc-plan-canvas", version}` (CLI/server version handshake)
+- `GET /health` — `{ok, app, version, protocolVersion, runtimeId}`; the CLI reuses a detached server only when its package, protocol, and Canvas-module fingerprint match, preventing an older same-version worktree from serving stale browser code
 - `GET /` — session list (ECC chrome)
 - `POST /api/sessions` `{file, reopen?}` — open/resume; `409 user-ended` unless `reopen`
 - `GET /canvas/<key>` — editor chrome; `GET /artifact/<key>/` — rendered artifact
@@ -115,6 +115,7 @@ sibling-asset access confined to the artifact directory; state dir is user-local
 never executes artifact content — it only serves it to the browser.
 
 The one optional outbound request is the pinned Mermaid library, fetched by the browser only
-for artifacts that contain a diagram; it renders with `securityLevel: 'strict'`, degrades to
-showing diagram source if unavailable, and can be repointed at a local mirror via
+after an artifact containing a diagram has loaded; it renders with `securityLevel: 'strict'`,
+cannot hold the Canvas page in a loading state, degrades to showing diagram source if
+unavailable, and can be repointed at a local mirror via
 `ECC_PLAN_CANVAS_MERMAID_URL`. The server itself still makes no network calls.

--- a/docs/design/plan-canvas.md
+++ b/docs/design/plan-canvas.md
@@ -82,7 +82,7 @@ after 30 min, `ECC_PLAN_CANVAS_IDLE_MS`). Feedback is deliver-and-drain: queued 
 handed to exactly one `await` call and persisted to disk until then, so nothing is lost if
 the poll is interrupted.
 
-- `GET /health` — `{ok, app, version, protocolVersion, runtimeId}`; the CLI reuses a detached server only when its package, protocol, and Canvas-module fingerprint match, preventing an older same-version worktree from serving stale browser code. An OS-managed, port-scoped startup lock serializes compatibility checks and replacement so concurrent opens reuse the winning server instead of racing two detached launches. The lock is released automatically when its process exits.
+- `GET /health` — `{ok, app, version, protocolVersion, runtimeId}`; the CLI reuses a detached server only when its package, protocol, and Canvas-module fingerprint match, preventing an older same-version worktree from serving stale browser code. An OS-managed, port-scoped startup lock on a separate derived UDP endpoint serializes compatibility checks and replacement, so concurrent opens reuse the winning server without colliding with UDP traffic on the Canvas service port. The lock is released automatically when its process exits.
 - `GET /` — session list (ECC chrome)
 - `POST /api/sessions` `{file, reopen?}` — open/resume; `409 user-ended` unless `reopen`
 - `GET /canvas/<key>` — editor chrome; `GET /artifact/<key>/` — rendered artifact

--- a/docs/design/plan-canvas.md
+++ b/docs/design/plan-canvas.md
@@ -82,7 +82,7 @@ after 30 min, `ECC_PLAN_CANVAS_IDLE_MS`). Feedback is deliver-and-drain: queued 
 handed to exactly one `await` call and persisted to disk until then, so nothing is lost if
 the poll is interrupted.
 
-- `GET /health` — `{ok, app, version, protocolVersion, runtimeId}`; the CLI reuses a detached server only when its package, protocol, and Canvas-module fingerprint match, preventing an older same-version worktree from serving stale browser code. An OS-managed, port-scoped startup lock on a separate derived UDP endpoint serializes compatibility checks and replacement, so concurrent opens reuse the winning server without colliding with UDP traffic on the Canvas service port. The lock is released automatically when its process exits.
+- `GET /health` — `{ok, app, version, protocolVersion, runtimeId}`; the CLI reuses a detached server only when its package, protocol, and Canvas-module fingerprint match, preventing an older same-version worktree from serving stale browser code. A private per-user, port-scoped ticket lock serializes compatibility checks and replacement without consuming a network endpoint, so concurrent opens reuse the winning server. Unique owner tickets make stale-process recovery safe without deleting a later caller's lock.
 - `GET /` — session list (ECC chrome)
 - `POST /api/sessions` `{file, reopen?}` — open/resume; `409 user-ended` unless `reopen`
 - `GET /canvas/<key>` — editor chrome; `GET /artifact/<key>/` — rendered artifact

--- a/docs/testing/plan-canvas-loading-hang.tdd.md
+++ b/docs/testing/plan-canvas-loading-hang.tdd.md
@@ -1,0 +1,81 @@
+# Plan Canvas loading hang TDD evidence
+
+## Source
+
+No implementation plan was supplied. The journeys and guarantees below were
+derived from the reported intermittent localhost loading hang, especially when
+opening a second Plan Canvas in one agent chat.
+
+## User journeys
+
+1. As a reviewer opening plans from multiple ECC worktrees, I want every new
+   Canvas to use the current server code so an older same-version process cannot
+   disable or stall the page.
+2. As a reviewer opening a plan with Mermaid diagrams, I want the Canvas page to
+   finish loading even when the Mermaid CDN is slow or unavailable.
+
+## Task report
+
+### Replace a stale same-version detached server
+
+- RED: `node tests/integration/plan-canvas-e2e.test.js` produced 9 passes and
+  1 failure. The current CLI reused a fake legacy server that reported the same
+  package version and sent the session-open request to it.
+- RED checkpoint: `5dc6d85c test: add reproducer for stale plan canvas server`.
+- GREEN: the health handshake now carries a protocol version and a SHA-256
+  fingerprint of every module loaded into the detached Canvas server. The CLI
+  retires any process whose package, protocol, or runtime fingerprint differs.
+- GREEN: `node tests/integration/plan-canvas-e2e.test.js` produced 10 passes and
+  0 failures.
+- GREEN checkpoint: `7e0d115e fix: restart stale plan canvas servers`.
+
+### Keep Mermaid enhancement from blocking page load
+
+- RED: `node tests/scripts/plan-canvas.test.js` produced 27 passes and 1
+  failure. The generated artifact loaded Mermaid with top-level `await`, which
+  allowed an unresolved remote import to hold the document load event open.
+- RED checkpoint: `ca0d0415 test: reproduce mermaid page load stall`.
+- GREEN: the dynamic Mermaid import now starts from an async `load` listener.
+  Browsers do not await that listener, so diagrams remain progressive
+  enhancement and the raw Mermaid source remains available during a network
+  stall.
+- GREEN: `node tests/scripts/plan-canvas.test.js` produced 28 passes and 0
+  failures.
+- GREEN checkpoint: `7fc31254 fix: keep mermaid from blocking canvas load`.
+
+## Test specification
+
+| # | What is guaranteed | Test target | Type | Result |
+| --- | --- | --- | --- | --- |
+| 1 | A legacy server with the same package version is shut down before the current CLI opens a plan | `same-version legacy server is replaced before a canvas opens` | End to end | PASS |
+| 2 | Health exposes package, protocol, and exact Canvas runtime identity | `GET /health identifies the app and version` | Integration | PASS |
+| 3 | Mermaid remote enhancement starts only after document load | `a plan containing mermaid serves the themed Mermaid loader` | Integration | PASS |
+| 4 | Open, browser load, await, feedback, reply, approval, reopen, end, and stop still work together | `tests/integration/plan-canvas-e2e.test.js` | End to end | PASS |
+| 5 | The large ECC 2 to ECC 3 master plan bootstraps under blocked local storage | Headless Chrome DOM and screenshot check against `/canvas/24af75d4c4fe` | Browser | PASS |
+
+## Coverage and full-suite evidence
+
+`npm run coverage` passed all 3,993 discovered tests with these project totals:
+
+- Statements: 88.98%
+- Branches: 80.66%
+- Functions: 94.32%
+- Lines: 88.98%
+
+The `scripts/lib/plan-canvas` group reached 98.38% statements, 88.2% branches,
+98.64% functions, and 98.38% lines. Focused ESLint checks passed for every
+modified JavaScript test and production file.
+
+## Browser evidence and known gaps
+
+The live shared server was initially process `15351`, started from the older
+`ecc-tiered-sandbox` worktree, and served an unguarded `localStorage` client even
+when invoked from current main. The patched CLI replaced it with the isolated
+worktree server and restored persisted sessions. Two real plan sessions then
+opened successfully. Headless Chrome with local storage disabled completed the
+large master-plan DOM load in about two seconds and produced a rendered Canvas
+screenshot.
+
+Chrome was exercised directly on macOS. Safari and Firefox were not run. The
+fix relies only on standard health JSON, dynamic `import()`, and the standard
+window `load` event.

--- a/docs/testing/plan-canvas-loading-hang.tdd.md
+++ b/docs/testing/plan-canvas-loading-hang.tdd.md
@@ -13,6 +13,9 @@ opening a second Plan Canvas in one agent chat.
    disable or stall the page.
 2. As a reviewer opening a plan with Mermaid diagrams, I want the Canvas page to
    finish loading even when the Mermaid CDN is slow or unavailable.
+3. As a reviewer with several Canvas tabs still open, I want the next Canvas to
+   receive and render its document instead of waiting forever for a browser
+   connection slot.
 
 ## Task report
 
@@ -43,6 +46,36 @@ opening a second Plan Canvas in one agent chat.
   failures.
 - GREEN checkpoint: `7fc31254 fix: keep mermaid from blocking canvas load`.
 
+### Stop open canvases from exhausting the browser connection pool
+
+- RED: the normal Chrome profile showed an `Untitled` blank tab with its load
+  indicator running indefinitely. `lsof -nP -iTCP:4517` showed exactly six
+  established connections from Chrome's network service to Plan Canvas. Each
+  older Canvas tab owned one permanent `EventSource`, exhausting Chromium's
+  six-connection HTTP/1 pool before the next document request could receive a
+  byte.
+- RED: the focused integration test failed because `/client.js` still created
+  `EventSource`, `/api/session/:key/state` did not exist, `/events/:key` held
+  its response open, and health still advertised protocol 2.
+- GREEN: protocol 3 replaces per-tab EventSource streams with one-second,
+  finite state requests carrying chat, presence, session status, and artifact
+  revision. Polls are sequential and abort after five seconds, so they cannot
+  pile up. Legacy `/events/:key` now returns HTTP 204, the status that tells an
+  existing EventSource client not to reconnect after the server upgrade.
+- GREEN: `node tests/scripts/plan-canvas.test.js` produced 31 passes and 0
+  failures, including preservation of the active-browser idle lifecycle.
+  Focused ESLint and `git diff --check` passed.
+- BROWSER: nine Canvas tabs were opened in one Chrome automation profile on an
+  isolated protocol-3 server. Every tab reached `document.readyState =
+  complete`, exposed its expected plan heading through the iframe accessibility
+  tree, and reported zero EventSource resources. Two shared keep-alive sockets
+  served the nine tabs at the observation point.
+- DESKTOP: the normal Chrome profile kept the original blank protocol-2 tab
+  visible while three protocol-3 canvases on the isolated port rendered the
+  Sandbox Execution Fabric, Feature Fleet, and ECC 2 to ECC 3 plans. A captured
+  desktop-window image showed all three rendered tabs and live `agent listening`
+  presence.
+
 ## Test specification
 
 | # | What is guaranteed | Test target | Type | Result |
@@ -52,30 +85,44 @@ opening a second Plan Canvas in one agent chat.
 | 3 | Mermaid remote enhancement starts only after document load | `a plan containing mermaid serves the themed Mermaid loader` | Integration | PASS |
 | 4 | Open, browser load, await, feedback, reply, approval, reopen, end, and stop still work together | `tests/integration/plan-canvas-e2e.test.js` | End to end | PASS |
 | 5 | The large ECC 2 to ECC 3 master plan bootstraps under blocked local storage | Headless Chrome DOM and screenshot check against `/canvas/24af75d4c4fe` | Browser | PASS |
+| 6 | The browser client never reserves one permanent HTTP connection per open Canvas | `browser client uses finite polling instead of one permanent connection per canvas` | Integration | PASS |
+| 7 | Old EventSource clients stop reconnecting after upgrading the server | `legacy EventSource endpoint retires without reconnecting` | Integration | PASS |
+| 8 | Browser polling carries chat, presence, end state, and artifact revision | Browser-state integration cases in `tests/scripts/plan-canvas.test.js` | Integration | PASS |
+| 9 | More than Chromium's six HTTP/1 connection slots can coexist without blocking a new Canvas | Nine-tab Chrome DOM, accessibility-tree, resource-timing, and screenshot run | Browser | PASS |
+| 10 | An actively viewed Canvas keeps the shared server alive through finite polls | `finite browser polls keep an actively viewed canvas server alive` | Integration | PASS |
 
 ## Coverage and full-suite evidence
 
-`npm run coverage` passed all 3,993 discovered tests with these project totals:
+`npm run coverage` passed all 3,996 discovered tests with these project totals:
 
 - Statements: 88.98%
-- Branches: 80.66%
-- Functions: 94.32%
+- Branches: 80.65%
+- Functions: 94.34%
 - Lines: 88.98%
 
-The `scripts/lib/plan-canvas` group reached 98.38% statements, 88.2% branches,
-98.64% functions, and 98.38% lines. Focused ESLint checks passed for every
+The `scripts/lib/plan-canvas` group reached 98.53% statements, 87.82% branches,
+100% functions, and 98.53% lines. Focused ESLint checks passed for every
 modified JavaScript test and production file.
 
 ## Browser evidence and known gaps
 
 The live shared server was initially process `15351`, started from the older
 `ecc-tiered-sandbox` worktree, and served an unguarded `localStorage` client even
-when invoked from current main. The patched CLI replaced it with the isolated
-worktree server and restored persisted sessions. Two real plan sessions then
-opened successfully. Headless Chrome with local storage disabled completed the
-large master-plan DOM load in about two seconds and produced a rendered Canvas
-screenshot.
+when invoked from current main. The first patch replaced it with the isolated
+worktree server and restored persisted sessions. That did not establish the
+reported bug was fixed: HTTP 200 responses and a fresh-profile screenshot did
+not exercise the saturated normal browser profile.
 
-Chrome was exercised directly on macOS. Safari and Firefox were not run. The
-fix relies only on standard health JSON, dynamic `import()`, and the standard
-window `load` event.
+The corrected investigation captured the real blank tab, its six live browser
+connections, and the exact release-preview session behind it. The final browser
+run used an isolated protocol-3 server on port 4518 so other agents could not
+replace the executable under test. It rendered the actual in-progress Sandbox
+Execution Fabric from the tiered-sandbox worktree, plus Feature Fleet and the
+ECC 2 to ECC 3 master plan, in the normal desktop Chrome profile. Active agent
+listeners remained attached to all three.
+
+Chrome was exercised directly on macOS through both the user's normal profile
+and a browser-automation profile. Safari and Firefox were not run. The
+connection-pool fix relies on ordinary finite `fetch` requests, `AbortController`,
+HTTP 204 EventSource retirement behavior, and file metadata for live-reload
+revision checks.

--- a/docs/testing/plan-canvas-pdf-export.tdd.md
+++ b/docs/testing/plan-canvas-pdf-export.tdd.md
@@ -25,8 +25,8 @@ artifact as a real PDF file without sending the plan to an external converter.
 - RED: the focused server suite produced 30 passes and 2 failures because the
   Canvas had no Download PDF control or PDF endpoint.
 - GREEN: renderer unit tests pass 7/7, Plan Canvas server tests pass 34/34,
-  and the end-to-end review workflow passes 11/11.
-- FULL SUITE: the final review-hardened implementation passes all 4,007
+  and the end-to-end review workflow passes 12/12.
+- FULL SUITE: the final review-hardened implementation passes all 4,008
   discovered tests; hosted security reruns are recorded on PR #2894.
 - COVERAGE: `npm run coverage` passes 4,003/4,003 with 88.97% statements,
   80.58% branches, 94.22% functions, and 88.97% lines. The Plan Canvas

--- a/docs/testing/plan-canvas-pdf-export.tdd.md
+++ b/docs/testing/plan-canvas-pdf-export.tdd.md
@@ -24,9 +24,9 @@ artifact as a real PDF file without sending the plan to an external converter.
 
 - RED: the focused server suite produced 30 passes and 2 failures because the
   Canvas had no Download PDF control or PDF endpoint.
-- GREEN: renderer unit tests pass 7/7, Plan Canvas server tests pass 34/34,
-  and the end-to-end review workflow passes 12/12.
-- FULL SUITE: the final review-hardened implementation passes all 4,008
+- GREEN: renderer unit tests pass 7/7, Plan Canvas server tests pass 35/35,
+  and the end-to-end review workflow passes 13/13.
+- FULL SUITE: the final review-hardened implementation passes all 4,010
   discovered tests; hosted security reruns are recorded on PR #2894.
 - COVERAGE: `npm run coverage` passes 4,003/4,003 with 88.97% statements,
   80.58% branches, 94.22% functions, and 88.97% lines. The Plan Canvas

--- a/docs/testing/plan-canvas-pdf-export.tdd.md
+++ b/docs/testing/plan-canvas-pdf-export.tdd.md
@@ -14,17 +14,20 @@ artifact as a real PDF file without sending the plan to an external converter.
 | Only a loopback artifact URL can reach the renderer | `assertLoopbackUrl` tests | PASS |
 | Filenames are useful and safe across platforms | `pdfFileName` tests | PASS |
 | Incomplete output is never served as a PDF | `%PDF` header and `%%EOF` completion tests | PASS |
+| Validation uses the opened file handle | File-descriptor regression test and CodeQL rerun | PASS |
 | Renderer state is private and temporary | Fake-process lifecycle test and live process/temp-state inspection | PASS |
+| Artifact HTML cannot make outbound export requests | PDF-only CSP and loopback-origin deny-proxy regression tests | PASS |
+| Browser renderer concurrency is bounded | Concurrent endpoint test expects HTTP 429 and `Retry-After` | PASS |
 | Export adds no cloud converter or npm runtime dependency | Implementation and package diff inspection | PASS |
 
 ## Red and green
 
 - RED: the focused server suite produced 30 passes and 2 failures because the
   Canvas had no Download PDF control or PDF endpoint.
-- GREEN: renderer unit tests pass 6/6, Plan Canvas server tests pass 32/32,
-  and the end-to-end review workflow passes 10/10.
-- FULL SUITE: `npm test` passes all 4,003 discovered tests; full ESLint,
-  Markdown lint, package dry-run, and `git diff --check` also pass.
+- GREEN: renderer unit tests pass 7/7, Plan Canvas server tests pass 34/34,
+  and the end-to-end review workflow passes 11/11.
+- FULL SUITE: the final review-hardened implementation passes all 4,007
+  discovered tests; hosted security reruns are recorded on PR #2894.
 - COVERAGE: `npm run coverage` passes 4,003/4,003 with 88.97% statements,
   80.58% branches, 94.22% functions, and 88.97% lines. The Plan Canvas
   module group reaches 96.72% statements and lines, 84.47% branches, and
@@ -42,9 +45,12 @@ artifact as a real PDF file without sending the plan to an external converter.
 
 The loopback server discovers Google Chrome, Chromium, or Microsoft Edge, or
 uses `ECC_PLAN_CANVAS_CHROME_PATH`. It launches the executable without a shell,
-with a private temporary profile and a loopback-only artifact URL. Completion
-requires both a `%PDF-` header and `%%EOF` marker. The renderer is terminated and
-temporary state is removed before the response is handed to the browser.
+with a private temporary profile, a loopback-only artifact URL, an export-only
+CSP, and a local deny proxy that allows only the exact Canvas origin. Completion
+requires both a `%PDF-` header and `%%EOF` marker read from the already-open file
+handle. The renderer is terminated and temporary state is removed before the
+response is handed to the browser. Concurrent export attempts fail quickly with
+a retryable HTTP 429 response while one renderer is active.
 
 If no renderer exists, the browser receives an actionable local error. Plan
 Canvas does not upload the artifact or add a hosted conversion dependency.

--- a/docs/testing/plan-canvas-pdf-export.tdd.md
+++ b/docs/testing/plan-canvas-pdf-export.tdd.md
@@ -25,8 +25,8 @@ artifact as a real PDF file without sending the plan to an external converter.
 - RED: the focused server suite produced 30 passes and 2 failures because the
   Canvas had no Download PDF control or PDF endpoint.
 - GREEN: renderer unit tests pass 7/7, Plan Canvas server tests pass 35/35,
-  and the end-to-end review workflow passes 14/14.
-- FULL SUITE: the final review-hardened implementation passes all 4,011
+  and the end-to-end review workflow passes 13/13.
+- FULL SUITE: the final review-hardened implementation passes all 4,010
   discovered tests; hosted security reruns are recorded on PR #2894.
 - COVERAGE: `npm run coverage` passes 4,003/4,003 with 88.97% statements,
   80.58% branches, 94.22% functions, and 88.97% lines. The Plan Canvas

--- a/docs/testing/plan-canvas-pdf-export.tdd.md
+++ b/docs/testing/plan-canvas-pdf-export.tdd.md
@@ -25,8 +25,8 @@ artifact as a real PDF file without sending the plan to an external converter.
 - RED: the focused server suite produced 30 passes and 2 failures because the
   Canvas had no Download PDF control or PDF endpoint.
 - GREEN: renderer unit tests pass 7/7, Plan Canvas server tests pass 35/35,
-  and the end-to-end review workflow passes 13/13.
-- FULL SUITE: the final review-hardened implementation passes all 4,010
+  and the end-to-end review workflow passes 14/14.
+- FULL SUITE: the final review-hardened implementation passes all 4,011
   discovered tests; hosted security reruns are recorded on PR #2894.
 - COVERAGE: `npm run coverage` passes 4,003/4,003 with 88.97% statements,
   80.58% branches, 94.22% functions, and 88.97% lines. The Plan Canvas

--- a/docs/testing/plan-canvas-pdf-export.tdd.md
+++ b/docs/testing/plan-canvas-pdf-export.tdd.md
@@ -1,0 +1,50 @@
+# Plan Canvas PDF export TDD evidence
+
+## User journey
+
+As a Plan Canvas reviewer, I can select **Download PDF** and receive the current
+artifact as a real PDF file without sending the plan to an external converter.
+
+## Guarantees
+
+| Guarantee | Evidence | Result |
+| --- | --- | --- |
+| The Canvas exposes a labeled PDF download action | Server integration test and browser accessibility tree | PASS |
+| The browser fetches a PDF, creates a Blob URL, and starts a named download | Generated-client integration test and real Chrome interaction | PASS |
+| Only a loopback artifact URL can reach the renderer | `assertLoopbackUrl` tests | PASS |
+| Filenames are useful and safe across platforms | `pdfFileName` tests | PASS |
+| Incomplete output is never served as a PDF | `%PDF` header and `%%EOF` completion tests | PASS |
+| Renderer state is private and temporary | Fake-process lifecycle test and live process/temp-state inspection | PASS |
+| Export adds no cloud converter or npm runtime dependency | Implementation and package diff inspection | PASS |
+
+## Red and green
+
+- RED: the focused server suite produced 30 passes and 2 failures because the
+  Canvas had no Download PDF control or PDF endpoint.
+- GREEN: renderer unit tests pass 6/6, Plan Canvas server tests pass 32/32,
+  and the end-to-end review workflow passes 10/10.
+- FULL SUITE: `npm test` passes all 4,003 discovered tests; full ESLint,
+  Markdown lint, package dry-run, and `git diff --check` also pass.
+- COVERAGE: `npm run coverage` passes 4,003/4,003 with 88.97% statements,
+  80.58% branches, 94.22% functions, and 88.97% lines. The Plan Canvas
+  module group reaches 96.72% statements and lines, 84.47% branches, and
+  95.34% functions.
+- BROWSER: Chrome selected Download PDF on the real Sandbox Execution Fabric.
+  The request returned HTTP 200, `application/pdf`, and downloaded
+  `EXECUTION-FABRIC.pdf` to the browser's download directory.
+- DOCUMENT: the downloaded Sandbox PDF is a valid PDF 1.4 document with five
+  pages. The ECC 2 to ECC 3 master plan exports as a valid eight-page PDF.
+  The HTML release-preview artifact exports as a valid four-page PDF.
+  Rendered first-page previews retain headings, body text, tables/code styling,
+  and print-safe light colors.
+
+## Runtime contract
+
+The loopback server discovers Google Chrome, Chromium, or Microsoft Edge, or
+uses `ECC_PLAN_CANVAS_CHROME_PATH`. It launches the executable without a shell,
+with a private temporary profile and a loopback-only artifact URL. Completion
+requires both a `%PDF-` header and `%%EOF` marker. The renderer is terminated and
+temporary state is removed before the response is handed to the browser.
+
+If no renderer exists, the browser receives an actionable local error. Plan
+Canvas does not upload the artifact or add a hosted conversion dependency.

--- a/scripts/lib/plan-canvas/pdf.js
+++ b/scripts/lib/plan-canvas/pdf.js
@@ -115,9 +115,9 @@ function assertLoopbackUrl(value) {
 function isCompletePdf(file, fsImpl = fs) {
   let fd;
   try {
-    const stat = fsImpl.statSync(file);
-    if (!stat.isFile() || stat.size < 12) return false;
     fd = fsImpl.openSync(file, 'r');
+    const stat = fsImpl.fstatSync(fd);
+    if (!stat.isFile() || stat.size < 12) return false;
     const head = Buffer.alloc(5);
     fsImpl.readSync(fd, head, 0, head.length, 0);
     const tailLength = Math.min(2048, stat.size);

--- a/scripts/lib/plan-canvas/pdf.js
+++ b/scripts/lib/plan-canvas/pdf.js
@@ -1,0 +1,261 @@
+'use strict';
+
+/**
+ * Local PDF export for Plan Canvas.
+ *
+ * Chromium's print-to-PDF implementation renders the same loopback artifact
+ * the reviewer sees, so Markdown, HTML, images, tables, and Mermaid diagrams
+ * keep their browser layout. No artifact content is sent to a converter or
+ * added as an npm runtime dependency.
+ */
+
+const { spawn } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const DEFAULT_EXPORT_TIMEOUT_MS = 45 * 1000;
+const PDF_POLL_MS = 100;
+
+function errorWithCode(message, code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
+function isExecutable(file, { platform = process.platform, fsImpl = fs } = {}) {
+  if (!file) return false;
+  try {
+    fsImpl.accessSync(file, platform === 'win32' ? fs.constants.F_OK : fs.constants.X_OK);
+    return fsImpl.statSync(file).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function pathExecutableNames(platform) {
+  if (platform === 'win32') {
+    return ['chrome.exe', 'msedge.exe', 'chromium.exe'];
+  }
+  return ['google-chrome-stable', 'google-chrome', 'chromium', 'chromium-browser', 'microsoft-edge-stable', 'microsoft-edge'];
+}
+
+function executableCandidates({ env, platform }) {
+  const candidates = [];
+  if (platform === 'darwin') {
+    candidates.push(
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      '/Applications/Chromium.app/Contents/MacOS/Chromium',
+      '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'
+    );
+    if (env.HOME) {
+      candidates.push(
+        path.join(env.HOME, 'Applications/Google Chrome.app/Contents/MacOS/Google Chrome'),
+        path.join(env.HOME, 'Applications/Chromium.app/Contents/MacOS/Chromium'),
+        path.join(env.HOME, 'Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge')
+      );
+    }
+  }
+  if (platform === 'win32') {
+    for (const root of [env.PROGRAMFILES, env['PROGRAMFILES(X86)'], env.LOCALAPPDATA].filter(Boolean)) {
+      candidates.push(
+        path.join(root, 'Google/Chrome/Application/chrome.exe'),
+        path.join(root, 'Microsoft/Edge/Application/msedge.exe'),
+        path.join(root, 'Chromium/Application/chrome.exe')
+      );
+    }
+  }
+
+  const pathEntries = String(env.PATH || '')
+    .split(path.delimiter)
+    .map(entry => entry.replace(/^"|"$/g, ''))
+    .filter(Boolean);
+  for (const directory of pathEntries) {
+    for (const name of pathExecutableNames(platform)) candidates.push(path.join(directory, name));
+  }
+  return candidates;
+}
+
+function resolveChromiumExecutable({
+  env = process.env,
+  platform = process.platform,
+  fsImpl = fs
+} = {}) {
+  const override = String(env.ECC_PLAN_CANVAS_CHROME_PATH || '').trim();
+  if (override) return isExecutable(override, { platform, fsImpl }) ? override : null;
+  return executableCandidates({ env, platform }).find(candidate => isExecutable(candidate, { platform, fsImpl })) || null;
+}
+
+function pdfFileName(artifactFile) {
+  const original = path.basename(String(artifactFile || 'plan'));
+  const stem = original
+    .replace(/\.(?:plan\.)?(?:md|markdown|html?|htm)$/i, '')
+    .split('')
+    .map(character => character.charCodeAt(0) < 32 ? '-' : character)
+    .join('')
+    .replace(/[<>:"/\\|?*]/g, '-')
+    .replace(/[.\s]+$/g, '')
+    .trim() || 'plan';
+  return `${stem}.pdf`;
+}
+
+function assertLoopbackUrl(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw errorWithCode('PDF export URL is invalid', 'PDF_EXPORT_INVALID_URL');
+  }
+  if (url.protocol !== 'http:' || !['127.0.0.1', 'localhost', '[::1]'].includes(url.hostname)) {
+    throw errorWithCode('PDF export is restricted to the Plan Canvas loopback server', 'PDF_EXPORT_INVALID_URL');
+  }
+  return url.toString();
+}
+
+function isCompletePdf(file, fsImpl = fs) {
+  let fd;
+  try {
+    const stat = fsImpl.statSync(file);
+    if (!stat.isFile() || stat.size < 12) return false;
+    fd = fsImpl.openSync(file, 'r');
+    const head = Buffer.alloc(5);
+    fsImpl.readSync(fd, head, 0, head.length, 0);
+    const tailLength = Math.min(2048, stat.size);
+    const tail = Buffer.alloc(tailLength);
+    fsImpl.readSync(fd, tail, 0, tailLength, stat.size - tailLength);
+    return head.toString('ascii') === '%PDF-' && tail.toString('latin1').includes('%%EOF');
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try { fsImpl.closeSync(fd); } catch { /* best-effort probe */ }
+    }
+  }
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function stopChild(child) {
+  if (!child || child.exitCode !== null || child.signalCode) return;
+  const closed = new Promise(resolve => child.once('close', resolve));
+  try { child.kill('SIGTERM'); } catch { return; }
+  await Promise.race([closed, delay(1000)]);
+  if (child.exitCode === null && !child.signalCode) {
+    try { child.kill('SIGKILL'); } catch { /* already gone */ }
+    await Promise.race([closed, delay(500)]);
+  }
+}
+
+function waitForPdf(child, outputFile, { timeoutMs, fsImpl }) {
+  return new Promise((resolve, reject) => {
+    let stderr = '';
+    let settled = false;
+    const finish = error => {
+      if (settled) return;
+      settled = true;
+      clearInterval(poll);
+      clearTimeout(timeout);
+      child.removeListener('error', onError);
+      child.removeListener('close', onClose);
+      if (error) reject(error);
+      else resolve();
+    };
+    const failure = message => {
+      const detail = stderr.trim().slice(-1200);
+      return errorWithCode(`${message}${detail ? `: ${detail}` : ''}`, 'PDF_EXPORT_FAILED');
+    };
+    const onError = error => finish(failure(`Could not start the PDF renderer (${error.message})`));
+    const onClose = code => {
+      if (isCompletePdf(outputFile, fsImpl)) finish();
+      else finish(failure(`PDF renderer exited with status ${code}`));
+    };
+    if (child.stderr) {
+      child.stderr.on('data', chunk => {
+        stderr += chunk.toString();
+        if (stderr.length > 8000) stderr = stderr.slice(-4000);
+      });
+    }
+    child.once('error', onError);
+    child.once('close', onClose);
+    const poll = setInterval(() => {
+      if (isCompletePdf(outputFile, fsImpl)) finish();
+    }, PDF_POLL_MS);
+    const timeout = setTimeout(() => finish(failure(`PDF export timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+}
+
+async function exportPdf({
+  url,
+  artifactFile,
+  env = process.env,
+  platform = process.platform,
+  executable = null,
+  timeoutMs = DEFAULT_EXPORT_TIMEOUT_MS,
+  spawnImpl = spawn,
+  fsImpl = fs,
+  osImpl = os
+} = {}) {
+  const safeUrl = assertLoopbackUrl(url);
+  const browser = executable || resolveChromiumExecutable({ env, platform, fsImpl });
+  if (!browser) {
+    const override = String(env.ECC_PLAN_CANVAS_CHROME_PATH || '').trim();
+    throw errorWithCode(
+      override
+        ? `PDF renderer not found at ECC_PLAN_CANVAS_CHROME_PATH=${override}`
+        : 'PDF export requires Google Chrome, Chromium, or Microsoft Edge; set ECC_PLAN_CANVAS_CHROME_PATH to its executable',
+      'PDF_BROWSER_NOT_FOUND'
+    );
+  }
+
+  const tempDir = fsImpl.mkdtempSync(path.join(osImpl.tmpdir(), 'ecc-plan-canvas-pdf-'));
+  const outputFile = path.join(tempDir, 'artifact.pdf');
+  const profileDir = path.join(tempDir, 'profile');
+  fsImpl.mkdirSync(profileDir, { recursive: true });
+  let child = null;
+  try {
+    const args = [
+      '--headless=new',
+      '--disable-gpu',
+      '--disable-component-update',
+      '--disable-default-apps',
+      '--disable-extensions',
+      '--disable-sync',
+      '--metrics-recording-only',
+      '--mute-audio',
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--no-pdf-header-footer',
+      '--print-to-pdf-no-header',
+      '--hide-scrollbars',
+      `--user-data-dir=${profileDir}`,
+      `--print-to-pdf=${outputFile}`,
+      '--virtual-time-budget=5000',
+      safeUrl
+    ];
+    child = spawnImpl(browser, args, {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      shell: false,
+      env: { ...env, LANG: 'en_US.UTF-8' }
+    });
+    await waitForPdf(child, outputFile, { timeoutMs, fsImpl });
+    const buffer = fsImpl.readFileSync(outputFile);
+    if (!isCompletePdf(outputFile, fsImpl)) {
+      throw errorWithCode('PDF renderer produced an incomplete document', 'PDF_EXPORT_FAILED');
+    }
+    return { buffer, filename: pdfFileName(artifactFile) };
+  } finally {
+    await stopChild(child);
+    fsImpl.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+module.exports = {
+  DEFAULT_EXPORT_TIMEOUT_MS,
+  assertLoopbackUrl,
+  exportPdf,
+  isCompletePdf,
+  pdfFileName,
+  resolveChromiumExecutable
+};

--- a/scripts/lib/plan-canvas/pdf.js
+++ b/scripts/lib/plan-canvas/pdf.js
@@ -11,6 +11,7 @@
 
 const { spawn } = require('child_process');
 const fs = require('fs');
+const net = require('net');
 const os = require('os');
 const path = require('path');
 
@@ -137,6 +138,33 @@ function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function startDenyProxy(netImpl = net) {
+  return new Promise((resolve, reject) => {
+    const server = netImpl.createServer(socket => {
+      socket.on('error', () => {});
+      socket.destroy();
+    });
+    const onError = error => reject(errorWithCode(
+      `Could not isolate PDF renderer network access (${error.message})`,
+      'PDF_EXPORT_FAILED'
+    ));
+    server.once('error', onError);
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', onError);
+      server.on('error', () => {});
+      server.unref();
+      resolve({ server, url: `http://127.0.0.1:${server.address().port}` });
+    });
+  });
+}
+
+function stopDenyProxy(server) {
+  if (!server) return Promise.resolve();
+  return new Promise(resolve => {
+    try { server.close(resolve); } catch { resolve(); }
+  });
+}
+
 async function stopChild(child) {
   if (!child || child.exitCode !== null || child.signalCode) return;
   const closed = new Promise(resolve => child.once('close', resolve));
@@ -195,9 +223,11 @@ async function exportPdf({
   timeoutMs = DEFAULT_EXPORT_TIMEOUT_MS,
   spawnImpl = spawn,
   fsImpl = fs,
-  osImpl = os
+  osImpl = os,
+  netImpl = net
 } = {}) {
   const safeUrl = assertLoopbackUrl(url);
+  const exportUrl = new URL(safeUrl);
   const browser = executable || resolveChromiumExecutable({ env, platform, fsImpl });
   if (!browser) {
     const override = String(env.ECC_PLAN_CANVAS_CHROME_PATH || '').trim();
@@ -214,14 +244,18 @@ async function exportPdf({
   const profileDir = path.join(tempDir, 'profile');
   fsImpl.mkdirSync(profileDir, { recursive: true });
   let child = null;
+  let denyProxy = null;
   try {
+    denyProxy = await startDenyProxy(netImpl);
     const args = [
       '--headless=new',
+      '--disable-background-networking',
       '--disable-gpu',
       '--disable-component-update',
       '--disable-default-apps',
       '--disable-extensions',
       '--disable-sync',
+      '--disable-quic',
       '--metrics-recording-only',
       '--mute-audio',
       '--no-first-run',
@@ -229,6 +263,9 @@ async function exportPdf({
       '--no-pdf-header-footer',
       '--print-to-pdf-no-header',
       '--hide-scrollbars',
+      `--proxy-server=${denyProxy.url}`,
+      `--proxy-bypass-list=<-loopback>;${exportUrl.origin}`,
+      `--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE ${exportUrl.hostname}`,
       `--user-data-dir=${profileDir}`,
       `--print-to-pdf=${outputFile}`,
       '--virtual-time-budget=5000',
@@ -247,6 +284,7 @@ async function exportPdf({
     return { buffer, filename: pdfFileName(artifactFile) };
   } finally {
     await stopChild(child);
+    await stopDenyProxy(denyProxy && denyProxy.server);
     fsImpl.rmSync(tempDir, { recursive: true, force: true });
   }
 }

--- a/scripts/lib/plan-canvas/sdk.js
+++ b/scripts/lib/plan-canvas/sdk.js
@@ -205,6 +205,19 @@ function artifactSdkJs() {
   });
 
   // --- chrome bridge ---------------------------------------------------------
+  function exportSnapshot() {
+    const clone = document.documentElement.cloneNode(true);
+    clone.querySelectorAll('script,iframe,object,embed,form,base,meta[http-equiv],[data-ecc-plan-canvas]').forEach(el => el.remove());
+    clone.querySelectorAll('*').forEach(el => {
+      for (const attr of [...el.attributes]) {
+        if (attr.name.toLowerCase().startsWith('on') || attr.name.toLowerCase() === 'srcdoc') {
+          el.removeAttribute(attr.name);
+        }
+      }
+    });
+    return '<!doctype html>\\n' + clone.outerHTML;
+  }
+
   window.addEventListener('message', e => {
     const msg = e.data || {};
     if (msg.type === 'pc:set-mode') {
@@ -212,6 +225,8 @@ function artifactSdkJs() {
       if (!annotate) { hl.style.display = 'none'; selhint.style.display = 'none'; closeCard(); }
     } else if (msg.type === 'pc:restore-scroll') {
       window.scrollTo(msg.x || 0, msg.y || 0);
+    } else if (msg.type === 'pc:export-snapshot' && typeof msg.requestId === 'string') {
+      post({ type: 'pc:export-snapshot-result', requestId: msg.requestId, html: exportSnapshot() });
     }
   });
   document.addEventListener('keydown', e => {

--- a/scripts/lib/plan-canvas/server.js
+++ b/scripts/lib/plan-canvas/server.js
@@ -411,6 +411,16 @@ function createPlanCanvasServer({
     if (pdfMatch && (req.method === 'GET' || req.method === 'POST')) {
       const session = store.get(pdfMatch[1]);
       if (!session) return sendJson(res, 404, { error: 'unknown session' });
+      const sendBusy = () => {
+        res.setHeader('retry-after', '1');
+        if (req.method === 'POST') res.setHeader('connection', 'close');
+        return sendJson(res, 429, {
+          error: 'another PDF export is already in progress',
+          code: 'PDF_EXPORT_BUSY'
+        });
+      };
+      // Reject overload before accepting a potentially slow snapshot body.
+      if (pdfExportActive) return sendBusy();
       let requestedSnapshot = null;
       if (req.method === 'POST') {
         const body = await readJsonBody(req, MAX_PDF_SNAPSHOT_BYTES);
@@ -419,13 +429,8 @@ function createPlanCanvasServer({
         }
         requestedSnapshot = { key: session.key, html: body.html };
       }
-      if (pdfExportActive) {
-        res.setHeader('retry-after', '1');
-        return sendJson(res, 429, {
-          error: 'another PDF export is already in progress',
-          code: 'PDF_EXPORT_BUSY'
-        });
-      }
+      // A renderer may have started while this request body was arriving.
+      if (pdfExportActive) return sendBusy();
       pdfExportActive = true;
       try {
         pdfSnapshot = requestedSnapshot;

--- a/scripts/lib/plan-canvas/server.js
+++ b/scripts/lib/plan-canvas/server.js
@@ -4,7 +4,7 @@
  * Plan Canvas loopback server.
  *
  * One detached process serves every open review session: the browser chrome,
- * the rendered artifact, an SSE stream for live updates, and the long-poll
+ * the rendered artifact, finite browser state polling, and the long-poll
  * endpoint agents block on. Sessions are keyed by canonical artifact path
  * (see sessions.js).
  */
@@ -35,9 +35,7 @@ const MAX_BODY_BYTES = 1024 * 1024;
 const DEFAULT_THINKING_STALE_MS = 90 * 1000;
 // An explicit typing signal expires faster: it means "a reply is seconds away".
 const DEFAULT_TYPING_EXPIRY_MS = 30 * 1000;
-// Presence is push-based, so expiring states need a tick to re-broadcast on.
-const DEFAULT_PRESENCE_SWEEP_MS = 5 * 1000;
-const PLAN_CANVAS_PROTOCOL_VERSION = 2;
+const PLAN_CANVAS_PROTOCOL_VERSION = 3;
 const TYPING_STATES = new Set(['thinking', 'typing', 'idle']);
 
 // Package versions do not distinguish two worktrees on the same release.
@@ -145,7 +143,6 @@ function createPlanCanvasServer({
   heartbeatMs = 15000,
   thinkingStaleMs = DEFAULT_THINKING_STALE_MS,
   typingExpiryMs = DEFAULT_TYPING_EXPIRY_MS,
-  presenceSweepMs = DEFAULT_PRESENCE_SWEEP_MS,
   onIdleShutdown = null,
   log = () => {}
 } = {}) {
@@ -154,17 +151,13 @@ function createPlanCanvasServer({
   const allowedHostnames = buildAllowedHostnames(host);
   const wake = new EventEmitter();
   wake.setMaxListeners(0);
-  const sseClients = new Map(); // key -> Set<res>
   const awaitCounts = new Map(); // key -> active long-poll count
   const workingKeys = new Map(); // key -> ms timestamp the agent took feedback
   const typingKeys = new Map(); // key -> ms timestamp the agent signalled composing
-  const watchers = new Map(); // key -> fs.FSWatcher
-  const lastPresence = new Map(); // key -> last broadcast state, for sweep diffing
   let idleTimer = null;
-  let presenceSweep = null;
   let closed = false;
 
-  // --- presence + SSE ---------------------------------------------------
+  // --- presence ---------------------------------------------------------
 
   /**
    * Presence never claims more than the server actually knows:
@@ -192,34 +185,6 @@ function createPlanCanvasServer({
     return session.pendingFeedback && session.pendingFeedback.length > 0 ? 'queued' : 'waiting';
   }
 
-  function broadcast(key, event, payload) {
-    const clients = sseClients.get(key);
-    if (!clients) return;
-    const frameText = `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`;
-    for (const client of clients) client.write(frameText);
-  }
-
-  function broadcastPresence(key) {
-    const state = presenceFor(key);
-    lastPresence.set(key, state);
-    broadcast(key, 'presence', { state });
-  }
-
-  // Re-broadcast only where an expiry actually changed the answer, so an
-  // untouched canvas sees the thinking bubble clear itself.
-  function sweepPresence() {
-    for (const key of sseClients.keys()) {
-      const state = presenceFor(key);
-      if (lastPresence.get(key) !== state) broadcastPresence(key);
-    }
-  }
-
-  function startPresenceSweep() {
-    if (presenceSweep || !presenceSweepMs) return;
-    presenceSweep = setInterval(sweepPresence, presenceSweepMs);
-    if (presenceSweep.unref) presenceSweep.unref();
-  }
-
   // The agent is off working on this feedback batch; start the thinking clock.
   function markThinking(key) {
     workingKeys.set(key, Date.now());
@@ -234,7 +199,6 @@ function createPlanCanvasServer({
 
   function connectionCount() {
     let total = 0;
-    for (const clients of sseClients.values()) total += clients.size;
     for (const count of awaitCounts.values()) total += count;
     return total;
   }
@@ -260,31 +224,12 @@ function createPlanCanvasServer({
     armIdleTimer();
   }
 
-  // --- artifact watching --------------------------------------------------
-
-  function watchSession(session) {
-    if (watchers.has(session.key)) return;
-    const dir = path.dirname(session.file);
-    const base = path.basename(session.file);
-    let debounce = null;
+  function artifactVersionFor(session) {
     try {
-      const watcher = fs.watch(dir, (eventType, filename) => {
-        if (filename && filename !== base) return;
-        clearTimeout(debounce);
-        debounce = setTimeout(() => broadcast(session.key, 'reload', {}), 150);
-      });
-      watcher.on('error', () => watchers.delete(session.key));
-      watchers.set(session.key, watcher);
+      const stat = fs.statSync(session.file, { bigint: true });
+      return `${stat.mtimeNs}:${stat.size}`;
     } catch {
-      // Watching is best-effort; manual reload still works.
-    }
-  }
-
-  function unwatchSession(key) {
-    const watcher = watchers.get(key);
-    if (watcher) {
-      watcher.close();
-      watchers.delete(key);
+      return null;
     }
   }
 
@@ -295,9 +240,6 @@ function createPlanCanvasServer({
     if (!session) return null;
     clearAgentActivity(key);
     wake.emit(`wake:${key}`);
-    broadcast(key, 'ended', { endedBy: session.endedBy });
-    broadcastPresence(key);
-    unwatchSession(key);
     return session;
   }
 
@@ -322,8 +264,6 @@ function createPlanCanvasServer({
           next_step: 'The user ended this review from the browser. Do not reopen it unless they ask; pass reopen:true when they do.'
         });
       }
-      watchSession(session);
-      broadcastPresence(session.key);
       return sendJson(res, 200, {
         status: 'open',
         key: session.key,
@@ -350,7 +290,6 @@ function createPlanCanvasServer({
       const first = store.takeFeedback(key);
       if (first.status !== 'waiting') {
         if (first.status === 'feedback') markThinking(key);
-        broadcastPresence(key);
         return sendJson(res, 200, first);
       }
 
@@ -358,7 +297,6 @@ function createPlanCanvasServer({
       noteConnectionOpened();
       awaitCounts.set(key, (awaitCounts.get(key) || 0) + 1);
       clearAgentActivity(key);
-      broadcastPresence(key);
 
       let settled = false;
       let heartbeat = null;
@@ -371,7 +309,6 @@ function createPlanCanvasServer({
           if (payload.status === 'feedback') markThinking(key);
           res.end(JSON.stringify(payload));
         }
-        broadcastPresence(key);
         noteConnectionClosed();
       };
       const onWake = () => {
@@ -417,6 +354,23 @@ function createPlanCanvasServer({
       return sendJson(res, 200, { status: 'ended', endedBy: 'agent' });
     }
 
+    const stateMatch = pathname.match(/^\/api\/session\/([a-f0-9]{12})\/state$/);
+    if (stateMatch && req.method === 'GET') {
+      const session = store.get(stateMatch[1]);
+      if (!session) return sendJson(res, 404, { error: 'unknown session' });
+      // A visible Canvas used to keep the shared server alive through its SSE
+      // connection. Preserve that lifecycle with finite polling by restarting
+      // the idle clock whenever an active browser reports in.
+      armIdleTimer();
+      return sendJson(res, 200, {
+        status: session.status,
+        endedBy: session.endedBy || null,
+        chat: session.chat,
+        presence: presenceFor(session.key),
+        artifactVersion: artifactVersionFor(session)
+      });
+    }
+
     const sessionMatch = pathname.match(/^\/api\/session\/([a-f0-9]{12})\/(feedback|end|reply|typing)$/);
     if (sessionMatch && req.method === 'POST') {
       const [, key, action] = sessionMatch;
@@ -428,13 +382,10 @@ function createPlanCanvasServer({
         const result = store.queueFeedback(key, body.items, { endSession: Boolean(body.endSession) });
         if (!result) return sendJson(res, 409, { error: 'session already ended' });
         wake.emit(`wake:${key}`);
-        broadcast(key, 'chat-sync', { chat: store.get(key).chat });
-        if (body.endSession) broadcast(key, 'ended', { endedBy: 'user' });
         // A parked `await` takes the batch synchronously on the wake above, so
         // presence is already `thinking` by now; with nobody listening it
-        // reports `queued`. Either way the browser must be told, which the
-        // original handler never did, leaving a stale pill on screen.
-        broadcastPresence(key);
+        // reports `queued`. The browser sees the current answer on its next
+        // finite state poll.
         return sendJson(res, 200, {
           status: 'queued',
           accepted: result.accepted.length,
@@ -455,8 +406,6 @@ function createPlanCanvasServer({
         }
         const entry = store.addAgentReply(key, body.text);
         clearAgentActivity(key);
-        broadcast(key, 'chat-sync', { chat: store.get(key).chat });
-        broadcastPresence(key);
         return sendJson(res, 200, { status: 'sent', at: entry.at });
       }
 
@@ -471,7 +420,6 @@ function createPlanCanvasServer({
         if (state === 'idle') clearAgentActivity(key);
         else if (state === 'typing') typingKeys.set(key, Date.now());
         else markThinking(key);
-        broadcastPresence(key);
         return sendJson(res, 200, { status: 'ok', presence: presenceFor(key) });
       }
     }
@@ -482,32 +430,13 @@ function createPlanCanvasServer({
   function handleEvents(req, res, key) {
     const session = store.get(key);
     if (!session) return sendJson(res, 404, { error: 'unknown session' });
-    noteConnectionOpened();
-    res.writeHead(200, {
-      'content-type': 'text/event-stream',
-      'cache-control': 'no-store',
-      connection: 'keep-alive'
-    });
-    res.write(`event: chat-sync\ndata: ${JSON.stringify({ chat: session.chat })}\n\n`);
-    res.write(`event: presence\ndata: ${JSON.stringify({ state: presenceFor(key) })}\n\n`);
-    if (!sseClients.has(key)) sseClients.set(key, new Set());
-    sseClients.get(key).add(res);
-    lastPresence.set(key, presenceFor(key));
-    startPresenceSweep();
-    const ping = setInterval(() => res.write(': ping\n\n'), 25000);
-    if (ping.unref) ping.unref();
-    req.on('close', () => {
-      clearInterval(ping);
-      const clients = sseClients.get(key);
-      if (clients) {
-        clients.delete(res);
-        if (clients.size === 0) {
-          sseClients.delete(key);
-          lastPresence.delete(key);
-        }
-      }
-      noteConnectionClosed();
-    });
+    // Older Canvas clients opened one permanent EventSource per tab. Six open
+    // tabs exhausted Chromium's HTTP/1 connection pool for this origin, so
+    // the next top-level navigation waited forever without receiving a byte.
+    // HTTP 204 tells EventSource not to reconnect, releasing legacy tabs after
+    // a server upgrade. Current clients use finite state polling below.
+    res.writeHead(204, { 'cache-control': 'no-store', connection: 'close' });
+    res.end();
   }
 
   function serveArtifact(res, key, assetPath) {
@@ -626,14 +555,6 @@ function createPlanCanvasServer({
   function close() {
     closed = true;
     clearTimeout(idleTimer);
-    clearInterval(presenceSweep);
-    presenceSweep = null;
-    lastPresence.clear();
-    for (const key of watchers.keys()) unwatchSession(key);
-    for (const clients of sseClients.values()) {
-      for (const client of clients) client.end();
-    }
-    sseClients.clear();
     wake.emit('server-close');
     return new Promise((resolve, reject) => {
       server.close(error => (error ? reject(error) : resolve()));
@@ -652,7 +573,7 @@ function createPlanCanvasServer({
     });
   }
 
-  return { server, listen, close, presenceFor, sweepPresence, watchSession };
+  return { server, listen, close, presenceFor };
 }
 
 module.exports = {

--- a/scripts/lib/plan-canvas/server.js
+++ b/scripts/lib/plan-canvas/server.js
@@ -411,6 +411,14 @@ function createPlanCanvasServer({
     if (pdfMatch && (req.method === 'GET' || req.method === 'POST')) {
       const session = store.get(pdfMatch[1]);
       if (!session) return sendJson(res, 404, { error: 'unknown session' });
+      let requestedSnapshot = null;
+      if (req.method === 'POST') {
+        const body = await readJsonBody(req, MAX_PDF_SNAPSHOT_BYTES);
+        if (typeof body.html !== 'string' || !body.html.trim()) {
+          return sendJson(res, 400, { error: 'html snapshot is required' });
+        }
+        requestedSnapshot = { key: session.key, html: body.html };
+      }
       if (pdfExportActive) {
         res.setHeader('retry-after', '1');
         return sendJson(res, 429, {
@@ -420,13 +428,7 @@ function createPlanCanvasServer({
       }
       pdfExportActive = true;
       try {
-        if (req.method === 'POST') {
-          const body = await readJsonBody(req, MAX_PDF_SNAPSHOT_BYTES);
-          if (typeof body.html !== 'string' || !body.html.trim()) {
-            return sendJson(res, 400, { error: 'html snapshot is required' });
-          }
-          pdfSnapshot = { key: session.key, html: body.html };
-        }
+        pdfSnapshot = requestedSnapshot;
         const pdf = await pdfExporter({
           url: `http://${req.headers.host}/artifact/${session.key}/?pdf=1`,
           artifactFile: session.file

--- a/scripts/lib/plan-canvas/server.js
+++ b/scripts/lib/plan-canvas/server.js
@@ -17,6 +17,7 @@ const path = require('path');
 
 const { buildAllowedHostnames, isAllowedHostHeader, isAllowedOrigin } = require('../loopback-guard');
 const { renderMarkdown } = require('./markdown');
+const { exportPdf } = require('./pdf');
 const { artifactSdkJs } = require('./sdk');
 const {
   canvasCss,
@@ -35,7 +36,7 @@ const MAX_BODY_BYTES = 1024 * 1024;
 const DEFAULT_THINKING_STALE_MS = 90 * 1000;
 // An explicit typing signal expires faster: it means "a reply is seconds away".
 const DEFAULT_TYPING_EXPIRY_MS = 30 * 1000;
-const PLAN_CANVAS_PROTOCOL_VERSION = 3;
+const PLAN_CANVAS_PROTOCOL_VERSION = 4;
 const TYPING_STATES = new Set(['thinking', 'typing', 'idle']);
 
 // Package versions do not distinguish two worktrees on the same release.
@@ -45,6 +46,7 @@ function computeRuntimeId() {
   const sources = [
     ['loopback-guard.js', path.join(__dirname, '..', 'loopback-guard.js')],
     ['markdown.js', path.join(__dirname, 'markdown.js')],
+    ['pdf.js', path.join(__dirname, 'pdf.js')],
     ['sdk.js', path.join(__dirname, 'sdk.js')],
     ['server.js', __filename],
     ['sessions.js', path.join(__dirname, 'sessions.js')],
@@ -135,6 +137,22 @@ function sendHtml(res, statusCode, html, { csp = true } = {}) {
   res.end(html);
 }
 
+function sendPdf(res, { buffer, filename }) {
+  const asciiName = filename.replace(/[^\x20-\x7e]/g, '_').replace(/["\\]/g, '-');
+  const encodedName = encodeURIComponent(filename).replace(/['()]/g, character =>
+    `%${character.charCodeAt(0).toString(16).toUpperCase()}`
+  );
+  res.writeHead(200, {
+    'content-type': 'application/pdf',
+    'content-length': buffer.length,
+    'content-disposition': `attachment; filename="${asciiName}"; filename*=UTF-8''${encodedName}`,
+    'x-content-type-options': 'nosniff',
+    'x-plan-canvas-filename': encodeURIComponent(filename),
+    'cache-control': 'no-store'
+  });
+  res.end(buffer);
+}
+
 function createPlanCanvasServer({
   store,
   host = DEFAULT_HOST,
@@ -143,6 +161,7 @@ function createPlanCanvasServer({
   heartbeatMs = 15000,
   thinkingStaleMs = DEFAULT_THINKING_STALE_MS,
   typingExpiryMs = DEFAULT_TYPING_EXPIRY_MS,
+  pdfExporter = exportPdf,
   onIdleShutdown = null,
   log = () => {}
 } = {}) {
@@ -369,6 +388,22 @@ function createPlanCanvasServer({
         presence: presenceFor(session.key),
         artifactVersion: artifactVersionFor(session)
       });
+    }
+
+    const pdfMatch = pathname.match(/^\/api\/session\/([a-f0-9]{12})\/pdf$/);
+    if (pdfMatch && req.method === 'GET') {
+      const session = store.get(pdfMatch[1]);
+      if (!session) return sendJson(res, 404, { error: 'unknown session' });
+      try {
+        const pdf = await pdfExporter({
+          url: `http://${req.headers.host}/artifact/${session.key}/?pdf=1`,
+          artifactFile: session.file
+        });
+        return sendPdf(res, pdf);
+      } catch (error) {
+        const statusCode = error.code === 'PDF_BROWSER_NOT_FOUND' ? 503 : 500;
+        return sendJson(res, statusCode, { error: error.message, code: error.code || 'PDF_EXPORT_FAILED' });
+      }
     }
 
     const sessionMatch = pathname.match(/^\/api\/session\/([a-f0-9]{12})\/(feedback|end|reply|typing)$/);

--- a/scripts/lib/plan-canvas/server.js
+++ b/scripts/lib/plan-canvas/server.js
@@ -433,8 +433,18 @@ function createPlanCanvasServer({
         });
         return sendPdf(res, pdf);
       } catch (error) {
-        const statusCode = error.code === 'PDF_BROWSER_NOT_FOUND' ? 503 : 500;
-        return sendJson(res, statusCode, { error: error.message, code: error.code || 'PDF_EXPORT_FAILED' });
+        const code = error.code || 'PDF_EXPORT_FAILED';
+        log(`[plan-canvas] PDF export failed (${code}): ${error.stack || error.message}`);
+        if (code === 'PDF_BROWSER_NOT_FOUND') {
+          return sendJson(res, 503, {
+            error: 'PDF export requires Google Chrome, Chromium, or Microsoft Edge; configure ECC_PLAN_CANVAS_CHROME_PATH if auto-discovery cannot find it',
+            code
+          });
+        }
+        return sendJson(res, 500, {
+          error: 'PDF export failed; check the Plan Canvas server log for details',
+          code: 'PDF_EXPORT_FAILED'
+        });
       } finally {
         pdfSnapshot = null;
         pdfExportActive = false;

--- a/scripts/lib/plan-canvas/server.js
+++ b/scripts/lib/plan-canvas/server.js
@@ -31,6 +31,7 @@ const DEFAULT_PORT = 4517;
 const DEFAULT_HOST = '127.0.0.1';
 const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 const MAX_BODY_BYTES = 1024 * 1024;
+const MAX_PDF_SNAPSHOT_BYTES = 5 * 1024 * 1024;
 // How long the "agent is thinking" indicator survives without the agent
 // checking back in, before presence decays to the honest queued/waiting.
 const DEFAULT_THINKING_STALE_MS = 90 * 1000;
@@ -38,6 +39,19 @@ const DEFAULT_THINKING_STALE_MS = 90 * 1000;
 const DEFAULT_TYPING_EXPIRY_MS = 30 * 1000;
 const PLAN_CANVAS_PROTOCOL_VERSION = 4;
 const TYPING_STATES = new Set(['thinking', 'typing', 'idle']);
+const PDF_EXPORT_CSP = [
+  "default-src 'none'",
+  "base-uri 'none'",
+  "connect-src 'none'",
+  "font-src 'self' data:",
+  "form-action 'none'",
+  "frame-src 'none'",
+  "img-src 'self' data:",
+  "media-src 'self' data:",
+  "object-src 'none'",
+  "script-src 'none'",
+  "style-src 'self' 'unsafe-inline'"
+].join('; ');
 
 // Package versions do not distinguish two worktrees on the same release.
 // Fingerprint every module loaded into the detached server so a current CLI
@@ -96,13 +110,13 @@ function resolveIdleTimeoutMs(env = process.env) {
   return Number.isInteger(value) && value > 0 ? value : DEFAULT_IDLE_TIMEOUT_MS;
 }
 
-function readJsonBody(req) {
+function readJsonBody(req, maxBytes = MAX_BODY_BYTES) {
   return new Promise((resolve, reject) => {
     let size = 0;
     const chunks = [];
     req.on('data', chunk => {
       size += chunk.length;
-      if (size > MAX_BODY_BYTES) {
+      if (size > maxBytes) {
         reject(new Error('body too large'));
         req.destroy();
         return;
@@ -130,8 +144,9 @@ function sendJson(res, statusCode, payload) {
 function sendHtml(res, statusCode, html, { csp = true } = {}) {
   const headers = { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'no-store' };
   if (csp) {
-    headers['content-security-policy'] =
-      "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'self'";
+    headers['content-security-policy'] = typeof csp === 'string'
+      ? csp
+      : "default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-src 'self'";
   }
   res.writeHead(statusCode, headers);
   res.end(html);
@@ -175,6 +190,8 @@ function createPlanCanvasServer({
   const typingKeys = new Map(); // key -> ms timestamp the agent signalled composing
   let idleTimer = null;
   let closed = false;
+  let pdfExportActive = false;
+  let pdfSnapshot = null;
 
   // --- presence ---------------------------------------------------------
 
@@ -391,10 +408,25 @@ function createPlanCanvasServer({
     }
 
     const pdfMatch = pathname.match(/^\/api\/session\/([a-f0-9]{12})\/pdf$/);
-    if (pdfMatch && req.method === 'GET') {
+    if (pdfMatch && (req.method === 'GET' || req.method === 'POST')) {
       const session = store.get(pdfMatch[1]);
       if (!session) return sendJson(res, 404, { error: 'unknown session' });
+      if (pdfExportActive) {
+        res.setHeader('retry-after', '1');
+        return sendJson(res, 429, {
+          error: 'another PDF export is already in progress',
+          code: 'PDF_EXPORT_BUSY'
+        });
+      }
+      pdfExportActive = true;
       try {
+        if (req.method === 'POST') {
+          const body = await readJsonBody(req, MAX_PDF_SNAPSHOT_BYTES);
+          if (typeof body.html !== 'string' || !body.html.trim()) {
+            return sendJson(res, 400, { error: 'html snapshot is required' });
+          }
+          pdfSnapshot = { key: session.key, html: body.html };
+        }
         const pdf = await pdfExporter({
           url: `http://${req.headers.host}/artifact/${session.key}/?pdf=1`,
           artifactFile: session.file
@@ -403,6 +435,9 @@ function createPlanCanvasServer({
       } catch (error) {
         const statusCode = error.code === 'PDF_BROWSER_NOT_FOUND' ? 503 : 500;
         return sendJson(res, statusCode, { error: error.message, code: error.code || 'PDF_EXPORT_FAILED' });
+      } finally {
+        pdfSnapshot = null;
+        pdfExportActive = false;
       }
     }
 
@@ -474,11 +509,14 @@ function createPlanCanvasServer({
     res.end();
   }
 
-  function serveArtifact(res, key, assetPath) {
+  function serveArtifact(res, key, assetPath, { pdfExport = false } = {}) {
     const session = store.get(key);
     if (!session) return sendHtml(res, 404, '<h1>Unknown session</h1>');
 
     if (!assetPath) {
+      if (pdfExport && pdfSnapshot && pdfSnapshot.key === key) {
+        return sendHtml(res, 200, pdfSnapshot.html, { csp: PDF_EXPORT_CSP });
+      }
       let content;
       try {
         content = fs.readFileSync(session.file, 'utf8');
@@ -491,13 +529,13 @@ function createPlanCanvasServer({
           title: path.basename(session.file),
           sdkSrc: '/sdk.js'
         });
-        return sendHtml(res, 200, html, { csp: false });
+        return sendHtml(res, 200, html, { csp: pdfExport ? PDF_EXPORT_CSP : false });
       }
       const sdkTag = '<script src="/sdk.js"></script>';
       const injected = content.includes('</body>')
         ? content.replace('</body>', `${sdkTag}\n</body>`)
         : `${content}\n${sdkTag}`;
-      return sendHtml(res, 200, injected, { csp: false });
+      return sendHtml(res, 200, injected, { csp: pdfExport ? PDF_EXPORT_CSP : false });
     }
 
     // Sibling assets resolve relative to the artifact's directory and must
@@ -574,7 +612,9 @@ function createPlanCanvasServer({
         const artifactMatch = pathname.match(/^\/artifact\/([a-f0-9]{12})\/(.*)$/);
         if (req.method === 'GET' && artifactMatch) {
           const assetPath = decodeURIComponent(artifactMatch[2]);
-          return serveArtifact(res, artifactMatch[1], assetPath || null);
+          return serveArtifact(res, artifactMatch[1], assetPath || null, {
+            pdfExport: url.searchParams.get('pdf') === '1'
+          });
         }
         if (pathname.startsWith('/api/')) {
           return handleApi(req, res, url);

--- a/scripts/lib/plan-canvas/server.js
+++ b/scripts/lib/plan-canvas/server.js
@@ -10,6 +10,7 @@
  */
 
 const { EventEmitter } = require('events');
+const crypto = require('crypto');
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
@@ -36,7 +37,32 @@ const DEFAULT_THINKING_STALE_MS = 90 * 1000;
 const DEFAULT_TYPING_EXPIRY_MS = 30 * 1000;
 // Presence is push-based, so expiring states need a tick to re-broadcast on.
 const DEFAULT_PRESENCE_SWEEP_MS = 5 * 1000;
+const PLAN_CANVAS_PROTOCOL_VERSION = 2;
 const TYPING_STATES = new Set(['thinking', 'typing', 'idle']);
+
+// Package versions do not distinguish two worktrees on the same release.
+// Fingerprint every module loaded into the detached server so a current CLI
+// never reuses stale browser or protocol code from an older checkout.
+function computeRuntimeId() {
+  const sources = [
+    ['loopback-guard.js', path.join(__dirname, '..', 'loopback-guard.js')],
+    ['markdown.js', path.join(__dirname, 'markdown.js')],
+    ['sdk.js', path.join(__dirname, 'sdk.js')],
+    ['server.js', __filename],
+    ['sessions.js', path.join(__dirname, 'sessions.js')],
+    ['ui.js', path.join(__dirname, 'ui.js')]
+  ];
+  const digest = crypto.createHash('sha256');
+  for (const [name, sourcePath] of sources) {
+    digest.update(name);
+    digest.update('\0');
+    digest.update(fs.readFileSync(sourcePath));
+    digest.update('\0');
+  }
+  return digest.digest('hex').slice(0, 16);
+}
+
+const PLAN_CANVAS_RUNTIME_ID = computeRuntimeId();
 
 const CONTENT_TYPES = {
   '.css': 'text/css; charset=utf-8',
@@ -541,7 +567,13 @@ function createPlanCanvasServer({
     Promise.resolve()
       .then(() => {
         if (req.method === 'GET' && pathname === '/health') {
-          return sendJson(res, 200, { ok: true, app: 'ecc-plan-canvas', version });
+          return sendJson(res, 200, {
+            ok: true,
+            app: 'ecc-plan-canvas',
+            version,
+            protocolVersion: PLAN_CANVAS_PROTOCOL_VERSION,
+            runtimeId: PLAN_CANVAS_RUNTIME_ID
+          });
         }
         if (req.method === 'POST' && pathname === '/shutdown') {
           sendJson(res, 200, { status: 'stopping' });
@@ -628,6 +660,8 @@ module.exports = {
   DEFAULT_PORT,
   DEFAULT_THINKING_STALE_MS,
   DEFAULT_TYPING_EXPIRY_MS,
+  PLAN_CANVAS_PROTOCOL_VERSION,
+  PLAN_CANVAS_RUNTIME_ID,
   createPlanCanvasServer,
   resolveIdleTimeoutMs,
   resolvePort

--- a/scripts/lib/plan-canvas/ui.js
+++ b/scripts/lib/plan-canvas/ui.js
@@ -117,9 +117,19 @@ function canvasCss() {
   .toggle[aria-pressed="true"] .track{background:var(--accent);border-color:var(--accent-dim)}
   .toggle[aria-pressed="true"] .knob{transform:translateX(13px);background:#fff}
 
-  .icon-btn{height:28px;padding:0 10px;border-radius:6px;border:1px solid var(--border);background:var(--bg3);color:var(--text2);cursor:pointer;font-size:11.5px;display:flex;align-items:center;gap:5px;transition:all .12s}
+  .icon-btn{height:28px;padding:0 10px;border-radius:6px;border:1px solid var(--border);background:var(--bg3);color:var(--text2);cursor:pointer;font-size:11.5px;display:flex;align-items:center;gap:5px;white-space:nowrap;transition:all .12s}
   .icon-btn:hover{border-color:var(--border-light);color:var(--text);background:var(--bg4)}
+  .icon-btn:disabled{cursor:wait;opacity:.65}
   .icon-btn.danger:hover{border-color:var(--red);color:var(--red);background:var(--red-glow)}
+  .export-status{max-width:180px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:10.5px;color:var(--text2)}
+  .export-status.error{color:var(--red)}
+  @media(max-width:900px){
+    .bar{gap:8px;padding:0 10px}
+    .brand .name,.presence,.toggle>span:first-child,.export-status{display:none}
+    .brand .file{max-width:90px}
+    #downloadPdfBtn{font-size:0}
+    #downloadPdfBtn:after{content:'PDF';font-size:11.5px}
+  }
 
   .layout{display:flex;height:calc(100% - 52px)}
   .frame{flex:1;min-width:0;position:relative;background:var(--bg2)}
@@ -204,6 +214,8 @@ function canvasClientJs() {
   const sendBtn = $('send');
   const statusEl = $('sendStatus');
   const presence = $('presence');
+  const downloadPdfBtn = $('downloadPdfBtn');
+  const exportStatus = $('exportStatus');
   const QKEY = 'ecc-plan-canvas:queue:' + key;
   let queue = [];
   let lastScroll = { x: 0, y: 0 };
@@ -415,6 +427,48 @@ function canvasClientJs() {
   $('changes').addEventListener('click', () => send([{ kind: 'verdict', verdict: 'request-changes' }]));
 
   // --- session controls ------------------------------------------------
+  let exportStatusTimer = null;
+  function reportExportStatus(message, isError) {
+    clearTimeout(exportStatusTimer);
+    exportStatus.textContent = message;
+    exportStatus.classList.toggle('error', Boolean(isError));
+    if (message && !isError) {
+      exportStatusTimer = setTimeout(() => { exportStatus.textContent = ''; }, 5000);
+    }
+  }
+  downloadPdfBtn.addEventListener('click', async () => {
+    if (downloadPdfBtn.disabled) return;
+    downloadPdfBtn.disabled = true;
+    downloadPdfBtn.textContent = 'Preparing PDF\u2026';
+    reportExportStatus('Rendering locally\u2026');
+    try {
+      const res = await fetch('/api/session/' + key + '/pdf', { cache: 'no-store' });
+      if (!res.ok) {
+        const detail = await res.json().catch(() => ({}));
+        throw new Error(detail.error || ('HTTP ' + res.status));
+      }
+      const blob = await res.blob();
+      if (!blob.size || blob.type !== 'application/pdf') throw new Error('server returned an invalid PDF');
+      const encodedName = res.headers.get('x-plan-canvas-filename') || 'plan.pdf';
+      let filename = 'plan.pdf';
+      try { filename = decodeURIComponent(encodedName); } catch { /* safe fallback */ }
+      const objectUrl = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = objectUrl;
+      link.download = filename;
+      link.hidden = true;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      setTimeout(() => URL.revokeObjectURL(objectUrl), 30000);
+      reportExportStatus('Downloaded ' + filename);
+    } catch (error) {
+      reportExportStatus('PDF failed: ' + error.message, true);
+    } finally {
+      downloadPdfBtn.disabled = false;
+      downloadPdfBtn.textContent = 'Download PDF';
+    }
+  });
   $('reloadBtn').addEventListener('click', reloadArtifact);
   $('endBtn').addEventListener('click', async () => {
     if (!window.confirm('End this review session?')) return;
@@ -527,6 +581,8 @@ function renderCanvasHtml(session, { clientPath = '/client.js', cssPath = '/canv
     <span>Annotate</span><span class="track"><span class="knob"></span></span>
   </div>
   <button id="themeBtn" class="icon-btn" type="button">light</button>
+  <span id="exportStatus" class="export-status" role="status" aria-live="polite"></span>
+  <button id="downloadPdfBtn" class="icon-btn" type="button" aria-label="Download PDF" title="Download the current artifact as a PDF">Download PDF</button>
   <button id="reloadBtn" class="icon-btn" type="button" title="Reload artifact">Reload</button>
   <button id="endBtn" class="icon-btn danger" type="button">End session</button>
 </header>
@@ -600,6 +656,16 @@ ${TOKENS_CSS}
   pre.mermaid[data-processed]{background:transparent;border:none;padding:4px 0;text-align:center;overflow-x:auto}
   pre.mermaid[data-processed] svg{max-width:100%;height:auto}
   pre.mermaid.mermaid-unrendered:before{content:'diagram source (renderer unavailable)';display:block;font-family:var(--font);font-size:10.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--text3);margin-bottom:6px}
+  @page{margin:14mm}
+  @media print{
+    :root{--bg:#fff;--bg2:#fff;--bg3:#f4f5f7;--bg4:#eaecef;--surface:#fff;--surface-hover:#fff;--border:#d8dce5;--border-light:#c6cbd6;--text:#161922;--text2:#505667;--text3:#73798a;--accent:#3d5ab8;--accent-glow:rgba(61,90,184,.1);--pink:#b94076}
+    *{-webkit-print-color-adjust:exact;print-color-adjust:exact}
+    body{background:#fff;color:var(--text);font-size:11pt}
+    .doc{max-width:none;padding:0}
+    h1,h2,h3,h4,h5,h6{break-after:avoid-page}
+    blockquote,pre,table,img,svg{break-inside:avoid-page}
+    [data-ecc-plan-canvas="ui"]{display:none!important}
+  }
 </style>
 </head>
 <body>

--- a/scripts/lib/plan-canvas/ui.js
+++ b/scripts/lib/plan-canvas/ui.js
@@ -24,28 +24,32 @@ function mermaidUrl(env = process.env) {
   return override && String(override).trim() ? String(override).trim() : DEFAULT_MERMAID_URL;
 }
 
-// Browser module that renders `<pre class="mermaid">` blocks, themed to match
-// the ECC canvas. Kept import-only so a CDN failure degrades gracefully.
+// Browser enhancement that renders `<pre class="mermaid">` blocks, themed to
+// match the ECC canvas. Start the remote import only after `load`: an async
+// event listener is not awaited by the browser, so a stalled CDN can never
+// keep the artifact iframe or the outer Canvas page in a loading state.
 function mermaidLoaderScript(url) {
-  return `<script type="module">
-  try {
-    const mermaid = (await import(${JSON.stringify(url)})).default;
-    mermaid.initialize({
-      startOnLoad: false,
-      securityLevel: 'strict',
-      theme: 'dark',
-      fontFamily: "-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif",
-      themeVariables: {
-        primaryColor: '#13161e', primaryBorderColor: '#6885e8', primaryTextColor: '#dfe2e9',
-        lineColor: '#80859a', secondaryColor: '#191d2a', tertiaryColor: '#101218',
-        background: '#080a0e', mainBkg: '#13161e', clusterBkg: '#0d0f14'
-      }
-    });
-    await mermaid.run({ querySelector: '.mermaid' });
-  } catch (err) {
-    document.querySelectorAll('.mermaid').forEach(el => el.classList.add('mermaid-unrendered'));
-    console.warn('Mermaid render skipped:', err && err.message);
-  }
+  return `<script>
+  window.addEventListener('load', async () => {
+    try {
+      const mermaid = (await import(${JSON.stringify(url)})).default;
+      mermaid.initialize({
+        startOnLoad: false,
+        securityLevel: 'strict',
+        theme: 'dark',
+        fontFamily: "-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif",
+        themeVariables: {
+          primaryColor: '#13161e', primaryBorderColor: '#6885e8', primaryTextColor: '#dfe2e9',
+          lineColor: '#80859a', secondaryColor: '#191d2a', tertiaryColor: '#101218',
+          background: '#080a0e', mainBkg: '#13161e', clusterBkg: '#0d0f14'
+        }
+      });
+      await mermaid.run({ querySelector: '.mermaid' });
+    } catch (err) {
+      document.querySelectorAll('.mermaid').forEach(el => el.classList.add('mermaid-unrendered'));
+      console.warn('Mermaid render skipped:', err && err.message);
+    }
+  }, { once: true });
 </script>`;
 }
 

--- a/scripts/lib/plan-canvas/ui.js
+++ b/scripts/lib/plan-canvas/ui.js
@@ -209,6 +209,8 @@ function canvasClientJs() {
   let lastScroll = { x: 0, y: 0 };
   let ended = boot.status === 'ended';
   let sending = false;
+  let chatFingerprint = JSON.stringify(boot.chat || []);
+  let artifactVersion = null;
 
   try { queue = JSON.parse(sessionStorage.getItem(QKEY) || '[]'); } catch { queue = []; }
 
@@ -436,7 +438,7 @@ function canvasClientJs() {
   }
   if (ended) markEnded(boot.endedBy);
 
-  // --- server events ----------------------------------------------------
+  // --- server state -----------------------------------------------------
   const PRESENCE_LABELS = {
     waiting: 'agent not connected',
     listening: 'agent listening',
@@ -450,20 +452,44 @@ function canvasClientJs() {
     presence.querySelector('.label').textContent = PRESENCE_LABELS[state] || state;
     renderActivity(state);
   }
-  function connectEvents() {
-    const es = new EventSource('/events/' + key);
-    es.addEventListener('chat-sync', e => renderChat(JSON.parse(e.data).chat || []));
-    es.addEventListener('presence', e => applyPresence(JSON.parse(e.data).state));
-    es.addEventListener('reload', reloadArtifact);
-    es.addEventListener('ended', e => { markEnded(JSON.parse(e.data).endedBy); es.close(); });
-    es.onerror = () => {
-      if (ended) return;
-      renderActivity('offline');
-      presence.setAttribute('data-state', 'waiting');
-      presence.querySelector('.label').textContent = 'canvas server offline';
-    };
+  async function pollState() {
+    if (ended) return;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5000);
+    try {
+      const res = await fetch('/api/session/' + key + '/state', {
+        cache: 'no-store',
+        signal: controller.signal
+      });
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      const state = await res.json();
+      const nextChatFingerprint = JSON.stringify(state.chat || []);
+      if (nextChatFingerprint !== chatFingerprint) {
+        chatFingerprint = nextChatFingerprint;
+        renderChat(state.chat || []);
+      }
+      if (state.status === 'ended') {
+        markEnded(state.endedBy);
+        return;
+      }
+      applyPresence(state.presence);
+      if (artifactVersion === null) artifactVersion = state.artifactVersion;
+      else if (state.artifactVersion !== artifactVersion) {
+        artifactVersion = state.artifactVersion;
+        reloadArtifact();
+      }
+    } catch {
+      if (!ended) {
+        renderActivity('offline');
+        presence.setAttribute('data-state', 'waiting');
+        presence.querySelector('.label').textContent = 'canvas server offline';
+      }
+    } finally {
+      clearTimeout(timeout);
+      if (!ended) setTimeout(pollState, 1000);
+    }
   }
-  connectEvents();
+  pollState();
 })();`;
 }
 

--- a/scripts/lib/plan-canvas/ui.js
+++ b/scripts/lib/plan-canvas/ui.js
@@ -271,6 +271,7 @@ function canvasClientJs() {
   function postToFrame(msg) {
     if (frame.contentWindow) frame.contentWindow.postMessage(msg, '*');
   }
+  const snapshotWaiters = new Map();
   window.addEventListener('message', e => {
     if (e.source !== frame.contentWindow) return;
     const msg = e.data || {};
@@ -278,11 +279,32 @@ function canvasClientJs() {
     else if (msg.type === 'pc:queue-and-send' && msg.item) { addToQueue(msg.item); send(); }
     else if (msg.type === 'pc:scroll') lastScroll = { x: msg.x || 0, y: msg.y || 0 };
     else if (msg.type === 'pc:toggle-mode') setAnnotate(!annotate);
+    else if (msg.type === 'pc:export-snapshot-result' && typeof msg.requestId === 'string') {
+      const waiter = snapshotWaiters.get(msg.requestId);
+      if (waiter) {
+        snapshotWaiters.delete(msg.requestId);
+        waiter(msg.html);
+      }
+    }
     else if (msg.type === 'pc:ready') {
       postToFrame({ type: 'pc:set-mode', annotate });
       postToFrame({ type: 'pc:restore-scroll', x: lastScroll.x, y: lastScroll.y });
     }
   });
+  function requestArtifactSnapshot() {
+    return new Promise(resolve => {
+      const requestId = Date.now().toString(36) + Math.random().toString(36).slice(2);
+      const timer = setTimeout(() => {
+        snapshotWaiters.delete(requestId);
+        resolve(null);
+      }, 1500);
+      snapshotWaiters.set(requestId, html => {
+        clearTimeout(timer);
+        resolve(typeof html === 'string' ? html : null);
+      });
+      postToFrame({ type: 'pc:export-snapshot', requestId });
+    });
+  }
 
   // --- queue ----------------------------------------------------------
   function persistQueue() { try { sessionStorage.setItem(QKEY, JSON.stringify(queue)); } catch { /* full */ } }
@@ -442,7 +464,13 @@ function canvasClientJs() {
     downloadPdfBtn.textContent = 'Preparing PDF\u2026';
     reportExportStatus('Rendering locally\u2026');
     try {
-      const res = await fetch('/api/session/' + key + '/pdf', { cache: 'no-store' });
+      const snapshot = await requestArtifactSnapshot();
+      const res = await fetch('/api/session/' + key + '/pdf', {
+        method: snapshot ? 'POST' : 'GET',
+        headers: snapshot ? { 'content-type': 'application/json' } : undefined,
+        body: snapshot ? JSON.stringify({ html: snapshot }) : undefined,
+        cache: 'no-store'
+      });
       if (!res.ok) {
         const detail = await res.json().catch(() => ({}));
         throw new Error(detail.error || ('HTTP ' + res.status));

--- a/scripts/plan-canvas.js
+++ b/scripts/plan-canvas.js
@@ -179,19 +179,20 @@ async function withServerStartLock(port, task, {
   const lockPort = validatePort(port);
   const startedAt = Date.now();
   let socket = null;
+  let socketError = null;
 
   while (true) {
     try {
       socket = await new Promise((resolve, reject) => {
         const candidate = dgramImpl.createSocket('udp4');
         const onError = error => {
-          candidate.close();
+          try { candidate.close(); } catch { /* failed bind has no open handle */ }
           reject(error);
         };
         candidate.once('error', onError);
         candidate.bind(lockPort, DEFAULT_HOST, () => {
           candidate.removeListener('error', onError);
-          candidate.on('error', () => {});
+          candidate.on('error', error => { socketError = error; });
           candidate.unref();
           resolve(candidate);
         });
@@ -206,11 +207,23 @@ async function withServerStartLock(port, task, {
     }
   }
 
+  let result;
   try {
-    return await task();
+    result = await task();
   } finally {
-    if (socket) socket.close();
+    if (socket) {
+      await new Promise(resolve => {
+        try { socket.close(resolve); } catch { resolve(); }
+      });
+    }
   }
+  if (socketError) {
+    const error = new Error(`Plan Canvas startup lock failed on port ${port}: ${socketError.message}`);
+    error.code = 'PLAN_CANVAS_START_LOCK_FAILED';
+    error.cause = socketError;
+    throw error;
+  }
+  return result;
 }
 
 function serverIsCompatible(health) {

--- a/scripts/plan-canvas.js
+++ b/scripts/plan-canvas.js
@@ -390,10 +390,6 @@ async function cmdServer(args, { stateDir, port }) {
       startedAt: new Date().toISOString()
     }, null, 2)
   );
-  // Sessions restored from disk resume their file watchers.
-  for (const session of store.list()) {
-    if (session.status !== 'ended') canvas.watchSession(store.get(session.key));
-  }
   process.on('SIGINT', () => shutdown(0));
   process.on('SIGTERM', () => shutdown(0));
   process.stderr.write(`[plan-canvas] serving on http://${bound.host}:${bound.port}\n`);

--- a/scripts/plan-canvas.js
+++ b/scripts/plan-canvas.js
@@ -21,7 +21,7 @@ const fs = require('fs');
 const http = require('http');
 const os = require('os');
 const path = require('path');
-const { spawn } = require('child_process');
+const { execFileSync, spawn } = require('child_process');
 
 const {
   canonicalizeArtifactPath,
@@ -39,7 +39,6 @@ const {
 } = require('./lib/plan-canvas/server');
 
 const VERSION = require('../package.json').version;
-const DEFAULT_START_LOCK_LEASE_MS = 5 * 1000;
 
 const SAFE_REQUEST_PATHS = new Set([
   '/',
@@ -183,6 +182,37 @@ function processIsAlive(pid) {
   }
 }
 
+function readProcessIdentity(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  try {
+    if (process.platform === 'linux') {
+      const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf8');
+      const commandEnd = stat.lastIndexOf(')');
+      if (commandEnd === -1) return null;
+      const fieldsAfterCommand = stat.slice(commandEnd + 1).trim().split(/\s+/);
+      const startTicks = fieldsAfterCommand[19];
+      return startTicks ? `linux:${startTicks}` : null;
+    }
+    if (process.platform === 'win32') {
+      const command = `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`;
+      const startTicks = execFileSync(
+        'powershell.exe',
+        ['-NoProfile', '-NonInteractive', '-Command', command],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 3000, windowsHide: true }
+      ).trim();
+      return startTicks ? `win32:${startTicks}` : null;
+    }
+    const startedAt = execFileSync(
+      'ps',
+      ['-p', String(pid), '-o', 'lstart='],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 1000 }
+    ).trim();
+    return startedAt ? `${process.platform}:${startedAt}` : null;
+  } catch {
+    return null;
+  }
+}
+
 function readServerStartTicket(file) {
   let fd;
   try {
@@ -201,9 +231,10 @@ function readServerStartTicket(file) {
   }
 }
 
-function listServerStartTickets(lockDir, port, ownToken, staleAfterMs = DEFAULT_START_LOCK_LEASE_MS) {
+function listServerStartTickets(lockDir, port, ownToken, malformedStaleAfterMs = 60 * 1000) {
   const prefix = `ecc-plan-canvas-${validatePort(port)}-`;
   const entries = [];
+  const identities = new Map();
   for (const name of fs.readdirSync(lockDir)) {
     if (!name.startsWith(prefix) || (!name.endsWith('.choosing') && !name.endsWith('.ticket'))) continue;
     const file = path.join(lockDir, name);
@@ -215,18 +246,25 @@ function listServerStartTickets(lockDir, port, ownToken, staleAfterMs = DEFAULT_
       continue;
     }
     if (value.malformed) {
-      if (Date.now() - value.mtimeMs > staleAfterMs) {
+      if (Date.now() - value.mtimeMs > malformedStaleAfterMs) {
         try { fs.rmSync(file, { force: true }); } catch { /* already removed */ }
       }
       continue;
     }
-    const stale = value.token !== ownToken && (
-      !processIsAlive(value.pid) || Date.now() - value.mtimeMs > staleAfterMs
-    );
+    let stale = false;
+    if (value.token !== ownToken) {
+      if (!processIsAlive(value.pid)) {
+        stale = true;
+      } else if (typeof value.processIdentity === 'string') {
+        if (!identities.has(value.pid)) identities.set(value.pid, readProcessIdentity(value.pid));
+        const currentIdentity = identities.get(value.pid);
+        stale = currentIdentity !== null && currentIdentity !== value.processIdentity;
+      }
+    }
     if (stale) {
-      // A bounded, renewable lease prevents PID reuse from making an exited
-      // owner's ticket look live forever. Ticket names contain a never-reused
-      // owner token, so this cannot delete a later caller's ticket path.
+      // Process start identity distinguishes an exited owner from an unrelated
+      // process that later reused its PID. A live owner remains authoritative
+      // even if its event loop is paused for an arbitrary amount of time.
       try { fs.rmSync(file, { force: true }); } catch { /* already removed */ }
       continue;
     }
@@ -237,36 +275,36 @@ function listServerStartTickets(lockDir, port, ownToken, staleAfterMs = DEFAULT_
 
 async function withServerStartLock(port, task, {
   timeoutMs = 15 * 1000,
-  leaseMs = DEFAULT_START_LOCK_LEASE_MS,
   lockDir = path.join(os.homedir(), '.claude', 'plan-canvas', 'locks')
 } = {}) {
   const lockPort = validatePort(port);
+  const processIdentity = readProcessIdentity(process.pid);
+  if (!processIdentity) throw new Error('could not determine Plan Canvas startup lock process identity');
   const token = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const prefix = `ecc-plan-canvas-${lockPort}-${token}`;
   const choosingFile = path.join(lockDir, `${prefix}.choosing`);
   const ticketFile = path.join(lockDir, `${prefix}.ticket`);
   const startedAt = Date.now();
-  const lockLeaseMs = Number.isFinite(leaseMs) && leaseMs > 0
-    ? leaseMs
-    : DEFAULT_START_LOCK_LEASE_MS;
-  let leaseTimer = null;
   fs.mkdirSync(lockDir, { recursive: true, mode: 0o700 });
-  fs.writeFileSync(choosingFile, JSON.stringify({ pid: process.pid, token }), { flag: 'wx', mode: 0o600 });
+  fs.writeFileSync(
+    choosingFile,
+    JSON.stringify({ pid: process.pid, processIdentity, token }),
+    { flag: 'wx', mode: 0o600 }
+  );
 
   try {
-    const existing = listServerStartTickets(lockDir, lockPort, token, lockLeaseMs)
+    const existing = listServerStartTickets(lockDir, lockPort, token)
       .filter(entry => !entry.choosing && Number.isInteger(entry.number));
     const number = existing.reduce((maximum, entry) => Math.max(maximum, entry.number), 0) + 1;
-    fs.writeFileSync(ticketFile, JSON.stringify({ pid: process.pid, token, number }), { flag: 'wx', mode: 0o600 });
+    fs.writeFileSync(
+      ticketFile,
+      JSON.stringify({ pid: process.pid, processIdentity, token, number }),
+      { flag: 'wx', mode: 0o600 }
+    );
     fs.rmSync(choosingFile, { force: true });
-    leaseTimer = setInterval(() => {
-      const now = new Date();
-      try { fs.utimesSync(ticketFile, now, now); } catch { /* cleanup or lease loss */ }
-    }, Math.max(25, Math.floor(lockLeaseMs / 3)));
-    if (leaseTimer.unref) leaseTimer.unref();
 
     while (true) {
-      const entries = listServerStartTickets(lockDir, lockPort, token, lockLeaseMs);
+      const entries = listServerStartTickets(lockDir, lockPort, token);
       const anotherOwnerIsChoosing = entries.some(entry => entry.choosing && entry.token !== token);
       const tickets = entries
         .filter(entry => !entry.choosing && Number.isInteger(entry.number))
@@ -279,7 +317,6 @@ async function withServerStartLock(port, task, {
     }
     return await task();
   } finally {
-    clearInterval(leaseTimer);
     fs.rmSync(choosingFile, { force: true });
     fs.rmSync(ticketFile, { force: true });
   }

--- a/scripts/plan-canvas.js
+++ b/scripts/plan-canvas.js
@@ -19,6 +19,7 @@
 
 const fs = require('fs');
 const http = require('http');
+const os = require('os');
 const path = require('path');
 const { spawn } = require('child_process');
 
@@ -171,6 +172,73 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function serverStartLockPath(port, lockDir = os.tmpdir()) {
+  const userId = typeof process.getuid === 'function' ? process.getuid() : 'user';
+  return path.join(lockDir, `ecc-plan-canvas-${userId}-${validatePort(port)}.lock`);
+}
+
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === 'EPERM';
+  }
+}
+
+function removeStaleServerStartLock(lockPath, staleAfterMs = 60 * 1000) {
+  try {
+    const stat = fs.statSync(lockPath);
+    let owner = null;
+    try { owner = JSON.parse(fs.readFileSync(lockPath, 'utf8')); } catch { /* incomplete lock owner */ }
+    const oldEnough = Date.now() - stat.mtimeMs > staleAfterMs;
+    if (!oldEnough && (!owner || processIsAlive(owner.pid))) return false;
+    fs.rmSync(lockPath, { force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function withServerStartLock(port, task, {
+  lockDir = os.tmpdir(),
+  timeoutMs = 15 * 1000
+} = {}) {
+  fs.mkdirSync(lockDir, { recursive: true });
+  const lockPath = serverStartLockPath(port, lockDir);
+  const token = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const startedAt = Date.now();
+
+  while (true) {
+    try {
+      fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, token, createdAt: new Date().toISOString() }), {
+        flag: 'wx',
+        mode: 0o600
+      });
+      break;
+    } catch (error) {
+      if (error.code !== 'EEXIST') throw error;
+      if (removeStaleServerStartLock(lockPath)) continue;
+      if (Date.now() - startedAt >= timeoutMs) {
+        throw new Error(`timed out waiting for Plan Canvas startup lock on port ${port}`);
+      }
+      await sleep(50);
+    }
+  }
+
+  try {
+    return await task();
+  } finally {
+    try {
+      const owner = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+      if (owner.token === token) fs.rmSync(lockPath, { force: true });
+    } catch {
+      // A stale-lock recovery may already have removed it.
+    }
+  }
+}
+
 function serverIsCompatible(health) {
   return Boolean(
     health &&
@@ -186,24 +254,28 @@ function serverIsCompatible(health) {
 async function ensureServer({ stateDir, port }) {
   const health = await healthCheck(port);
   if (serverIsCompatible(health)) return port;
-  if (health) {
-    await request(port, 'POST', '/shutdown').catch(() => {});
-    for (let i = 0; i < 20 && (await healthCheck(port)); i++) await sleep(100);
-  }
-  fs.mkdirSync(stateDir, { recursive: true });
-  const logFd = fs.openSync(path.join(stateDir, 'server.log'), 'a');
-  const child = spawn(process.execPath, [__filename, 'server', '--port', String(port)], {
-    detached: true,
-    stdio: ['ignore', logFd, logFd],
-    env: { ...process.env, ECC_PLAN_CANVAS_STATE_DIR: stateDir }
+  return withServerStartLock(port, async () => {
+    const lockedHealth = await healthCheck(port);
+    if (serverIsCompatible(lockedHealth)) return port;
+    if (lockedHealth) {
+      await request(port, 'POST', '/shutdown').catch(() => {});
+      for (let i = 0; i < 20 && (await healthCheck(port)); i++) await sleep(100);
+    }
+    fs.mkdirSync(stateDir, { recursive: true });
+    const logFd = fs.openSync(path.join(stateDir, 'server.log'), 'a');
+    const child = spawn(process.execPath, [__filename, 'server', '--port', String(port)], {
+      detached: true,
+      stdio: ['ignore', logFd, logFd],
+      env: { ...process.env, ECC_PLAN_CANVAS_STATE_DIR: stateDir }
+    });
+    child.unref();
+    fs.closeSync(logFd);
+    for (let i = 0; i < 50; i++) {
+      await sleep(100);
+      if (serverIsCompatible(await healthCheck(port))) return port;
+    }
+    throw new Error(`plan-canvas server did not become compatible on port ${port}; check ${path.join(stateDir, 'server.log')}`);
   });
-  child.unref();
-  fs.closeSync(logFd);
-  for (let i = 0; i < 50; i++) {
-    await sleep(100);
-    if (serverIsCompatible(await healthCheck(port))) return port;
-  }
-  throw new Error(`plan-canvas server did not become compatible on port ${port}; check ${path.join(stateDir, 'server.log')}`);
 }
 
 function openBrowser(url) {
@@ -434,4 +506,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { main, ensureServer, healthCheck };
+module.exports = { main, ensureServer, healthCheck, withServerStartLock };

--- a/scripts/plan-canvas.js
+++ b/scripts/plan-canvas.js
@@ -172,11 +172,21 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function serverStartLockPort(port) {
+  const servicePort = validatePort(port);
+  // Keep the kernel-managed mutex independent of the TCP service endpoint.
+  // The rotation is one-to-one for ordinary non-privileged service ports, so
+  // separate Canvas ports do not contend with one another.
+  if (servicePort < 1024) return 49152 + servicePort;
+  const nonPrivilegedPortCount = 65535 - 1024 + 1;
+  return 1024 + ((servicePort - 1024 + Math.floor(nonPrivilegedPortCount / 2)) % nonPrivilegedPortCount);
+}
+
 async function withServerStartLock(port, task, {
   timeoutMs = 15 * 1000,
   dgramImpl = dgram
 } = {}) {
-  const lockPort = validatePort(port);
+  const lockPort = serverStartLockPort(port);
   const startedAt = Date.now();
   let socket = null;
   let socketError = null;

--- a/scripts/plan-canvas.js
+++ b/scripts/plan-canvas.js
@@ -187,12 +187,25 @@ function processIsAlive(pid) {
   }
 }
 
+function readServerStartLock(lockPath) {
+  let fd;
+  try {
+    fd = fs.openSync(lockPath, 'r');
+    const stat = fs.fstatSync(fd);
+    let owner = null;
+    try { owner = JSON.parse(fs.readFileSync(fd, 'utf8')); } catch { /* incomplete lock owner */ }
+    return { mtimeMs: stat.mtimeMs, owner };
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch { /* best-effort lock inspection */ }
+    }
+  }
+}
+
 function removeStaleServerStartLock(lockPath, staleAfterMs = 60 * 1000) {
   try {
-    const stat = fs.statSync(lockPath);
-    let owner = null;
-    try { owner = JSON.parse(fs.readFileSync(lockPath, 'utf8')); } catch { /* incomplete lock owner */ }
-    const oldEnough = Date.now() - stat.mtimeMs > staleAfterMs;
+    const { mtimeMs, owner } = readServerStartLock(lockPath);
+    const oldEnough = Date.now() - mtimeMs > staleAfterMs;
     if (!oldEnough && (!owner || processIsAlive(owner.pid))) return false;
     fs.rmSync(lockPath, { force: true });
     return true;

--- a/scripts/plan-canvas.js
+++ b/scripts/plan-canvas.js
@@ -30,6 +30,8 @@ const {
 } = require('./lib/plan-canvas/sessions');
 const {
   DEFAULT_HOST,
+  PLAN_CANVAS_PROTOCOL_VERSION,
+  PLAN_CANVAS_RUNTIME_ID,
   createPlanCanvasServer,
   resolveIdleTimeoutMs,
   resolvePort
@@ -168,12 +170,21 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-// Start (or reuse) the detached canvas server and return its port. A version
-// mismatch after an ECC update restarts the server so browser and CLI never
-// disagree about the protocol.
+function serverIsCompatible(health) {
+  return Boolean(
+    health &&
+    health.version === VERSION &&
+    health.protocolVersion === PLAN_CANVAS_PROTOCOL_VERSION &&
+    health.runtimeId === PLAN_CANVAS_RUNTIME_ID
+  );
+}
+
+// Start (or reuse) the detached canvas server and return its port. Worktrees
+// can share a package version while carrying different Canvas code, so the
+// health handshake binds reuse to the exact server runtime as well.
 async function ensureServer({ stateDir, port }) {
   const health = await healthCheck(port);
-  if (health && health.version === VERSION) return port;
+  if (serverIsCompatible(health)) return port;
   if (health) {
     await request(port, 'POST', '/shutdown').catch(() => {});
     for (let i = 0; i < 20 && (await healthCheck(port)); i++) await sleep(100);
@@ -189,9 +200,9 @@ async function ensureServer({ stateDir, port }) {
   fs.closeSync(logFd);
   for (let i = 0; i < 50; i++) {
     await sleep(100);
-    if (await healthCheck(port)) return port;
+    if (serverIsCompatible(await healthCheck(port))) return port;
   }
-  throw new Error(`plan-canvas server did not become healthy on port ${port}; check ${path.join(stateDir, 'server.log')}`);
+  throw new Error(`plan-canvas server did not become compatible on port ${port}; check ${path.join(stateDir, 'server.log')}`);
 }
 
 function openBrowser(url) {
@@ -218,7 +229,13 @@ async function cmdStatus({ stateDir, port }) {
     return { server: 'not running', hint: 'open an artifact to start one', stateDir };
   }
   const sessions = await request(port, 'GET', '/api/sessions');
-  return { server: `http://${DEFAULT_HOST}:${port}`, version: health.version, sessions: sessions.body.sessions };
+  return {
+    server: `http://${DEFAULT_HOST}:${port}`,
+    version: health.version,
+    protocolVersion: health.protocolVersion,
+    runtimeId: health.runtimeId,
+    sessions: sessions.body.sessions
+  };
 }
 
 async function cmdOpen(file, args, { stateDir, port }) {
@@ -364,7 +381,14 @@ async function cmdServer(args, { stateDir, port }) {
   fs.mkdirSync(stateDir, { recursive: true });
   fs.writeFileSync(
     serverInfoPath(stateDir),
-    JSON.stringify({ pid: process.pid, port: bound.port, version: VERSION, startedAt: new Date().toISOString() }, null, 2)
+    JSON.stringify({
+      pid: process.pid,
+      port: bound.port,
+      version: VERSION,
+      protocolVersion: PLAN_CANVAS_PROTOCOL_VERSION,
+      runtimeId: PLAN_CANVAS_RUNTIME_ID,
+      startedAt: new Date().toISOString()
+    }, null, 2)
   );
   // Sessions restored from disk resume their file watchers.
   for (const session of store.list()) {

--- a/scripts/plan-canvas.js
+++ b/scripts/plan-canvas.js
@@ -18,8 +18,8 @@
  */
 
 const fs = require('fs');
+const dgram = require('dgram');
 const http = require('http');
-const os = require('os');
 const path = require('path');
 const { spawn } = require('child_process');
 
@@ -172,67 +172,33 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function serverStartLockPath(port, lockDir = os.tmpdir()) {
-  const userId = typeof process.getuid === 'function' ? process.getuid() : 'user';
-  return path.join(lockDir, `ecc-plan-canvas-${userId}-${validatePort(port)}.lock`);
-}
-
-function processIsAlive(pid) {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    return error.code === 'EPERM';
-  }
-}
-
-function readServerStartLock(lockPath) {
-  let fd;
-  try {
-    fd = fs.openSync(lockPath, 'r');
-    const stat = fs.fstatSync(fd);
-    let owner = null;
-    try { owner = JSON.parse(fs.readFileSync(fd, 'utf8')); } catch { /* incomplete lock owner */ }
-    return { mtimeMs: stat.mtimeMs, owner };
-  } finally {
-    if (fd !== undefined) {
-      try { fs.closeSync(fd); } catch { /* best-effort lock inspection */ }
-    }
-  }
-}
-
-function removeStaleServerStartLock(lockPath, staleAfterMs = 60 * 1000) {
-  try {
-    const { mtimeMs, owner } = readServerStartLock(lockPath);
-    const oldEnough = Date.now() - mtimeMs > staleAfterMs;
-    if (!oldEnough && (!owner || processIsAlive(owner.pid))) return false;
-    fs.rmSync(lockPath, { force: true });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 async function withServerStartLock(port, task, {
-  lockDir = os.tmpdir(),
-  timeoutMs = 15 * 1000
+  timeoutMs = 15 * 1000,
+  dgramImpl = dgram
 } = {}) {
-  fs.mkdirSync(lockDir, { recursive: true });
-  const lockPath = serverStartLockPath(port, lockDir);
-  const token = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const lockPort = validatePort(port);
   const startedAt = Date.now();
+  let socket = null;
 
   while (true) {
     try {
-      fs.writeFileSync(lockPath, JSON.stringify({ pid: process.pid, token, createdAt: new Date().toISOString() }), {
-        flag: 'wx',
-        mode: 0o600
+      socket = await new Promise((resolve, reject) => {
+        const candidate = dgramImpl.createSocket('udp4');
+        const onError = error => {
+          candidate.close();
+          reject(error);
+        };
+        candidate.once('error', onError);
+        candidate.bind(lockPort, DEFAULT_HOST, () => {
+          candidate.removeListener('error', onError);
+          candidate.on('error', () => {});
+          candidate.unref();
+          resolve(candidate);
+        });
       });
       break;
     } catch (error) {
-      if (error.code !== 'EEXIST') throw error;
-      if (removeStaleServerStartLock(lockPath)) continue;
+      if (error.code !== 'EADDRINUSE') throw error;
       if (Date.now() - startedAt >= timeoutMs) {
         throw new Error(`timed out waiting for Plan Canvas startup lock on port ${port}`);
       }
@@ -243,12 +209,7 @@ async function withServerStartLock(port, task, {
   try {
     return await task();
   } finally {
-    try {
-      const owner = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
-      if (owner.token === token) fs.rmSync(lockPath, { force: true });
-    } catch {
-      // A stale-lock recovery may already have removed it.
-    }
+    if (socket) socket.close();
   }
 }
 

--- a/scripts/plan-canvas.js
+++ b/scripts/plan-canvas.js
@@ -71,7 +71,8 @@ function usage() {
     '  typing: --state <thinking|typing|idle>  Defaults to typing',
     '  server: --port <n> --host <h>',
     '',
-    'Environment: ECC_PLAN_CANVAS_PORT, ECC_PLAN_CANVAS_STATE_DIR, ECC_PLAN_CANVAS_IDLE_MS'
+    'Environment: ECC_PLAN_CANVAS_PORT, ECC_PLAN_CANVAS_STATE_DIR, ECC_PLAN_CANVAS_IDLE_MS,',
+    '             ECC_PLAN_CANVAS_CHROME_PATH'
   ].join('\n');
 }
 

--- a/scripts/plan-canvas.js
+++ b/scripts/plan-canvas.js
@@ -18,8 +18,8 @@
  */
 
 const fs = require('fs');
-const dgram = require('dgram');
 const http = require('http');
+const os = require('os');
 const path = require('path');
 const { spawn } = require('child_process');
 
@@ -172,68 +172,102 @@ function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function serverStartLockPort(port) {
-  const servicePort = validatePort(port);
-  // Keep the kernel-managed mutex independent of the TCP service endpoint.
-  // The rotation is one-to-one for ordinary non-privileged service ports, so
-  // separate Canvas ports do not contend with one another.
-  if (servicePort < 1024) return 49152 + servicePort;
-  const nonPrivilegedPortCount = 65535 - 1024 + 1;
-  return 1024 + ((servicePort - 1024 + Math.floor(nonPrivilegedPortCount / 2)) % nonPrivilegedPortCount);
+function processIsAlive(pid) {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error.code === 'EPERM';
+  }
+}
+
+function readServerStartTicket(file) {
+  let fd;
+  try {
+    fd = fs.openSync(file, 'r');
+    const stat = fs.fstatSync(fd);
+    try {
+      const value = JSON.parse(fs.readFileSync(fd, 'utf8'));
+      return { ...value, mtimeMs: stat.mtimeMs, malformed: false };
+    } catch {
+      return { mtimeMs: stat.mtimeMs, malformed: true };
+    }
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch { /* best-effort ticket inspection */ }
+    }
+  }
+}
+
+function listServerStartTickets(lockDir, port, ownToken, staleAfterMs = 60 * 1000) {
+  const prefix = `ecc-plan-canvas-${validatePort(port)}-`;
+  const entries = [];
+  for (const name of fs.readdirSync(lockDir)) {
+    if (!name.startsWith(prefix) || (!name.endsWith('.choosing') && !name.endsWith('.ticket'))) continue;
+    const file = path.join(lockDir, name);
+    let value = null;
+    try {
+      value = readServerStartTicket(file);
+    } catch {
+      // The owner may already have removed its unique ticket.
+      continue;
+    }
+    if (value.malformed) {
+      if (Date.now() - value.mtimeMs > staleAfterMs) {
+        try { fs.rmSync(file, { force: true }); } catch { /* already removed */ }
+      }
+      continue;
+    }
+    const stale = value.token !== ownToken && !processIsAlive(value.pid);
+    if (stale) {
+      // Ticket names contain a never-reused random owner token, so removing a
+      // dead owner's exact path cannot delete a later caller's live ticket.
+      try { fs.rmSync(file, { force: true }); } catch { /* already removed */ }
+      continue;
+    }
+    entries.push({ ...value, file, choosing: name.endsWith('.choosing') });
+  }
+  return entries;
 }
 
 async function withServerStartLock(port, task, {
   timeoutMs = 15 * 1000,
-  dgramImpl = dgram
+  lockDir = path.join(os.homedir(), '.claude', 'plan-canvas', 'locks')
 } = {}) {
-  const lockPort = serverStartLockPort(port);
+  const lockPort = validatePort(port);
+  const token = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const prefix = `ecc-plan-canvas-${lockPort}-${token}`;
+  const choosingFile = path.join(lockDir, `${prefix}.choosing`);
+  const ticketFile = path.join(lockDir, `${prefix}.ticket`);
   const startedAt = Date.now();
-  let socket = null;
-  let socketError = null;
+  fs.mkdirSync(lockDir, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(choosingFile, JSON.stringify({ pid: process.pid, token }), { flag: 'wx', mode: 0o600 });
 
-  while (true) {
-    try {
-      socket = await new Promise((resolve, reject) => {
-        const candidate = dgramImpl.createSocket('udp4');
-        const onError = error => {
-          try { candidate.close(); } catch { /* failed bind has no open handle */ }
-          reject(error);
-        };
-        candidate.once('error', onError);
-        candidate.bind(lockPort, DEFAULT_HOST, () => {
-          candidate.removeListener('error', onError);
-          candidate.on('error', error => { socketError = error; });
-          candidate.unref();
-          resolve(candidate);
-        });
-      });
-      break;
-    } catch (error) {
-      if (error.code !== 'EADDRINUSE') throw error;
+  try {
+    const existing = listServerStartTickets(lockDir, lockPort, token)
+      .filter(entry => !entry.choosing && Number.isInteger(entry.number));
+    const number = existing.reduce((maximum, entry) => Math.max(maximum, entry.number), 0) + 1;
+    fs.writeFileSync(ticketFile, JSON.stringify({ pid: process.pid, token, number }), { flag: 'wx', mode: 0o600 });
+    fs.rmSync(choosingFile, { force: true });
+
+    while (true) {
+      const entries = listServerStartTickets(lockDir, lockPort, token);
+      const anotherOwnerIsChoosing = entries.some(entry => entry.choosing && entry.token !== token);
+      const tickets = entries
+        .filter(entry => !entry.choosing && Number.isInteger(entry.number))
+        .sort((left, right) => left.number - right.number || left.token.localeCompare(right.token));
+      if (!anotherOwnerIsChoosing && tickets[0] && tickets[0].token === token) break;
       if (Date.now() - startedAt >= timeoutMs) {
         throw new Error(`timed out waiting for Plan Canvas startup lock on port ${port}`);
       }
       await sleep(50);
     }
-  }
-
-  let result;
-  try {
-    result = await task();
+    return await task();
   } finally {
-    if (socket) {
-      await new Promise(resolve => {
-        try { socket.close(resolve); } catch { resolve(); }
-      });
-    }
+    fs.rmSync(choosingFile, { force: true });
+    fs.rmSync(ticketFile, { force: true });
   }
-  if (socketError) {
-    const error = new Error(`Plan Canvas startup lock failed on port ${port}: ${socketError.message}`);
-    error.code = 'PLAN_CANVAS_START_LOCK_FAILED';
-    error.cause = socketError;
-    throw error;
-  }
-  return result;
 }
 
 function serverIsCompatible(health) {

--- a/scripts/plan-canvas.js
+++ b/scripts/plan-canvas.js
@@ -39,6 +39,7 @@ const {
 } = require('./lib/plan-canvas/server');
 
 const VERSION = require('../package.json').version;
+const DEFAULT_START_LOCK_LEASE_MS = 5 * 1000;
 
 const SAFE_REQUEST_PATHS = new Set([
   '/',
@@ -200,7 +201,7 @@ function readServerStartTicket(file) {
   }
 }
 
-function listServerStartTickets(lockDir, port, ownToken, staleAfterMs = 60 * 1000) {
+function listServerStartTickets(lockDir, port, ownToken, staleAfterMs = DEFAULT_START_LOCK_LEASE_MS) {
   const prefix = `ecc-plan-canvas-${validatePort(port)}-`;
   const entries = [];
   for (const name of fs.readdirSync(lockDir)) {
@@ -219,10 +220,13 @@ function listServerStartTickets(lockDir, port, ownToken, staleAfterMs = 60 * 100
       }
       continue;
     }
-    const stale = value.token !== ownToken && !processIsAlive(value.pid);
+    const stale = value.token !== ownToken && (
+      !processIsAlive(value.pid) || Date.now() - value.mtimeMs > staleAfterMs
+    );
     if (stale) {
-      // Ticket names contain a never-reused random owner token, so removing a
-      // dead owner's exact path cannot delete a later caller's live ticket.
+      // A bounded, renewable lease prevents PID reuse from making an exited
+      // owner's ticket look live forever. Ticket names contain a never-reused
+      // owner token, so this cannot delete a later caller's ticket path.
       try { fs.rmSync(file, { force: true }); } catch { /* already removed */ }
       continue;
     }
@@ -233,6 +237,7 @@ function listServerStartTickets(lockDir, port, ownToken, staleAfterMs = 60 * 100
 
 async function withServerStartLock(port, task, {
   timeoutMs = 15 * 1000,
+  leaseMs = DEFAULT_START_LOCK_LEASE_MS,
   lockDir = path.join(os.homedir(), '.claude', 'plan-canvas', 'locks')
 } = {}) {
   const lockPort = validatePort(port);
@@ -241,18 +246,27 @@ async function withServerStartLock(port, task, {
   const choosingFile = path.join(lockDir, `${prefix}.choosing`);
   const ticketFile = path.join(lockDir, `${prefix}.ticket`);
   const startedAt = Date.now();
+  const lockLeaseMs = Number.isFinite(leaseMs) && leaseMs > 0
+    ? leaseMs
+    : DEFAULT_START_LOCK_LEASE_MS;
+  let leaseTimer = null;
   fs.mkdirSync(lockDir, { recursive: true, mode: 0o700 });
   fs.writeFileSync(choosingFile, JSON.stringify({ pid: process.pid, token }), { flag: 'wx', mode: 0o600 });
 
   try {
-    const existing = listServerStartTickets(lockDir, lockPort, token)
+    const existing = listServerStartTickets(lockDir, lockPort, token, lockLeaseMs)
       .filter(entry => !entry.choosing && Number.isInteger(entry.number));
     const number = existing.reduce((maximum, entry) => Math.max(maximum, entry.number), 0) + 1;
     fs.writeFileSync(ticketFile, JSON.stringify({ pid: process.pid, token, number }), { flag: 'wx', mode: 0o600 });
     fs.rmSync(choosingFile, { force: true });
+    leaseTimer = setInterval(() => {
+      const now = new Date();
+      try { fs.utimesSync(ticketFile, now, now); } catch { /* cleanup or lease loss */ }
+    }, Math.max(25, Math.floor(lockLeaseMs / 3)));
+    if (leaseTimer.unref) leaseTimer.unref();
 
     while (true) {
-      const entries = listServerStartTickets(lockDir, lockPort, token);
+      const entries = listServerStartTickets(lockDir, lockPort, token, lockLeaseMs);
       const anotherOwnerIsChoosing = entries.some(entry => entry.choosing && entry.token !== token);
       const tickets = entries
         .filter(entry => !entry.choosing && Number.isInteger(entry.number))
@@ -265,6 +279,7 @@ async function withServerStartLock(port, task, {
     }
     return await task();
   } finally {
+    clearInterval(leaseTimer);
     fs.rmSync(choosingFile, { force: true });
     fs.rmSync(ticketFile, { force: true });
   }

--- a/skills/plan-canvas/SKILL.md
+++ b/skills/plan-canvas/SKILL.md
@@ -155,6 +155,9 @@ mirror at `ECC_PLAN_CANVAS_MERMAID_URL` for air-gapped use.
   session is refused; pass `--reopen` only when the user asks to resume.
 - Sibling assets (images, CSS) must sit next to the artifact and be
   referenced by relative path.
+- The reviewer can use **Download PDF** in the Canvas header to save the current
+  artifact directly. Export stays local and uses an installed Chrome, Chromium,
+  or Edge renderer; `ECC_PLAN_CANVAS_CHROME_PATH` selects a nonstandard install.
 - The server is loopback-only and exits after 30 idle minutes
   (`ECC_PLAN_CANVAS_IDLE_MS`); `stop` shuts it down explicitly. State lives
   in `~/.claude/plan-canvas/` (`ECC_PLAN_CANVAS_STATE_DIR`).

--- a/tests/integration/plan-canvas-e2e.test.js
+++ b/tests/integration/plan-canvas-e2e.test.js
@@ -17,6 +17,7 @@
  */
 
 const assert = require('assert');
+const dgram = require('dgram');
 const { EventEmitter } = require('events');
 const fs = require('fs');
 const http = require('http');
@@ -170,6 +171,23 @@ async function main() {
       );
     });
 
+    await test('unrelated UDP traffic on the Canvas port does not block startup', async () => {
+      const servicePort = port + 4;
+      const unrelatedSocket = dgram.createSocket('udp4');
+      await new Promise((resolve, reject) => {
+        unrelatedSocket.once('error', reject);
+        unrelatedSocket.bind(servicePort, '127.0.0.1', resolve);
+      });
+      try {
+        assert.strictEqual(
+          await withServerStartLock(servicePort, async () => 'started', { timeoutMs: 2000 }),
+          'started'
+        );
+      } finally {
+        unrelatedSocket.close();
+      }
+    });
+
     await test('port-scoped startup lock propagates socket failures', async () => {
       class FailingLockSocket extends EventEmitter {
         bind(_port, _host, callback) { setImmediate(callback); }
@@ -178,7 +196,7 @@ async function main() {
       }
       const socket = new FailingLockSocket();
       await assert.rejects(
-        withServerStartLock(port + 4, async () => {
+        withServerStartLock(port + 5, async () => {
           socket.emit('error', new Error('simulated UDP failure'));
         }, { dgramImpl: { createSocket: () => socket }, timeoutMs: 2000 }),
         error => error.code === 'PLAN_CANVAS_START_LOCK_FAILED' && error.message.includes('simulated UDP failure')

--- a/tests/integration/plan-canvas-e2e.test.js
+++ b/tests/integration/plan-canvas-e2e.test.js
@@ -152,22 +152,21 @@ async function main() {
         await new Promise(resolve => setTimeout(resolve, 40));
         active -= 1;
         return label;
-      }, { lockDir: tmp, timeoutMs: 2000 });
+      }, { timeoutMs: 2000 });
       assert.deepStrictEqual(await Promise.all([runLocked('first'), runLocked('second')]), ['first', 'second']);
       assert.strictEqual(maximumActive, 1);
-      assert.ok(!fs.readdirSync(tmp).some(name => name.endsWith('.lock')));
     });
 
-    await test('port-scoped startup lock recovers a dead owner', async () => {
+    await test('port-scoped startup lock releases after a failed owner', async () => {
       const lockPort = port + 3;
-      const userId = typeof process.getuid === 'function' ? process.getuid() : 'user';
-      const lockPath = path.join(tmp, `ecc-plan-canvas-${userId}-${lockPort}.lock`);
-      fs.writeFileSync(lockPath, JSON.stringify({ pid: 2147483647, token: 'dead-owner' }));
+      await assert.rejects(
+        withServerStartLock(lockPort, async () => { throw new Error('owner failed'); }, { timeoutMs: 2000 }),
+        /owner failed/
+      );
       assert.strictEqual(
-        await withServerStartLock(lockPort, async () => 'recovered', { lockDir: tmp, timeoutMs: 2000 }),
+        await withServerStartLock(lockPort, async () => 'recovered', { timeoutMs: 2000 }),
         'recovered'
       );
-      assert.ok(!fs.existsSync(lockPath));
     });
 
     await test('concurrent opens serialize replacement of a same-version legacy server', async () => {

--- a/tests/integration/plan-canvas-e2e.test.js
+++ b/tests/integration/plan-canvas-e2e.test.js
@@ -25,6 +25,7 @@ const { spawn, spawnSync } = require('child_process');
 
 const CLI = path.join(__dirname, '..', '..', 'scripts', 'plan-canvas.js');
 const HOOK = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'plan-canvas-sessions.js');
+const { withServerStartLock } = require('../../scripts/plan-canvas');
 
 const results = [];
 async function test(name, fn) {
@@ -142,7 +143,22 @@ async function main() {
   let key = null;
 
   try {
-    await test('same-version legacy server is replaced before a canvas opens', async () => {
+    await test('port-scoped startup lock serializes server replacement callers', async () => {
+      let active = 0;
+      let maximumActive = 0;
+      const runLocked = label => withServerStartLock(port + 2, async () => {
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        await new Promise(resolve => setTimeout(resolve, 40));
+        active -= 1;
+        return label;
+      }, { lockDir: tmp, timeoutMs: 2000 });
+      assert.deepStrictEqual(await Promise.all([runLocked('first'), runLocked('second')]), ['first', 'second']);
+      assert.strictEqual(maximumActive, 1);
+      assert.ok(!fs.readdirSync(tmp).some(name => name.endsWith('.lock')));
+    });
+
+    await test('concurrent opens serialize replacement of a same-version legacy server', async () => {
       const legacyPort = port + 1;
       const legacyStateDir = path.join(tmp, 'legacy-state');
       const legacyEnv = {
@@ -171,9 +187,14 @@ async function main() {
       });
 
       try {
-        const result = await cliAsync(legacyEnv, ['open', plan, '--no-open']);
-        assert.strictEqual(result.status, 0, result.stderr);
-        assert.strictEqual(result.parsed.status, 'open');
+        const results = await Promise.all([
+          cliAsync(legacyEnv, ['open', plan, '--no-open']),
+          cliAsync(legacyEnv, ['open', plan, '--no-open'])
+        ]);
+        for (const result of results) {
+          assert.strictEqual(result.status, 0, result.stderr);
+          assert.strictEqual(result.parsed.status, 'open');
+        }
         assert.strictEqual(shutdownRequested, true, 'current CLI should retire the stale server');
         const health = JSON.parse((await request(legacyPort, 'GET', '/health')).body);
         assert.strictEqual(health.protocolVersion, 4);

--- a/tests/integration/plan-canvas-e2e.test.js
+++ b/tests/integration/plan-canvas-e2e.test.js
@@ -18,7 +18,6 @@
 
 const assert = require('assert');
 const dgram = require('dgram');
-const { EventEmitter } = require('events');
 const fs = require('fs');
 const http = require('http');
 const os = require('os');
@@ -146,6 +145,7 @@ async function main() {
 
   try {
     await test('port-scoped startup lock serializes server replacement callers', async () => {
+      const lockDir = path.join(tmp, 'startup-locks');
       let active = 0;
       let maximumActive = 0;
       const runLocked = label => withServerStartLock(port + 2, async () => {
@@ -154,21 +154,27 @@ async function main() {
         await new Promise(resolve => setTimeout(resolve, 40));
         active -= 1;
         return label;
-      }, { timeoutMs: 2000 });
+      }, { lockDir, timeoutMs: 2000 });
       assert.deepStrictEqual(await Promise.all([runLocked('first'), runLocked('second')]), ['first', 'second']);
       assert.strictEqual(maximumActive, 1);
     });
 
-    await test('port-scoped startup lock releases after a failed owner', async () => {
+    await test('port-scoped startup lock recovers dead tickets and failed owners', async () => {
       const lockPort = port + 3;
+      const lockDir = path.join(tmp, 'startup-locks');
+      fs.mkdirSync(lockDir, { recursive: true });
+      const deadTicket = path.join(lockDir, `ecc-plan-canvas-${lockPort}-dead-owner.ticket`);
+      fs.writeFileSync(deadTicket, JSON.stringify({ pid: 2147483647, token: 'dead-owner', number: 1 }));
       await assert.rejects(
-        withServerStartLock(lockPort, async () => { throw new Error('owner failed'); }, { timeoutMs: 2000 }),
+        withServerStartLock(lockPort, async () => { throw new Error('owner failed'); }, { lockDir, timeoutMs: 2000 }),
         /owner failed/
       );
       assert.strictEqual(
-        await withServerStartLock(lockPort, async () => 'recovered', { timeoutMs: 2000 }),
+        await withServerStartLock(lockPort, async () => 'recovered', { lockDir, timeoutMs: 2000 }),
         'recovered'
       );
+      assert.ok(!fs.existsSync(deadTicket));
+      assert.ok(!fs.readdirSync(lockDir).some(name => name.startsWith(`ecc-plan-canvas-${lockPort}-`)));
     });
 
     await test('unrelated UDP traffic on the Canvas port does not block startup', async () => {
@@ -186,21 +192,6 @@ async function main() {
       } finally {
         unrelatedSocket.close();
       }
-    });
-
-    await test('port-scoped startup lock propagates socket failures', async () => {
-      class FailingLockSocket extends EventEmitter {
-        bind(_port, _host, callback) { setImmediate(callback); }
-        unref() {}
-        close(callback) { if (callback) setImmediate(callback); }
-      }
-      const socket = new FailingLockSocket();
-      await assert.rejects(
-        withServerStartLock(port + 5, async () => {
-          socket.emit('error', new Error('simulated UDP failure'));
-        }, { dgramImpl: { createSocket: () => socket }, timeoutMs: 2000 }),
-        error => error.code === 'PLAN_CANVAS_START_LOCK_FAILED' && error.message.includes('simulated UDP failure')
-      );
     });
 
     await test('concurrent opens serialize replacement of a same-version legacy server', async () => {

--- a/tests/integration/plan-canvas-e2e.test.js
+++ b/tests/integration/plan-canvas-e2e.test.js
@@ -17,6 +17,7 @@
  */
 
 const assert = require('assert');
+const { EventEmitter } = require('events');
 const fs = require('fs');
 const http = require('http');
 const os = require('os');
@@ -166,6 +167,21 @@ async function main() {
       assert.strictEqual(
         await withServerStartLock(lockPort, async () => 'recovered', { timeoutMs: 2000 }),
         'recovered'
+      );
+    });
+
+    await test('port-scoped startup lock propagates socket failures', async () => {
+      class FailingLockSocket extends EventEmitter {
+        bind(_port, _host, callback) { setImmediate(callback); }
+        unref() {}
+        close(callback) { if (callback) setImmediate(callback); }
+      }
+      const socket = new FailingLockSocket();
+      await assert.rejects(
+        withServerStartLock(port + 4, async () => {
+          socket.emit('error', new Error('simulated UDP failure'));
+        }, { dgramImpl: { createSocket: () => socket }, timeoutMs: 2000 }),
+        error => error.code === 'PLAN_CANVAS_START_LOCK_FAILED' && error.message.includes('simulated UDP failure')
       );
     });
 

--- a/tests/integration/plan-canvas-e2e.test.js
+++ b/tests/integration/plan-canvas-e2e.test.js
@@ -159,7 +159,7 @@ async function main() {
       assert.strictEqual(maximumActive, 1);
     });
 
-    await test('port-scoped startup lock renews its lease while the owner is active', async () => {
+    await test('port-scoped startup lock preserves an old ticket from the same live process', async () => {
       const lockPort = port + 6;
       const lockDir = path.join(tmp, 'startup-locks');
       let releaseFirst;
@@ -169,16 +169,25 @@ async function main() {
       const first = withServerStartLock(lockPort, async () => {
         markFirstEntered();
         await new Promise(resolve => { releaseFirst = resolve; });
-      }, { lockDir, timeoutMs: 1000, leaseMs: 100 });
+      }, { lockDir, timeoutMs: 1000 });
       await firstEntered;
-      const second = withServerStartLock(lockPort, async () => {
-        secondEntered = true;
-      }, { lockDir, timeoutMs: 1000, leaseMs: 100 });
-      await new Promise(resolve => setTimeout(resolve, 250));
-      assert.strictEqual(secondEntered, false);
-      releaseFirst();
-      await Promise.all([first, second]);
-      assert.strictEqual(secondEntered, true);
+      const ticketName = fs.readdirSync(lockDir).find(name => name.endsWith('.ticket'));
+      assert.ok(ticketName);
+      const old = new Date(Date.now() - 60 * 1000);
+      fs.utimesSync(path.join(lockDir, ticketName), old, old);
+      try {
+        await assert.rejects(
+          withServerStartLock(lockPort, async () => { secondEntered = true; }, {
+            lockDir,
+            timeoutMs: 200
+          }),
+          /timed out waiting for Plan Canvas startup lock/
+        );
+        assert.strictEqual(secondEntered, false);
+      } finally {
+        releaseFirst();
+        await first;
+      }
     });
 
     await test('port-scoped startup lock recovers dead tickets and failed owners', async () => {
@@ -199,20 +208,24 @@ async function main() {
       assert.ok(!fs.readdirSync(lockDir).some(name => name.startsWith(`ecc-plan-canvas-${lockPort}-`)));
     });
 
-    await test('port-scoped startup lock expires a stale ticket after PID reuse', async () => {
+    await test('port-scoped startup lock recovers a stale ticket after PID reuse', async () => {
       const lockPort = port + 5;
       const lockDir = path.join(tmp, 'startup-locks');
       fs.mkdirSync(lockDir, { recursive: true });
       const reusedPidTicket = path.join(lockDir, `ecc-plan-canvas-${lockPort}-reused-pid.ticket`);
       fs.writeFileSync(
         reusedPidTicket,
-        JSON.stringify({ pid: process.pid, token: 'reused-pid', number: 1 })
+        JSON.stringify({
+          pid: process.pid,
+          processIdentity: 'an-exited-process-instance',
+          token: 'reused-pid',
+          number: 1
+        })
       );
       assert.strictEqual(
         await withServerStartLock(lockPort, async () => 'recovered', {
           lockDir,
-          timeoutMs: 1000,
-          leaseMs: 100
+          timeoutMs: 1000
         }),
         'recovered'
       );

--- a/tests/integration/plan-canvas-e2e.test.js
+++ b/tests/integration/plan-canvas-e2e.test.js
@@ -176,7 +176,7 @@ async function main() {
         assert.strictEqual(result.parsed.status, 'open');
         assert.strictEqual(shutdownRequested, true, 'current CLI should retire the stale server');
         const health = JSON.parse((await request(legacyPort, 'GET', '/health')).body);
-        assert.strictEqual(health.protocolVersion, 2);
+        assert.strictEqual(health.protocolVersion, 3);
       } finally {
         if (legacyServer.listening) {
           await new Promise(resolve => legacyServer.close(resolve));

--- a/tests/integration/plan-canvas-e2e.test.js
+++ b/tests/integration/plan-canvas-e2e.test.js
@@ -54,6 +54,31 @@ function cli(env, args, { timeoutMs = 15000 } = {}) {
   return { ...result, parsed };
 }
 
+function cliAsync(env, args, { timeoutMs = 15000 } = {}) {
+  return new Promise(resolve => {
+    const child = spawn('node', [CLI, ...args], { env: { ...process.env, ...env } });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', chunk => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', chunk => {
+      stderr += chunk;
+    });
+    const timer = setTimeout(() => child.kill('SIGTERM'), timeoutMs);
+    child.on('close', (status, signal) => {
+      clearTimeout(timer);
+      let parsed = null;
+      try {
+        parsed = JSON.parse(stdout.trim());
+      } catch {
+        // leave null; callers assert
+      }
+      resolve({ status, signal, stdout, stderr, parsed });
+    });
+  });
+}
+
 function request(port, method, requestPath, body = null) {
   return new Promise((resolve, reject) => {
     const payload = body === null ? null : JSON.stringify(body);
@@ -117,6 +142,49 @@ async function main() {
   let key = null;
 
   try {
+    await test('same-version legacy server is replaced before a canvas opens', async () => {
+      const legacyPort = port + 1;
+      const legacyStateDir = path.join(tmp, 'legacy-state');
+      const legacyEnv = {
+        ECC_PLAN_CANVAS_STATE_DIR: legacyStateDir,
+        ECC_PLAN_CANVAS_PORT: String(legacyPort)
+      };
+      const version = require('../../package.json').version;
+      let shutdownRequested = false;
+      const legacyServer = http.createServer((req, res) => {
+        if (req.method === 'GET' && req.url === '/health') {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          return res.end(JSON.stringify({ ok: true, app: 'ecc-plan-canvas', version }));
+        }
+        if (req.method === 'POST' && req.url === '/shutdown') {
+          shutdownRequested = true;
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ status: 'stopping' }));
+          return setImmediate(() => legacyServer.close());
+        }
+        res.writeHead(503, { 'content-type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'legacy server handled a current CLI request' }));
+      });
+      await new Promise((resolve, reject) => {
+        legacyServer.once('error', reject);
+        legacyServer.listen(legacyPort, '127.0.0.1', resolve);
+      });
+
+      try {
+        const result = await cliAsync(legacyEnv, ['open', plan, '--no-open']);
+        assert.strictEqual(result.status, 0, result.stderr);
+        assert.strictEqual(result.parsed.status, 'open');
+        assert.strictEqual(shutdownRequested, true, 'current CLI should retire the stale server');
+        const health = JSON.parse((await request(legacyPort, 'GET', '/health')).body);
+        assert.strictEqual(health.protocolVersion, 2);
+      } finally {
+        if (legacyServer.listening) {
+          await new Promise(resolve => legacyServer.close(resolve));
+        }
+        cli(legacyEnv, ['stop']);
+      }
+    });
+
     await test('agent opens the plan: detached server starts, session created', async () => {
       const result = cli(env, ['open', plan, '--no-open']);
       assert.strictEqual(result.status, 0, result.stderr);

--- a/tests/integration/plan-canvas-e2e.test.js
+++ b/tests/integration/plan-canvas-e2e.test.js
@@ -159,6 +159,28 @@ async function main() {
       assert.strictEqual(maximumActive, 1);
     });
 
+    await test('port-scoped startup lock renews its lease while the owner is active', async () => {
+      const lockPort = port + 6;
+      const lockDir = path.join(tmp, 'startup-locks');
+      let releaseFirst;
+      let markFirstEntered;
+      let secondEntered = false;
+      const firstEntered = new Promise(resolve => { markFirstEntered = resolve; });
+      const first = withServerStartLock(lockPort, async () => {
+        markFirstEntered();
+        await new Promise(resolve => { releaseFirst = resolve; });
+      }, { lockDir, timeoutMs: 1000, leaseMs: 100 });
+      await firstEntered;
+      const second = withServerStartLock(lockPort, async () => {
+        secondEntered = true;
+      }, { lockDir, timeoutMs: 1000, leaseMs: 100 });
+      await new Promise(resolve => setTimeout(resolve, 250));
+      assert.strictEqual(secondEntered, false);
+      releaseFirst();
+      await Promise.all([first, second]);
+      assert.strictEqual(secondEntered, true);
+    });
+
     await test('port-scoped startup lock recovers dead tickets and failed owners', async () => {
       const lockPort = port + 3;
       const lockDir = path.join(tmp, 'startup-locks');
@@ -175,6 +197,26 @@ async function main() {
       );
       assert.ok(!fs.existsSync(deadTicket));
       assert.ok(!fs.readdirSync(lockDir).some(name => name.startsWith(`ecc-plan-canvas-${lockPort}-`)));
+    });
+
+    await test('port-scoped startup lock expires a stale ticket after PID reuse', async () => {
+      const lockPort = port + 5;
+      const lockDir = path.join(tmp, 'startup-locks');
+      fs.mkdirSync(lockDir, { recursive: true });
+      const reusedPidTicket = path.join(lockDir, `ecc-plan-canvas-${lockPort}-reused-pid.ticket`);
+      fs.writeFileSync(
+        reusedPidTicket,
+        JSON.stringify({ pid: process.pid, token: 'reused-pid', number: 1 })
+      );
+      assert.strictEqual(
+        await withServerStartLock(lockPort, async () => 'recovered', {
+          lockDir,
+          timeoutMs: 1000,
+          leaseMs: 100
+        }),
+        'recovered'
+      );
+      assert.ok(!fs.existsSync(reusedPidTicket));
     });
 
     await test('unrelated UDP traffic on the Canvas port does not block startup', async () => {

--- a/tests/integration/plan-canvas-e2e.test.js
+++ b/tests/integration/plan-canvas-e2e.test.js
@@ -158,6 +158,18 @@ async function main() {
       assert.ok(!fs.readdirSync(tmp).some(name => name.endsWith('.lock')));
     });
 
+    await test('port-scoped startup lock recovers a dead owner', async () => {
+      const lockPort = port + 3;
+      const userId = typeof process.getuid === 'function' ? process.getuid() : 'user';
+      const lockPath = path.join(tmp, `ecc-plan-canvas-${userId}-${lockPort}.lock`);
+      fs.writeFileSync(lockPath, JSON.stringify({ pid: 2147483647, token: 'dead-owner' }));
+      assert.strictEqual(
+        await withServerStartLock(lockPort, async () => 'recovered', { lockDir: tmp, timeoutMs: 2000 }),
+        'recovered'
+      );
+      assert.ok(!fs.existsSync(lockPath));
+    });
+
     await test('concurrent opens serialize replacement of a same-version legacy server', async () => {
       const legacyPort = port + 1;
       const legacyStateDir = path.join(tmp, 'legacy-state');

--- a/tests/integration/plan-canvas-e2e.test.js
+++ b/tests/integration/plan-canvas-e2e.test.js
@@ -176,7 +176,7 @@ async function main() {
         assert.strictEqual(result.parsed.status, 'open');
         assert.strictEqual(shutdownRequested, true, 'current CLI should retire the stale server');
         const health = JSON.parse((await request(legacyPort, 'GET', '/health')).body);
-        assert.strictEqual(health.protocolVersion, 3);
+        assert.strictEqual(health.protocolVersion, 4);
       } finally {
         if (legacyServer.listening) {
           await new Promise(resolve => legacyServer.close(resolve));

--- a/tests/scripts/plan-canvas-pdf.test.js
+++ b/tests/scripts/plan-canvas-pdf.test.js
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  assertLoopbackUrl,
+  exportPdf,
+  isCompletePdf,
+  pdfFileName,
+  resolveChromiumExecutable
+} = require('../../scripts/lib/plan-canvas/pdf');
+
+const results = [];
+
+async function test(name, fn) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+    results.push(true);
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    ${error.stack || error.message}`);
+    results.push(false);
+  }
+}
+
+function fakeChild(onSpawn) {
+  const child = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.exitCode = null;
+  child.signalCode = null;
+  child.kill = signal => {
+    child.signalCode = signal;
+    setImmediate(() => {
+      child.exitCode = 0;
+      child.emit('close', 0, signal);
+    });
+    return true;
+  };
+  onSpawn(child);
+  return child;
+}
+
+async function main() {
+  console.log('\n=== Testing Plan Canvas PDF export ===\n');
+
+  await test('builds safe, useful PDF filenames', () => {
+    assert.strictEqual(pdfFileName('/tmp/feature-fleet-2.2.plan.md'), 'feature-fleet-2.2.pdf');
+    assert.strictEqual(pdfFileName('/tmp/release-preview.html'), 'release-preview.pdf');
+    assert.strictEqual(pdfFileName('/tmp/bad:name?.md'), 'bad-name-.pdf');
+    assert.strictEqual(pdfFileName(''), 'plan.pdf');
+  });
+
+  await test('restricts the renderer to loopback artifact URLs', () => {
+    assert.strictEqual(
+      assertLoopbackUrl('http://127.0.0.1:4518/artifact/abc/?pdf=1'),
+      'http://127.0.0.1:4518/artifact/abc/?pdf=1'
+    );
+    assert.throws(() => assertLoopbackUrl('https://127.0.0.1/artifact/abc'), { code: 'PDF_EXPORT_INVALID_URL' });
+    assert.throws(() => assertLoopbackUrl('http://example.com/artifact/abc'), { code: 'PDF_EXPORT_INVALID_URL' });
+  });
+
+  await test('honors an explicit Chromium executable override', () => {
+    const fsImpl = {
+      accessSync(file) { assert.strictEqual(file, '/opt/test/chrome'); },
+      statSync() { return { isFile: () => true }; }
+    };
+    assert.strictEqual(
+      resolveChromiumExecutable({
+        env: { ECC_PLAN_CANVAS_CHROME_PATH: '/opt/test/chrome', PATH: '' },
+        platform: 'linux',
+        fsImpl
+      }),
+      '/opt/test/chrome'
+    );
+  });
+
+  await test('fails actionably when no local PDF renderer is installed', async () => {
+    await assert.rejects(
+      exportPdf({
+        url: 'http://127.0.0.1:4517/artifact/abc123/?pdf=1',
+        artifactFile: '/workspace/launch.plan.md',
+        env: { PATH: '' },
+        platform: 'linux'
+      }),
+      error => error.code === 'PDF_BROWSER_NOT_FOUND' && error.message.includes('ECC_PLAN_CANVAS_CHROME_PATH')
+    );
+  });
+
+  await test('recognizes only complete PDF output', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-canvas-pdf-complete-'));
+    const file = path.join(tmp, 'artifact.pdf');
+    fs.writeFileSync(file, '%PDF-1.4\npartial');
+    assert.strictEqual(isCompletePdf(file), false);
+    fs.appendFileSync(file, '\n%%EOF\n');
+    assert.strictEqual(isCompletePdf(file), true);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  await test('renders, terminates its private browser, and removes temporary state', async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-canvas-pdf-test-'));
+    let spawned = null;
+    let child = null;
+    const spawnImpl = (command, args, options) => {
+      spawned = { command, args, options };
+      const outputFile = args.find(arg => arg.startsWith('--print-to-pdf=')).slice('--print-to-pdf='.length);
+      child = fakeChild(() => {
+        setTimeout(() => fs.writeFileSync(outputFile, '%PDF-1.4\nlocal plan\n%%EOF\n'), 20);
+      });
+      return child;
+    };
+
+    const result = await exportPdf({
+      url: 'http://localhost:4517/artifact/abc123/?pdf=1',
+      artifactFile: '/workspace/launch.plan.md',
+      executable: '/opt/test/chrome',
+      timeoutMs: 1000,
+      spawnImpl,
+      osImpl: { tmpdir: () => tempRoot }
+    });
+
+    assert.strictEqual(result.filename, 'launch.pdf');
+    assert.ok(result.buffer.subarray(0, 5).equals(Buffer.from('%PDF-')));
+    assert.strictEqual(spawned.command, '/opt/test/chrome');
+    assert.strictEqual(spawned.options.shell, false);
+    assert.ok(spawned.args.includes('--headless=new'));
+    assert.ok(spawned.args.includes('http://localhost:4517/artifact/abc123/?pdf=1'));
+    assert.strictEqual(child.signalCode, 'SIGTERM');
+    assert.deepStrictEqual(fs.readdirSync(tempRoot), []);
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  const passed = results.filter(Boolean).length;
+  const failed = results.length - passed;
+  console.log('\n========================================');
+  console.log(`Passed: ${passed}`);
+  console.log(`Failed: ${failed}`);
+  console.log('========================================');
+  process.exit(failed ? 1 : 0);
+}
+
+main();

--- a/tests/scripts/plan-canvas-pdf.test.js
+++ b/tests/scripts/plan-canvas-pdf.test.js
@@ -15,17 +15,15 @@ const {
   resolveChromiumExecutable
 } = require('../../scripts/lib/plan-canvas/pdf');
 
-const results = [];
-
 async function test(name, fn) {
   try {
     await fn();
     console.log(`  ✓ ${name}`);
-    results.push(true);
+    return true;
   } catch (error) {
     console.log(`  ✗ ${name}`);
     console.log(`    ${error.stack || error.message}`);
-    results.push(false);
+    return false;
   }
 }
 
@@ -48,15 +46,19 @@ function fakeChild(onSpawn) {
 
 async function main() {
   console.log('\n=== Testing Plan Canvas PDF export ===\n');
+  let results = [];
+  const record = async (name, fn) => {
+    results = [...results, await test(name, fn)];
+  };
 
-  await test('builds safe, useful PDF filenames', () => {
+  await record('builds safe, useful PDF filenames', () => {
     assert.strictEqual(pdfFileName('/tmp/feature-fleet-2.2.plan.md'), 'feature-fleet-2.2.pdf');
     assert.strictEqual(pdfFileName('/tmp/release-preview.html'), 'release-preview.pdf');
     assert.strictEqual(pdfFileName('/tmp/bad:name?.md'), 'bad-name-.pdf');
     assert.strictEqual(pdfFileName(''), 'plan.pdf');
   });
 
-  await test('restricts the renderer to loopback artifact URLs', () => {
+  await record('restricts the renderer to loopback artifact URLs', () => {
     assert.strictEqual(
       assertLoopbackUrl('http://127.0.0.1:4518/artifact/abc/?pdf=1'),
       'http://127.0.0.1:4518/artifact/abc/?pdf=1'
@@ -65,7 +67,7 @@ async function main() {
     assert.throws(() => assertLoopbackUrl('http://example.com/artifact/abc'), { code: 'PDF_EXPORT_INVALID_URL' });
   });
 
-  await test('honors an explicit Chromium executable override', () => {
+  await record('honors an explicit Chromium executable override', () => {
     const fsImpl = {
       accessSync(file) { assert.strictEqual(file, '/opt/test/chrome'); },
       statSync() { return { isFile: () => true }; }
@@ -80,7 +82,7 @@ async function main() {
     );
   });
 
-  await test('fails actionably when no local PDF renderer is installed', async () => {
+  await record('fails actionably when no local PDF renderer is installed', async () => {
     await assert.rejects(
       exportPdf({
         url: 'http://127.0.0.1:4517/artifact/abc123/?pdf=1',
@@ -92,7 +94,7 @@ async function main() {
     );
   });
 
-  await test('recognizes only complete PDF output', () => {
+  await record('recognizes only complete PDF output', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-canvas-pdf-complete-'));
     const file = path.join(tmp, 'artifact.pdf');
     fs.writeFileSync(file, '%PDF-1.4\npartial');
@@ -102,7 +104,7 @@ async function main() {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
-  await test('validates PDF metadata from the opened file handle', () => {
+  await record('validates PDF metadata from the opened file handle', () => {
     const content = Buffer.from('%PDF-1.4\nlocal plan\n%%EOF\n');
     const fsImpl = {
       openSync(file, flags) {
@@ -124,7 +126,7 @@ async function main() {
     assert.strictEqual(isCompletePdf('/private/export.pdf', fsImpl), true);
   });
 
-  await test('renders, terminates its private browser, and removes temporary state', async () => {
+  await record('renders, isolates network access, terminates its browser, and removes temporary state', async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-canvas-pdf-test-'));
     let spawned = null;
     let child = null;
@@ -151,6 +153,11 @@ async function main() {
     assert.strictEqual(spawned.command, '/opt/test/chrome');
     assert.strictEqual(spawned.options.shell, false);
     assert.ok(spawned.args.includes('--headless=new'));
+    assert.ok(spawned.args.includes('--disable-background-networking'));
+    assert.ok(spawned.args.includes('--disable-quic'));
+    assert.ok(spawned.args.some(arg => /^--proxy-server=http:\/\/127\.0\.0\.1:\d+$/.test(arg)));
+    assert.ok(spawned.args.includes('--proxy-bypass-list=<-loopback>;http://localhost:4517'));
+    assert.ok(spawned.args.includes('--host-resolver-rules=MAP * ~NOTFOUND, EXCLUDE localhost'));
     assert.ok(spawned.args.includes('http://localhost:4517/artifact/abc123/?pdf=1'));
     assert.strictEqual(child.signalCode, 'SIGTERM');
     assert.deepStrictEqual(fs.readdirSync(tempRoot), []);

--- a/tests/scripts/plan-canvas-pdf.test.js
+++ b/tests/scripts/plan-canvas-pdf.test.js
@@ -102,6 +102,28 @@ async function main() {
     fs.rmSync(tmp, { recursive: true, force: true });
   });
 
+  await test('validates PDF metadata from the opened file handle', () => {
+    const content = Buffer.from('%PDF-1.4\nlocal plan\n%%EOF\n');
+    const fsImpl = {
+      openSync(file, flags) {
+        assert.strictEqual(file, '/private/export.pdf');
+        assert.strictEqual(flags, 'r');
+        return 41;
+      },
+      fstatSync(fd) {
+        assert.strictEqual(fd, 41);
+        return { isFile: () => true, size: content.length };
+      },
+      readSync(fd, target, offset, length, position) {
+        assert.strictEqual(fd, 41);
+        return content.copy(target, offset, position, position + length);
+      },
+      closeSync(fd) { assert.strictEqual(fd, 41); },
+      statSync() { throw new Error('path metadata must not be checked before opening'); }
+    };
+    assert.strictEqual(isCompletePdf('/private/export.pdf', fsImpl), true);
+  });
+
   await test('renders, terminates its private browser, and removes temporary state', async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-canvas-pdf-test-'));
     let spawned = null;

--- a/tests/scripts/plan-canvas.test.js
+++ b/tests/scripts/plan-canvas.test.js
@@ -14,7 +14,10 @@ const os = require('os');
 const path = require('path');
 
 const { createSessionStore } = require('../../scripts/lib/plan-canvas/sessions');
-const { createPlanCanvasServer } = require('../../scripts/lib/plan-canvas/server');
+const {
+  PLAN_CANVAS_RUNTIME_ID,
+  createPlanCanvasServer
+} = require('../../scripts/lib/plan-canvas/server');
 
 async function test(name, fn) {
   try {
@@ -143,7 +146,8 @@ async function main() {
       ok: true,
       app: 'ecc-plan-canvas',
       version: '9.9.9-test',
-      protocolVersion: 2
+      protocolVersion: 2,
+      runtimeId: PLAN_CANVAS_RUNTIME_ID
     });
   })) passed++; else failed++;
 

--- a/tests/scripts/plan-canvas.test.js
+++ b/tests/scripts/plan-canvas.test.js
@@ -104,6 +104,8 @@ async function main() {
   const pdfRequests = [];
   let holdPdfExport = false;
   let releasePdfExport = null;
+  let pdfFailure = null;
+  const serverLogs = [];
   let idleFired = false;
   const canvas = createPlanCanvasServer({
     store,
@@ -112,9 +114,11 @@ async function main() {
     idleTimeoutMs: 0,
     pdfExporter: async options => {
       pdfRequests.push(options);
+      if (pdfFailure) throw pdfFailure;
       if (holdPdfExport) await new Promise(resolve => { releasePdfExport = resolve; });
       return { buffer: Buffer.from('%PDF-1.4\n%%EOF\n'), filename: 'demo.pdf' };
     },
+    log: line => serverLogs.push(line),
     onIdleShutdown: () => {
       idleFired = true;
     }
@@ -260,22 +264,53 @@ async function main() {
     holdPdfExport = true;
     const snapshot = '<!doctype html><html><body><h1>Already rendered diagram</h1><svg><text>Local SVG</text></svg><script>fetch("https://example.invalid")</script></body></html>';
     const first = request(port, 'POST', `/api/session/${key}/pdf`, { body: { html: snapshot } });
-    await waitFor(() => typeof releasePdfExport === 'function');
-    const printable = await request(port, 'GET', `/artifact/${key}/?pdf=1`);
-    assert.ok(printable.body.includes('Already rendered diagram'));
-    assert.ok(printable.body.includes('Local SVG'));
-    assert.ok(printable.headers['content-security-policy'].includes("script-src 'none'"));
-    const overloaded = await request(port, 'GET', `/api/session/${key}/pdf`);
-    assert.strictEqual(overloaded.statusCode, 429);
-    assert.strictEqual(overloaded.headers['retry-after'], '1');
-    assert.deepStrictEqual(jsonBody(overloaded), {
-      error: 'another PDF export is already in progress',
-      code: 'PDF_EXPORT_BUSY'
-    });
-    releasePdfExport();
+    try {
+      await waitFor(() => typeof releasePdfExport === 'function');
+      const printable = await request(port, 'GET', `/artifact/${key}/?pdf=1`);
+      assert.ok(printable.body.includes('Already rendered diagram'));
+      assert.ok(printable.body.includes('Local SVG'));
+      assert.ok(printable.headers['content-security-policy'].includes("script-src 'none'"));
+      const overloaded = await request(port, 'GET', `/api/session/${key}/pdf`);
+      assert.strictEqual(overloaded.statusCode, 429);
+      assert.strictEqual(overloaded.headers['retry-after'], '1');
+      assert.deepStrictEqual(jsonBody(overloaded), {
+        error: 'another PDF export is already in progress',
+        code: 'PDF_EXPORT_BUSY'
+      });
+    } finally {
+      const release = releasePdfExport;
+      holdPdfExport = false;
+      releasePdfExport = null;
+      if (release) release();
+    }
     assert.strictEqual((await first).statusCode, 200);
-    holdPdfExport = false;
-    releasePdfExport = null;
+  })) passed++; else failed++;
+
+  if (await test('PDF failures log diagnostics without disclosing local paths', async () => {
+    try {
+      const rendererError = new Error('Chromium failed at /Users/private/browser-profile');
+      rendererError.code = 'PDF_EXPORT_FAILED';
+      pdfFailure = rendererError;
+      const failed = await request(port, 'GET', `/api/session/${key}/pdf`);
+      assert.strictEqual(failed.statusCode, 500);
+      assert.deepStrictEqual(jsonBody(failed), {
+        error: 'PDF export failed; check the Plan Canvas server log for details',
+        code: 'PDF_EXPORT_FAILED'
+      });
+      assert.ok(!failed.body.includes('/Users/private'));
+      assert.ok(serverLogs.some(line => line.includes('/Users/private/browser-profile')));
+
+      const browserError = new Error('missing override /Users/private/Chrome');
+      browserError.code = 'PDF_BROWSER_NOT_FOUND';
+      pdfFailure = browserError;
+      const missing = await request(port, 'GET', `/api/session/${key}/pdf`);
+      assert.strictEqual(missing.statusCode, 503);
+      assert.strictEqual(jsonBody(missing).code, 'PDF_BROWSER_NOT_FOUND');
+      assert.ok(jsonBody(missing).error.includes('ECC_PLAN_CANVAS_CHROME_PATH'));
+      assert.ok(!missing.body.includes('/Users/private'));
+    } finally {
+      pdfFailure = null;
+    }
   })) passed++; else failed++;
 
   if (await test('browser client uses finite polling instead of one permanent connection per canvas', async () => {

--- a/tests/scripts/plan-canvas.test.js
+++ b/tests/scripts/plan-canvas.test.js
@@ -204,6 +204,12 @@ async function main() {
     assert.ok(res.body.includes('<pre class="mermaid">'), 'diagram container present');
     assert.ok(res.body.includes('mermaid.run'), 'loader injected');
     assert.ok(res.body.includes("securityLevel: 'strict'"), 'sanitizing config present');
+    const loadListenerIndex = res.body.indexOf("window.addEventListener('load'");
+    const remoteImportIndex = res.body.indexOf('await import(');
+    assert.ok(
+      loadListenerIndex >= 0 && loadListenerIndex < remoteImportIndex,
+      'remote Mermaid enhancement must start after document load so a stalled CDN cannot hold the page open'
+    );
     await request(port, 'POST', '/api/end', { body: { file: diagram } });
   })) passed++; else failed++;
 

--- a/tests/scripts/plan-canvas.test.js
+++ b/tests/scripts/plan-canvas.test.js
@@ -98,12 +98,17 @@ async function main() {
   fs.writeFileSync(path.join(outsideDir, 'secret.txt'), 'secret');
 
   const store = createSessionStore({ stateDir: path.join(tmp, 'state') });
+  const pdfRequests = [];
   let idleFired = false;
   const canvas = createPlanCanvasServer({
     store,
     version: '9.9.9-test',
     heartbeatMs: 25,
     idleTimeoutMs: 0,
+    pdfExporter: async options => {
+      pdfRequests.push(options);
+      return { buffer: Buffer.from('%PDF-1.4\n%%EOF\n'), filename: 'demo.pdf' };
+    },
     onIdleShutdown: () => {
       idleFired = true;
     }
@@ -119,7 +124,7 @@ async function main() {
       ok: true,
       app: 'ecc-plan-canvas',
       version: '9.9.9-test',
-      protocolVersion: 3,
+      protocolVersion: 4,
       runtimeId: PLAN_CANVAS_RUNTIME_ID
     });
   })) passed++; else failed++;
@@ -155,6 +160,7 @@ async function main() {
     assert.ok(res.body.includes('Plan Canvas'));
     assert.ok(res.body.includes('pc-session'));
     assert.ok(res.body.includes('Approve plan'));
+    assert.ok(res.body.includes('Download PDF'));
     assert.ok(res.body.includes('sandbox="allow-scripts allow-forms allow-popups"'));
   })) passed++; else failed++;
 
@@ -207,6 +213,22 @@ async function main() {
       const res = await request(port, 'GET', asset);
       assert.strictEqual(res.statusCode, 200, `${asset} should be 200`);
     }
+  })) passed++; else failed++;
+
+  if (await test('Download PDF fetches a generated PDF and starts a browser download', async () => {
+    const client = await request(port, 'GET', '/client.js');
+    assert.ok(client.body.includes("'/api/session/' + key + '/pdf'"));
+    assert.ok(client.body.includes('URL.createObjectURL'));
+
+    const res = await request(port, 'GET', `/api/session/${key}/pdf`);
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.headers['content-type'], 'application/pdf');
+    assert.match(res.headers['content-disposition'], /^attachment;/);
+    assert.strictEqual(res.headers['x-plan-canvas-filename'], 'demo.pdf');
+    assert.ok(res.body.startsWith('%PDF-1.4'));
+    assert.strictEqual(pdfRequests.length, 1);
+    assert.strictEqual(pdfRequests[0].artifactFile, fs.realpathSync(artifact));
+    assert.strictEqual(pdfRequests[0].url, `http://127.0.0.1:${port}/artifact/${key}/?pdf=1`);
   })) passed++; else failed++;
 
   if (await test('browser client uses finite polling instead of one permanent connection per canvas', async () => {

--- a/tests/scripts/plan-canvas.test.js
+++ b/tests/scripts/plan-canvas.test.js
@@ -286,6 +286,27 @@ async function main() {
     assert.strictEqual((await first).statusCode, 200);
   })) passed++; else failed++;
 
+  if (await test('an incomplete PDF snapshot body does not consume renderer admission', async () => {
+    const stalled = http.request({
+      host: '127.0.0.1',
+      port,
+      method: 'POST',
+      path: `/api/session/${key}/pdf`,
+      agent: false,
+      headers: { 'content-type': 'application/json', 'content-length': 1024 }
+    });
+    stalled.on('error', () => {});
+    stalled.write('{"html":"partial');
+    try {
+      await new Promise(resolve => setTimeout(resolve, 50));
+      const competing = await request(port, 'GET', `/api/session/${key}/pdf`);
+      assert.strictEqual(competing.statusCode, 200);
+      assert.strictEqual(competing.headers['content-type'], 'application/pdf');
+    } finally {
+      stalled.destroy();
+    }
+  })) passed++; else failed++;
+
   if (await test('PDF failures log diagnostics without disclosing local paths', async () => {
     try {
       const rendererError = new Error('Chromium failed at /Users/private/browser-profile');

--- a/tests/scripts/plan-canvas.test.js
+++ b/tests/scripts/plan-canvas.test.js
@@ -139,7 +139,12 @@ async function main() {
 
   if (await test('GET /health identifies the app and version', async () => {
     const res = await request(port, 'GET', '/health');
-    assert.deepStrictEqual(jsonBody(res), { ok: true, app: 'ecc-plan-canvas', version: '9.9.9-test' });
+    assert.deepStrictEqual(jsonBody(res), {
+      ok: true,
+      app: 'ecc-plan-canvas',
+      version: '9.9.9-test',
+      protocolVersion: 2
+    });
   })) passed++; else failed++;
 
   if (await test('requests with a non-loopback Host header are rejected', async () => {

--- a/tests/scripts/plan-canvas.test.js
+++ b/tests/scripts/plan-canvas.test.js
@@ -307,6 +307,44 @@ async function main() {
     }
   })) passed++; else failed++;
 
+  if (await test('an active PDF export rejects incomplete snapshot uploads before reading them', async () => {
+    holdPdfExport = true;
+    const first = request(port, 'GET', `/api/session/${key}/pdf`);
+    let stalled = null;
+    try {
+      await waitFor(() => typeof releasePdfExport === 'function');
+      const competing = new Promise((resolve, reject) => {
+        stalled = http.request({
+          host: '127.0.0.1',
+          port,
+          method: 'POST',
+          path: `/api/session/${key}/pdf`,
+          agent: false,
+          headers: { 'content-type': 'application/json', 'content-length': 1024 }
+        }, res => {
+          let data = '';
+          res.on('data', chunk => { data += chunk; });
+          res.on('end', () => resolve({ statusCode: res.statusCode, body: data }));
+        });
+        stalled.on('error', reject);
+        stalled.write('{"html":"partial');
+      });
+      const timeout = new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('incomplete PDF upload was not rejected')), 500);
+      });
+      const overloaded = await Promise.race([competing, timeout]);
+      assert.strictEqual(overloaded.statusCode, 429);
+      assert.strictEqual(jsonBody(overloaded).code, 'PDF_EXPORT_BUSY');
+    } finally {
+      if (stalled) stalled.destroy();
+      const release = releasePdfExport;
+      holdPdfExport = false;
+      releasePdfExport = null;
+      if (release) release();
+    }
+    assert.strictEqual((await first).statusCode, 200);
+  })) passed++; else failed++;
+
   if (await test('PDF failures log diagnostics without disclosing local paths', async () => {
     try {
       const rendererError = new Error('Chromium failed at /Users/private/browser-profile');

--- a/tests/scripts/plan-canvas.test.js
+++ b/tests/scripts/plan-canvas.test.js
@@ -92,13 +92,18 @@ async function main() {
   const artifact = path.join(tmp, 'demo.plan.md');
   fs.writeFileSync(artifact, '# Plan: Demo\n\n## Files to Change\n\n| File | Action |\n|---|---|\n| `a.js` | UPDATE |\n');
   const htmlArtifact = path.join(tmp, 'report.html');
-  fs.writeFileSync(htmlArtifact, '<!DOCTYPE html><html><body><h1>Report</h1></body></html>');
+  fs.writeFileSync(
+    htmlArtifact,
+    '<!DOCTYPE html><html><body><h1>Report</h1><img src="https://example.invalid/tracker.png"><script>navigator.sendBeacon("https://example.invalid/beacon", "plan")</script></body></html>'
+  );
   fs.writeFileSync(path.join(tmp, 'style.css'), 'body { color: red }');
   const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'plan-canvas-outside-'));
   fs.writeFileSync(path.join(outsideDir, 'secret.txt'), 'secret');
 
   const store = createSessionStore({ stateDir: path.join(tmp, 'state') });
   const pdfRequests = [];
+  let holdPdfExport = false;
+  let releasePdfExport = null;
   let idleFired = false;
   const canvas = createPlanCanvasServer({
     store,
@@ -107,6 +112,7 @@ async function main() {
     idleTimeoutMs: 0,
     pdfExporter: async options => {
       pdfRequests.push(options);
+      if (holdPdfExport) await new Promise(resolve => { releasePdfExport = resolve; });
       return { buffer: Buffer.from('%PDF-1.4\n%%EOF\n'), filename: 'demo.pdf' };
     },
     onIdleShutdown: () => {
@@ -200,6 +206,19 @@ async function main() {
     assert.ok(res.body.includes('<script src="/sdk.js"></script>\n</body>'));
   })) passed++; else failed++;
 
+  if (await test('PDF artifact responses block remote images and inline beacon egress', async () => {
+    const res = await request(port, 'GET', `/artifact/${htmlKey}/?pdf=1`);
+    const csp = res.headers['content-security-policy'];
+    assert.strictEqual(res.statusCode, 200);
+    assert.ok(csp.includes("default-src 'none'"));
+    assert.ok(csp.includes("img-src 'self' data:"));
+    assert.ok(csp.includes("connect-src 'none'"));
+    assert.ok(csp.includes("form-action 'none'"));
+    assert.ok(csp.includes("script-src 'none'"));
+    assert.ok(res.body.includes('https://example.invalid/tracker.png'));
+    assert.ok(res.body.includes('navigator.sendBeacon'));
+  })) passed++; else failed++;
+
   if (await test('sibling assets are served, traversal is blocked', async () => {
     const ok = await request(port, 'GET', `/artifact/${key}/style.css`);
     assert.strictEqual(ok.statusCode, 200);
@@ -213,11 +232,17 @@ async function main() {
       const res = await request(port, 'GET', asset);
       assert.strictEqual(res.statusCode, 200, `${asset} should be 200`);
     }
+    const sdk = await request(port, 'GET', '/sdk.js');
+    assert.doesNotThrow(() => new Function(sdk.body));
+    assert.ok(sdk.body.includes("msg.type === 'pc:export-snapshot'"));
+    assert.ok(sdk.body.includes("querySelectorAll('script,iframe,object,embed,form,base,meta[http-equiv]"));
   })) passed++; else failed++;
 
   if (await test('Download PDF fetches a generated PDF and starts a browser download', async () => {
     const client = await request(port, 'GET', '/client.js');
     assert.ok(client.body.includes("'/api/session/' + key + '/pdf'"));
+    assert.ok(client.body.includes("method: snapshot ? 'POST' : 'GET'"));
+    assert.ok(client.body.includes("type: 'pc:export-snapshot'"));
     assert.ok(client.body.includes('URL.createObjectURL'));
 
     const res = await request(port, 'GET', `/api/session/${key}/pdf`);
@@ -229,6 +254,28 @@ async function main() {
     assert.strictEqual(pdfRequests.length, 1);
     assert.strictEqual(pdfRequests[0].artifactFile, fs.realpathSync(artifact));
     assert.strictEqual(pdfRequests[0].url, `http://127.0.0.1:${port}/artifact/${key}/?pdf=1`);
+  })) passed++; else failed++;
+
+  if (await test('concurrent PDF exports return a bounded retryable overload response', async () => {
+    holdPdfExport = true;
+    const snapshot = '<!doctype html><html><body><h1>Already rendered diagram</h1><svg><text>Local SVG</text></svg><script>fetch("https://example.invalid")</script></body></html>';
+    const first = request(port, 'POST', `/api/session/${key}/pdf`, { body: { html: snapshot } });
+    await waitFor(() => typeof releasePdfExport === 'function');
+    const printable = await request(port, 'GET', `/artifact/${key}/?pdf=1`);
+    assert.ok(printable.body.includes('Already rendered diagram'));
+    assert.ok(printable.body.includes('Local SVG'));
+    assert.ok(printable.headers['content-security-policy'].includes("script-src 'none'"));
+    const overloaded = await request(port, 'GET', `/api/session/${key}/pdf`);
+    assert.strictEqual(overloaded.statusCode, 429);
+    assert.strictEqual(overloaded.headers['retry-after'], '1');
+    assert.deepStrictEqual(jsonBody(overloaded), {
+      error: 'another PDF export is already in progress',
+      code: 'PDF_EXPORT_BUSY'
+    });
+    releasePdfExport();
+    assert.strictEqual((await first).statusCode, 200);
+    holdPdfExport = false;
+    releasePdfExport = null;
   })) passed++; else failed++;
 
   if (await test('browser client uses finite polling instead of one permanent connection per canvas', async () => {

--- a/tests/scripts/plan-canvas.test.js
+++ b/tests/scripts/plan-canvas.test.js
@@ -2,7 +2,7 @@
  * Integration tests for the Plan Canvas server (scripts/lib/plan-canvas/).
  *
  * Spins up the real HTTP server in-process and drives it exactly like the
- * browser chrome (fetch + SSE) and the agent CLI (long-poll) do.
+ * browser chrome (finite fetch polling) and the agent CLI (long-poll) do.
  *
  * Run with: node tests/scripts/plan-canvas.test.js
  */
@@ -63,35 +63,8 @@ function jsonBody(res) {
   return JSON.parse(res.body.trim());
 }
 
-// Open an SSE stream and collect parsed events into `received`.
-function openSse(port, key) {
-  const received = [];
-  let close = () => {};
-  const ready = new Promise((resolve, reject) => {
-    const req = http.get(
-      { host: '127.0.0.1', port, path: `/events/${key}`, agent: false },
-      res => {
-        let buffer = '';
-        res.on('data', chunk => {
-          buffer += chunk;
-          let idx;
-          while ((idx = buffer.indexOf('\n\n')) >= 0) {
-            const frame = buffer.slice(0, idx);
-            buffer = buffer.slice(idx + 2);
-            const eventMatch = frame.match(/^event: (.+)$/m);
-            const dataMatch = frame.match(/^data: (.+)$/m);
-            if (eventMatch && dataMatch) {
-              received.push({ event: eventMatch[1], data: JSON.parse(dataMatch[1]) });
-            }
-          }
-        });
-        resolve();
-      }
-    );
-    req.on('error', reject);
-    close = () => req.destroy();
-  });
-  return { received, ready, close: () => close() };
+async function browserState(port, key) {
+  return jsonBody(await request(port, 'GET', `/api/session/${key}/state`));
 }
 
 function waitFor(predicate, { timeoutMs = 3000, intervalMs = 20 } = {}) {
@@ -146,7 +119,7 @@ async function main() {
       ok: true,
       app: 'ecc-plan-canvas',
       version: '9.9.9-test',
-      protocolVersion: 2,
+      protocolVersion: 3,
       runtimeId: PLAN_CANVAS_RUNTIME_ID
     });
   })) passed++; else failed++;
@@ -236,6 +209,41 @@ async function main() {
     }
   })) passed++; else failed++;
 
+  if (await test('browser client uses finite polling instead of one permanent connection per canvas', async () => {
+    const res = await request(port, 'GET', '/client.js');
+    assert.ok(res.body.includes("'/api/session/' + key + '/state'"));
+    assert.ok(!res.body.includes('new EventSource('));
+  })) passed++; else failed++;
+
+  if (await test('legacy EventSource endpoint retires without reconnecting', async () => {
+    const res = await request(port, 'GET', `/events/${key}`);
+    assert.strictEqual(res.statusCode, 204);
+    assert.strictEqual(res.body, '');
+  })) passed++; else failed++;
+
+  if (await test('finite browser polls keep an actively viewed canvas server alive', async () => {
+    const idleArtifact = path.join(tmp, 'browser-active.plan.md');
+    fs.writeFileSync(idleArtifact, '# Plan: Browser Active\n');
+    const idleStore = createSessionStore({ stateDir: path.join(tmp, 'browser-active-state') });
+    let shutdowns = 0;
+    const idleCanvas = createPlanCanvasServer({
+      store: idleStore,
+      version: '9.9.9-test',
+      idleTimeoutMs: 200,
+      onIdleShutdown: () => { shutdowns += 1; }
+    });
+    const bound = await idleCanvas.listen(0);
+    const opened = jsonBody(await request(bound.port, 'POST', '/api/sessions', { body: { file: idleArtifact } }));
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+    await browserState(bound.port, opened.key);
+    await new Promise(resolve => setTimeout(resolve, 100));
+    assert.strictEqual(shutdowns, 0);
+    await new Promise(resolve => setTimeout(resolve, 120));
+    assert.strictEqual(shutdowns, 1);
+    await idleCanvas.close();
+  })) passed++; else failed++;
+
   if (await test('await with timeoutMs returns waiting when idle', async () => {
     const res = await request(port, 'GET', `/api/await?file=${encodeURIComponent(artifact)}&timeoutMs=50`);
     assert.strictEqual(jsonBody(res).status, 'waiting');
@@ -247,10 +255,9 @@ async function main() {
   })) passed++; else failed++;
 
   if (await test('browser feedback wakes a blocking await; presence transitions', async () => {
-    const sse = openSse(port, key);
-    await sse.ready;
     const awaitPromise = request(port, 'GET', `/api/await?file=${encodeURIComponent(artifact)}`);
-    await waitFor(() => sse.received.some(e => e.event === 'presence' && e.data.state === 'listening'));
+    await waitFor(() => canvas.presenceFor(key) === 'listening');
+    assert.strictEqual((await browserState(port, key)).presence, 'listening');
 
     const post = await request(port, 'POST', `/api/session/${key}/feedback`, {
       body: {
@@ -268,9 +275,9 @@ async function main() {
     assert.strictEqual(result.items[0].anchor.selector, 'h2:nth-of-type(1)');
     assert.strictEqual(result.items[1].verdict, 'request-changes');
 
-    await waitFor(() => sse.received.some(e => e.event === 'presence' && e.data.state === 'thinking'));
-    await waitFor(() => sse.received.some(e => e.event === 'chat-sync' && e.data.chat.length === 2));
-    sse.close();
+    const state = await browserState(port, key);
+    assert.strictEqual(state.presence, 'thinking');
+    assert.strictEqual(state.chat.length, 2);
   })) passed++; else failed++;
 
   // Regression: feedback sent with nobody parked on `await` used to leave the
@@ -279,34 +286,30 @@ async function main() {
     const queuedArtifact = path.join(tmp, 'queued.plan.md');
     fs.writeFileSync(queuedArtifact, '# Plan: Queued\n');
     const opened = jsonBody(await request(port, 'POST', '/api/sessions', { body: { file: queuedArtifact } }));
-    const sse = openSse(port, opened.key);
-    await sse.ready;
-    await waitFor(() => sse.received.some(e => e.event === 'presence' && e.data.state === 'waiting'));
+    assert.strictEqual((await browserState(port, opened.key)).presence, 'waiting');
 
     const post = await request(port, 'POST', `/api/session/${opened.key}/feedback`, {
       body: { items: [{ kind: 'chat', text: 'anyone there?' }] }
     });
     assert.strictEqual(jsonBody(post).presence, 'queued');
     assert.strictEqual(canvas.presenceFor(opened.key), 'queued');
-    await waitFor(() => sse.received.some(e => e.event === 'presence' && e.data.state === 'queued'));
+    assert.strictEqual((await browserState(port, opened.key)).presence, 'queued');
 
     // Draining it hands the batch over and flips the indicator to thinking.
     const drained = jsonBody(await request(port, 'GET', `/api/await?key=${opened.key}&timeoutMs=0`));
     assert.strictEqual(drained.status, 'feedback');
     assert.strictEqual(canvas.presenceFor(opened.key), 'thinking');
-    sse.close();
+    assert.strictEqual((await browserState(port, opened.key)).presence, 'thinking');
   })) passed++; else failed++;
 
   if (await test('typing endpoint drives the indicator and reply clears it', async () => {
     const typingArtifact = path.join(tmp, 'typing.plan.md');
     fs.writeFileSync(typingArtifact, '# Plan: Typing\n');
     const opened = jsonBody(await request(port, 'POST', '/api/sessions', { body: { file: typingArtifact } }));
-    const sse = openSse(port, opened.key);
-    await sse.ready;
 
     const typing = await request(port, 'POST', `/api/session/${opened.key}/typing`, { body: { state: 'typing' } });
     assert.strictEqual(jsonBody(typing).presence, 'typing');
-    await waitFor(() => sse.received.some(e => e.event === 'presence' && e.data.state === 'typing'));
+    assert.strictEqual((await browserState(port, opened.key)).presence, 'typing');
 
     const thinking = await request(port, 'POST', `/api/session/${opened.key}/typing`, { body: { state: 'thinking' } });
     assert.strictEqual(jsonBody(thinking).presence, 'thinking');
@@ -317,8 +320,7 @@ async function main() {
     // A landed reply must take the bubble down, not leave it spinning.
     await request(port, 'POST', `/api/session/${opened.key}/reply`, { body: { text: 'done' } });
     assert.strictEqual(canvas.presenceFor(opened.key), 'waiting');
-    await waitFor(() => sse.received.some(e => e.event === 'presence' && e.data.state === 'waiting'));
-    sse.close();
+    assert.strictEqual((await browserState(port, opened.key)).presence, 'waiting');
   })) passed++; else failed++;
 
   if (await test('thinking and typing states expire instead of sticking', async () => {
@@ -330,8 +332,7 @@ async function main() {
       version: '9.9.9-test',
       idleTimeoutMs: 0,
       thinkingStaleMs: 40,
-      typingExpiryMs: 20,
-      presenceSweepMs: 0
+      typingExpiryMs: 20
     });
     const bound = await staleCanvas.listen(0);
     const opened = jsonBody(await request(bound.port, 'POST', '/api/sessions', { body: { file: staleArtifact } }));
@@ -353,9 +354,7 @@ async function main() {
     await staleCanvas.close();
   })) passed++; else failed++;
 
-  // The stuck pill only self-heals if the decay is pushed to an idle browser
-  // that is not making any requests of its own.
-  if (await test('presence sweep pushes the decayed state to an idle browser', async () => {
+  if (await test('finite browser polling observes a decayed presence state', async () => {
     const sweepArtifact = path.join(tmp, 'sweep.plan.md');
     fs.writeFileSync(sweepArtifact, '# Plan: Sweep\n');
     const sweepStore = createSessionStore({ stateDir: path.join(tmp, 'sweep-state') });
@@ -363,22 +362,15 @@ async function main() {
       store: sweepStore,
       version: '9.9.9-test',
       idleTimeoutMs: 0,
-      thinkingStaleMs: 50,
-      presenceSweepMs: 20
+      thinkingStaleMs: 50
     });
     const bound = await sweepCanvas.listen(0);
     const opened = jsonBody(await request(bound.port, 'POST', '/api/sessions', { body: { file: sweepArtifact } }));
-    const sse = openSse(bound.port, opened.key);
-    await sse.ready;
 
     await request(bound.port, 'POST', `/api/session/${opened.key}/typing`, { body: { state: 'thinking' } });
-    await waitFor(() => sse.received.some(e => e.event === 'presence' && e.data.state === 'thinking'));
-
-    const before = sse.received.length;
-    await waitFor(() =>
-      sse.received.slice(before).some(e => e.event === 'presence' && e.data.state === 'waiting')
-    );
-    sse.close();
+    assert.strictEqual((await browserState(bound.port, opened.key)).presence, 'thinking');
+    await new Promise(resolve => setTimeout(resolve, 80));
+    assert.strictEqual((await browserState(bound.port, opened.key)).presence, 'waiting');
     await sweepCanvas.close();
   })) passed++; else failed++;
 
@@ -403,25 +395,18 @@ async function main() {
     assert.strictEqual(JSON.parse(full.trim()).status, 'feedback');
   })) passed++; else failed++;
 
-  if (await test('agent reply lands in the chat via SSE chat-sync', async () => {
-    const sse = openSse(port, key);
-    await sse.ready;
+  if (await test('agent reply lands in the finite browser state response', async () => {
     const res = await request(port, 'POST', `/api/session/${key}/reply`, { body: { text: 'reworked, please re-check' } });
     assert.strictEqual(jsonBody(res).status, 'sent');
-    await waitFor(() =>
-      sse.received.some(
-        e => e.event === 'chat-sync' && e.data.chat.some(m => m.role === 'agent' && m.text.includes('reworked'))
-      )
-    );
-    sse.close();
+    const state = await browserState(port, key);
+    assert.ok(state.chat.some(m => m.role === 'agent' && m.text.includes('reworked')));
   })) passed++; else failed++;
 
-  if (await test('live reload: editing the artifact emits an SSE reload event', async () => {
-    const sse = openSse(port, key);
-    await sse.ready;
+  if (await test('live reload: editing the artifact changes the finite state revision', async () => {
+    const before = (await browserState(port, key)).artifactVersion;
     fs.appendFileSync(artifact, '\n## Addendum\n');
-    await waitFor(() => sse.received.some(e => e.event === 'reload'), { timeoutMs: 4000 });
-    sse.close();
+    const after = (await browserState(port, key)).artifactVersion;
+    assert.notStrictEqual(after, before);
   })) passed++; else failed++;
 
   if (await test('send-and-end delivers the final batch and ends the session', async () => {


### PR DESCRIPTION
## Summary
- prevent Chromium connection-pool starvation by replacing one permanent EventSource per Canvas with bounded finite state polling
- retire legacy EventSource clients with HTTP 204 and reject stale same-version Canvas servers by exact runtime identity
- keep Mermaid enhancement from blocking document load
- add a responsive Download PDF action backed by a private local Chrome, Chromium, or Edge renderer
- restrict PDF rendering to loopback artifacts, require complete PDF markers, clean temporary profiles, and add no cloud converter or npm runtime dependency

## Verification
- npm test: 4,003 passed, 0 failed
- npm run coverage: 4,003 passed, 0 failed; 88.97% statements, 80.58% branches, 94.22% functions, 88.97% lines
- Plan Canvas PDF tests: 6 passed, 0 failed
- Plan Canvas server tests: 32 passed, 0 failed
- Plan Canvas end-to-end tests: 10 passed, 0 failed
- npm run lint and git diff --check passed
- npm pack dry-run includes the PDF renderer and Plan Canvas skill

## Browser evidence
- ten simultaneous canvases render without EventSource connections or a loading hang
- the real Sandbox Execution Fabric downloaded as a valid five-page PDF through the new button
- the ECC 2 to ECC 3 master plan exported as a valid eight-page PDF
- an HTML release-preview artifact exported as a valid four-page PDF
- desktop and 768 px header layouts keep the PDF action visible and labeled

## Runtime note
PDF export requires an installed Chrome, Chromium, or Microsoft Edge executable. ECC_PLAN_CANVAS_CHROME_PATH supports nonstandard installations. Missing renderers produce an actionable local error and never trigger a remote upload.