### PR TITLE
fix(hooks): block-no-verify no longer false-positives on quoted text

### DIFF
--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -285,13 +285,117 @@ function isInComment(input, idx) {
 }
 
 /**
- * Find the next 'git' token in the input starting from a position.
+ * Shell built-ins/interpreters that re-execute a quoted string as code
+ * (`bash -c '...'`, `eval "..."`, etc.). A `git ...` phrase found inside a
+ * quoted span whose preceding word is NOT one of these is just string data —
+ * e.g. an `echo` message, a heredoc, a JSON test fixture — not a real
+ * invocation, and must not be treated as one.
  */
-function findGit(input, start) {
+const QUOTE_EXEC_COMMANDS = new Set(['eval', 'bash', 'sh', 'zsh', 'ksh', 'dash', 'source', '.', 'exec']);
+
+/**
+ * Find every top-level (non-nested — shell quotes don't nest) quoted span in
+ * the input, tracking quote state from index 0 so a quote opened at the very
+ * start of the command (e.g. `echo '...'`) is honored for matches found deep
+ * inside it.
+ */
+function computeQuoteSpans(input) {
+  const spans = [];
+  let quote = null;
+  let spanStart = null;
+  let escaped = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input.charAt(i);
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (quote) {
+      if (quote === '"' && char === '\\') {
+        escaped = true;
+        continue;
+      }
+      if (char === quote) {
+        spans.push({ start: spanStart, end: i + 1 });
+        quote = null;
+        spanStart = null;
+      }
+      continue;
+    }
+
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      spanStart = i;
+    }
+  }
+
+  return spans;
+}
+
+/**
+ * Whether a quoted span is the string argument to an exec-style command, e.g.
+ * `bash -c '...'`, `sh -lc "..."`, `eval "..."`. Walks backward over
+ * whitespace-delimited words, skipping flags (`-c`, `-lc`, ...), until it
+ * finds the command name or hits a command delimiter (`;`, `&`, `|`, `(`,
+ * newline) that starts a fresh, unrelated command.
+ */
+function isExecutedSpan(input, span) {
+  let end = span.start;
+  for (let hop = 0; hop < 6; hop++) {
+    while (end > 0 && /\s/.test(input.charAt(end - 1))) end--;
+    if (end === 0) return false;
+    if (/[;&|(\n]/.test(input.charAt(end - 1))) return false;
+
+    let start = end;
+    while (start > 0 && !/[\s;&|()<>\n]/.test(input.charAt(start - 1))) start--;
+    const word = input.slice(start, end);
+    if (!word) return false;
+
+    if (!word.startsWith('-')) {
+      const base = word.split('/').pop().toLowerCase();
+      return QUOTE_EXEC_COMMANDS.has(base);
+    }
+
+    end = start;
+  }
+  return false;
+}
+
+/**
+ * Quoted spans whose content is inert string data rather than something the
+ * shell will actually execute — i.e. NOT the argument to eval/bash -c/sh -c/etc.
+ */
+function computeIgnoredSpans(input) {
+  return computeQuoteSpans(input).filter(span => !isExecutedSpan(input, span));
+}
+
+function isWithinIgnoredSpan(ignoredSpans, idx) {
+  return ignoredSpans.some(span => idx > span.start && idx < span.end);
+}
+
+/**
+ * Find the next 'git' token in the input starting from a position, skipping
+ * any match that falls inside an ignored (inert, quoted-as-data) span.
+ */
+function findGit(input, start, ignoredSpans) {
   let pos = start;
   while (pos < input.length) {
     const idx = input.indexOf('git', pos);
     if (idx === -1) return null;
+
+    if (isWithinIgnoredSpan(ignoredSpans, idx)) {
+      const span = ignoredSpans.find(s => idx > s.start && idx < s.end);
+      pos = span.end;
+      continue;
+    }
 
     const isExe = input.slice(idx + 3, idx + 7).toLowerCase() === '.exe';
     const len = isExe ? 7 : 3;
@@ -313,9 +417,9 @@ function findGit(input, start) {
  * Returns { command, offset } where offset is the position right after the
  * subcommand keyword, so callers can scope flag checks to only that portion.
  */
-function detectGitCommand(input, start = 0) {
+function detectGitCommand(input, start = 0, ignoredSpans = computeIgnoredSpans(input)) {
   while (start < input.length) {
-    const git = findGit(input, start);
+    const git = findGit(input, start, ignoredSpans);
     if (!git) return null;
 
     if (isInComment(input, git.idx)) {
@@ -468,9 +572,10 @@ function hasHooksPathOverride(input, detected) {
  */
 function checkCommand(input) {
   let start = 0;
+  const ignoredSpans = computeIgnoredSpans(input);
 
   while (start < input.length) {
-    const detected = detectGitCommand(input, start);
+    const detected = detectGitCommand(input, start, ignoredSpans);
     if (!detected) return { blocked: false };
 
     const { command: gitCommand, offset } = detected;

--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -361,14 +361,36 @@ function findSubstitutionRanges(input, start, end) {
     if (char === '$' && input.charAt(i + 1) === '(') {
       const subStart = i;
       let depth = 1;
+      let subQuote = null;
       let j = i + 2;
       while (j < end && depth > 0) {
-        if (input.charAt(j) === '\\') {
+        const inner = input.charAt(j);
+
+        // A paren inside a quote nested within the substitution is just
+        // string data to the shell (e.g. `$(printf ')' ; git ...)`) — it
+        // must not affect paren depth, or scanning stops at that literal
+        // `)` and misses everything (including a real bypass) after it.
+        if (subQuote) {
+          if (subQuote === '"' && inner === '\\') {
+            j += 2;
+            continue;
+          }
+          if (inner === subQuote) subQuote = null;
+          j++;
+          continue;
+        }
+
+        if (inner === '\\') {
           j += 2;
           continue;
         }
-        if (input.charAt(j) === '(') depth++;
-        else if (input.charAt(j) === ')') depth--;
+        if (inner === '"' || inner === "'") {
+          subQuote = inner;
+          j++;
+          continue;
+        }
+        if (inner === '(') depth++;
+        else if (inner === ')') depth--;
         j++;
       }
       ranges.push({ start: subStart, end: j });
@@ -411,7 +433,12 @@ function findSubstitutionRanges(input, start, end) {
  */
 function isExecutedSpan(input, span) {
   let end = span.start;
-  for (let hop = 0; hop < 8; hop++) {
+  // No fixed hop cap: `end` strictly decreases every iteration (bounded below
+  // by 0), so this always terminates in at most input.length steps. A fixed
+  // cap here previously let enough value-taking flags before the quote (e.g.
+  // several chained `bash -O <optname>` flags before `-c`) push the actual
+  // command name out of reach and wrongly return false.
+  while (true) {
     while (end > 0 && /\s/.test(input.charAt(end - 1))) end--;
     if (end === 0) return false;
     if (/[;&|(\n]/.test(input.charAt(end - 1))) return false;
@@ -429,7 +456,6 @@ function isExecutedSpan(input, span) {
 
     end = start;
   }
-  return false;
 }
 
 /**

--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -291,7 +291,7 @@ function isInComment(input, idx) {
  * e.g. an `echo` message, a heredoc, a JSON test fixture — not a real
  * invocation, and must not be treated as one.
  */
-const QUOTE_EXEC_COMMANDS = new Set(['eval', 'bash', 'sh', 'zsh', 'ksh', 'dash', 'source', '.', 'exec']);
+const QUOTE_EXEC_COMMANDS = new Set(['eval', 'bash', 'sh', 'zsh', 'ksh', 'dash', 'source', '.', 'exec', 'env']);
 
 /**
  * Find every top-level (non-nested — shell quotes don't nest) quoted span in
@@ -319,7 +319,7 @@ function computeQuoteSpans(input) {
         continue;
       }
       if (char === quote) {
-        spans.push({ start: spanStart, end: i + 1 });
+        spans.push({ start: spanStart, end: i + 1, quote });
         quote = null;
         spanStart = null;
       }
@@ -341,15 +341,77 @@ function computeQuoteSpans(input) {
 }
 
 /**
+ * Find every `$(...)` (balanced, possibly nested) and backtick-delimited
+ * command substitution in input[start, end). The shell evaluates these
+ * regardless of enclosing double quotes — only single quotes suppress them
+ * entirely — so their content can never be treated as inert text.
+ */
+function findSubstitutionRanges(input, start, end) {
+  const ranges = [];
+  let i = start;
+
+  while (i < end) {
+    const char = input.charAt(i);
+
+    if (char === '\\') {
+      i += 2;
+      continue;
+    }
+
+    if (char === '$' && input.charAt(i + 1) === '(') {
+      const subStart = i;
+      let depth = 1;
+      let j = i + 2;
+      while (j < end && depth > 0) {
+        if (input.charAt(j) === '\\') {
+          j += 2;
+          continue;
+        }
+        if (input.charAt(j) === '(') depth++;
+        else if (input.charAt(j) === ')') depth--;
+        j++;
+      }
+      ranges.push({ start: subStart, end: j });
+      i = j;
+      continue;
+    }
+
+    if (char === '`') {
+      const subStart = i;
+      let j = i + 1;
+      while (j < end && input.charAt(j) !== '`') {
+        if (input.charAt(j) === '\\') {
+          j += 2;
+          continue;
+        }
+        j++;
+      }
+      j = Math.min(j + 1, end);
+      ranges.push({ start: subStart, end: j });
+      i = j;
+      continue;
+    }
+
+    i++;
+  }
+
+  return ranges;
+}
+
+/**
  * Whether a quoted span is the string argument to an exec-style command, e.g.
- * `bash -c '...'`, `sh -lc "..."`, `eval "..."`. Walks backward over
- * whitespace-delimited words, skipping flags (`-c`, `-lc`, ...), until it
- * finds the command name or hits a command delimiter (`;`, `&`, `|`, `(`,
- * newline) that starts a fresh, unrelated command.
+ * `bash -c '...'`, `sh -lc "..."`, `eval "..."`, `env -S '...'`,
+ * `bash -O extglob -c '...'`. Walks backward over whitespace-delimited
+ * words, checking each one against the exec-command list, until it either
+ * finds a match or hits a command delimiter (`;`, `&`, `|`, `(`, newline)
+ * that starts a fresh, unrelated command. Checking every word rather than
+ * stopping at the first non-flag one matters because a value-taking flag
+ * (`-O extglob`, `-S <string>`) can put other, unrelated words between the
+ * command name and the quote.
  */
 function isExecutedSpan(input, span) {
   let end = span.start;
-  for (let hop = 0; hop < 6; hop++) {
+  for (let hop = 0; hop < 8; hop++) {
     while (end > 0 && /\s/.test(input.charAt(end - 1))) end--;
     if (end === 0) return false;
     if (/[;&|(\n]/.test(input.charAt(end - 1))) return false;
@@ -359,10 +421,11 @@ function isExecutedSpan(input, span) {
     const word = input.slice(start, end);
     if (!word) return false;
 
-    if (!word.startsWith('-')) {
-      const base = word.split('/').pop().toLowerCase();
-      return QUOTE_EXEC_COMMANDS.has(base);
-    }
+    // Check every word walked over, flag or not — a value-taking flag (e.g.
+    // `bash -O extglob -c '...'`, `env -S '...'`) means the command name can
+    // sit multiple tokens back from the quote, not just past a single flag.
+    const base = word.split('/').pop().toLowerCase();
+    if (QUOTE_EXEC_COMMANDS.has(base)) return true;
 
     end = start;
   }
@@ -370,11 +433,36 @@ function isExecutedSpan(input, span) {
 }
 
 /**
- * Quoted spans whose content is inert string data rather than something the
+ * Quoted ranges whose content is inert string data rather than something the
  * shell will actually execute — i.e. NOT the argument to eval/bash -c/sh -c/etc.
+ *
+ * Single-quoted spans suppress all expansion, so a non-executed one is inert
+ * end to end. Double-quoted spans still run any `$(...)` or backtick command
+ * substitution they contain regardless of what command they're an argument
+ * to, so those sub-ranges are carved out and left un-ignored even when the
+ * enclosing quote itself is inert.
  */
 function computeIgnoredSpans(input) {
-  return computeQuoteSpans(input).filter(span => !isExecutedSpan(input, span));
+  const ignored = [];
+
+  for (const span of computeQuoteSpans(input)) {
+    if (isExecutedSpan(input, span)) continue;
+
+    if (span.quote === "'") {
+      ignored.push({ start: span.start, end: span.end });
+      continue;
+    }
+
+    const subs = findSubstitutionRanges(input, span.start + 1, span.end - 1);
+    let cursor = span.start;
+    for (const sub of subs) {
+      if (sub.start > cursor) ignored.push({ start: cursor, end: sub.start });
+      cursor = sub.end;
+    }
+    if (cursor < span.end) ignored.push({ start: cursor, end: span.end });
+  }
+
+  return ignored;
 }
 
 function isWithinIgnoredSpan(ignoredSpans, idx) {

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -309,6 +309,16 @@ if (test('blocks --no-verify hidden behind bash -O extglob -c (value-taking flag
   assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
 })) passed++; else failed++;
 
+if (test('blocks --no-verify behind many chained flags before -c (no fixed token limit)', () => {
+  const r = runHook({ tool_input: { command: "bash -O extglob -O nullglob -O globstar -O nocaseglob -c 'git commit --no-verify -m test'" } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-verify when a quoted ) inside $(...) would otherwise end the substitution early', () => {
+  const r = runHook({ tool_input: { command: "echo \"$(printf ')' ; git commit --no-verify -m test)\"" } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
 console.log('─'.repeat(50));
 console.log(`Passed: ${passed}  Failed: ${failed}`);
 

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -219,6 +219,54 @@ if (test('still allows -tn (n is the -t template path, not a flag)', () => {
   assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
 })) passed++; else failed++;
 
+// --- Quoted text mentioning the phrase is not a real invocation (Issue: false positive) ---
+// A `git ...` phrase found inside a quoted span is only treated as a real
+// invocation when the quote is the argument to something that re-executes
+// strings (bash -c, sh -lc, eval, ...). Otherwise it's inert data — an echo
+// message, a heredoc, a JSON test fixture — and must not be blocked.
+
+if (test('allows an echo statement that only mentions --no-verify as text', () => {
+  const r = runHook({ tool_input: { command: 'echo "note: never run git commit --no-verify in this repo"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('allows a single-quoted echo mentioning the phrase', () => {
+  const r = runHook({ tool_input: { command: "echo 'reminder: --no-verify is banned for git commit here'" } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('allows echoing JSON-looking text that merely contains the phrase as data', () => {
+  // The actual command being run is `echo ...` — the JSON-looking argument
+  // is inert text, not a nested hook envelope, so it must not be unwrapped
+  // and re-checked as if it were the real command.
+  const r = runHook({
+    tool_input: {
+      command: 'echo \'{"tool_input":{"command":"git commit --no-verify -m test"}}\''
+    }
+  });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-verify hidden behind bash -c', () => {
+  const r = runHook({ tool_input: { command: "bash -c 'git commit --no-verify -m test'" } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-verify hidden behind an absolute-path bash -c', () => {
+  const r = runHook({ tool_input: { command: "/usr/bin/env bash -c 'git commit --no-verify -m test'" } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-verify hidden behind sh -lc', () => {
+  const r = runHook({ tool_input: { command: "sh -lc 'git commit --no-verify -m test'" } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-verify hidden behind eval', () => {
+  const r = runHook({ tool_input: { command: 'eval "git commit --no-verify -m test"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
 console.log('─'.repeat(50));
 console.log(`Passed: ${passed}  Failed: ${failed}`);
 

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -267,6 +267,48 @@ if (test('blocks --no-verify hidden behind eval', () => {
   assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
 })) passed++; else failed++;
 
+// --- Command substitution always executes, even inside an otherwise-inert
+// double-quoted argument (single quotes are the only thing that suppresses
+// it) — flagged by Greptile review on the initial version of this fix.
+
+if (test('blocks --no-verify hidden behind $(...) inside a double-quoted echo', () => {
+  const r = runHook({ tool_input: { command: 'echo "$(git commit --no-verify -m test)"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-verify hidden behind backticks inside a double-quoted echo', () => {
+  const r = runHook({ tool_input: { command: 'echo "`git commit --no-verify -m test`"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-verify hidden behind a bare (unquoted) $(...)', () => {
+  const r = runHook({ tool_input: { command: 'echo $(git commit --no-verify -m test)' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-verify behind $(...) alongside an unrelated inert $(...) in the same string', () => {
+  const r = runHook({ tool_input: { command: 'echo "outer $(echo inner) and $(git commit --no-verify -m test)"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('allows $(...) inside SINGLE quotes, where the shell never expands it', () => {
+  const r = runHook({ tool_input: { command: "echo '$(git commit --no-verify -m test)'" } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+// --- Value-taking flags between the exec command and the quote, and env -S
+// (flagged by CodeRabbit review on the initial version of this fix) ---
+
+if (test('blocks --no-verify hidden behind env -S', () => {
+  const r = runHook({ tool_input: { command: "env -S 'git commit --no-verify -m test'" } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-verify hidden behind bash -O extglob -c (value-taking flag before -c)', () => {
+  const r = runHook({ tool_input: { command: "bash -O extglob -c 'git commit --no-verify -m test'" } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
 console.log('─'.repeat(50));
 console.log(`Passed: ${passed}  Failed: ${failed}`);
 


### PR DESCRIPTION
## Summary

`scripts/hooks/block-no-verify.js` scans the raw command string for a git
invocation, but doesn't track shell quoting from the start of the command —
so it can't tell a real `git commit --no-verify` apart from a command that
merely *mentions* the phrase as text inside a different command's argument
(an `echo` message, a heredoc, a logged/test fixture).

Reproduced live against a real PreToolUse hook invocation:

```
$ echo "note: never run git commit --no-verify in this repo"
BLOCKED: --no-verify flag is not allowed with git commit. Git hooks must not be bypassed.
```

That's a harmless echo of documentation text, not a git invocation.

## Fix

Tracks top-level quote spans globally (`computeQuoteSpans`) and only treats
a `git ...` match found inside a quote as a real invocation when that quote
is the argument to something that actually re-executes strings — `bash -c`,
`sh -lc`, `eval`, etc. (`isExecutedSpan`/`computeIgnoredSpans`). So a real
bypass hidden behind those still blocks, while quoted mentions elsewhere
(echo, commit messages, JSON fixtures) don't.

## Type
- [x] Hook

## Testing

- Existing 29-case suite in `tests/hooks/block-no-verify.test.js`: all pass, no regressions (covers the chained-command, quoted-message, and case-insensitivity edge cases this fix had to stay compatible with).
- Added 7 new cases: the false-positive itself (plain + single-quoted echo, an actual echo of JSON-looking text), plus confirming real bypasses hidden behind `bash -c` / an absolute-path `bash -c` / `sh -lc` / `eval` still block.
- Re-verified RED (reconstructed pre-fix code, 2 of the new cases fail) -> GREEN (fixed code, all 36 pass) rather than only adding tests alongside the fix.
- `node scripts/ci/validate-no-personal-paths.js` and `npx eslint` on both changed files: clean.
- Full `npm test`: 3998/4013 passing — same 15 pre-existing failures reproduce identically with this fix stashed out (verified before submitting), so none are caused by this change.

## Checklist
- [x] Follows format guidelines
- [x] Tested with Claude Code
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions