### PR TITLE
fix(hooks): classify platform-dependent raw prefixes

### DIFF
--- a/scripts/hooks/plugin-hook-bootstrap.js
+++ b/scripts/hooks/plugin-hook-bootstrap.js
@@ -7,7 +7,6 @@ const { spawnSync } = require('child_process');
 const { ensureAgentDataHomeEnv } = require('../lib/agent-data-home');
 
 const SHELL_PROBE_TIMEOUT_MS = 2000;
-const STDOUT_PIPE_CAP_BYTES = 64 * 1024;
 
 function readStdinRaw() {
   try {
@@ -37,9 +36,8 @@ function isRawPassthrough(raw, stdout) {
   const stdoutBytes = toBuffer(stdout);
   if (rawBytes.length === 0 || stdoutBytes.length === 0) return false;
   return (
-    stdoutBytes.equals(rawBytes) ||
-    (stdoutBytes.length === STDOUT_PIPE_CAP_BYTES &&
-      rawBytes.subarray(0, stdoutBytes.length).equals(stdoutBytes))
+    stdoutBytes.length <= rawBytes.length &&
+    rawBytes.subarray(0, stdoutBytes.length).equals(stdoutBytes)
   );
 }
 
@@ -58,11 +56,11 @@ function passthrough(result) {
     // instead; the harness falls back to the tool_use's original result, the
     // same path #2240 established for bash-hook-dispatcher.
     //
-    // IMPORTANT: a strict `stdout === raw` check misses the common case where
-    // child processes' synchronous `process.stdout.write()` writes hit the
-    // ~64 KB Node.js pipe buffer and get truncated -- stdout is then exactly
-    // 65536 bytes and a strict prefix of raw. So we also detect that
-    // truncation sentinel.
+    // IMPORTANT: a strict `stdout === raw` check misses child processes whose
+    // synchronous `process.stdout.write()` is truncated before exit. Pipe
+    // capacity varies by platform and Node version (observed at 8, 16, and
+    // 64 KiB), so classify any non-empty byte-exact prefix of the raw hook
+    // event as passthrough instead of assuming one buffer size.
     const raw = result?.comparisonInput;
     const looksLikePassthrough = isRawPassthrough(raw, stdout);
     if (looksLikePassthrough) {

--- a/tests/hooks/plugin-hook-bootstrap-no-echo.test.js
+++ b/tests/hooks/plugin-hook-bootstrap-no-echo.test.js
@@ -277,8 +277,11 @@ if (
       );
     }
 
-    const mismatchedPrefix = Buffer.from(raw.subarray(0, 8 * 1024));
-    mismatchedPrefix[mismatchedPrefix.length - 1] ^= 1;
+    const mismatchLength = 8 * 1024;
+    const mismatchedPrefix = Buffer.concat([
+      raw.subarray(0, mismatchLength - 1),
+      Buffer.from([raw[mismatchLength - 1] ^ 1])
+    ]);
     assert.strictEqual(isRawPassthrough(raw, mismatchedPrefix), false);
   })
 )

--- a/tests/hooks/plugin-hook-bootstrap-no-echo.test.js
+++ b/tests/hooks/plugin-hook-bootstrap-no-echo.test.js
@@ -242,7 +242,7 @@ if (
 else failed++;
 
 if (
-  test('64 KiB passthrough sentinel is measured in UTF-8 bytes', () => {
+  test('truncated UTF-8 prefix is classified by bytes', () => {
     const fixturePath = path.join(FIXTURE_DIR, 'multibyte-prefix-fixture.js');
     fs.writeFileSync(
       fixturePath,
@@ -255,7 +255,7 @@ if (
       });
       assert.strictEqual(Buffer.byteLength(payload.slice(0, 32768), 'utf8'), 64 * 1024);
       assert.strictEqual(result.status, 0, result.stderr);
-      assert.strictEqual(result.stdout, '', 'a 64 KiB UTF-8 prefix of raw input must be suppressed');
+      assert.strictEqual(result.stdout, '', 'a UTF-8 byte prefix of raw input must be suppressed');
       assert.match(result.stderr, /returned raw input as stdout/);
     } finally {
       fs.unlinkSync(fixturePath);
@@ -266,18 +266,20 @@ if (
 else failed++;
 
 if (
-  test('byte boundary does not misclassify 64K multibyte characters', () => {
-    const byteBoundaryPrefix = 'é'.repeat(32768);
-    const characterBoundaryPrefix = 'é'.repeat(65536);
+  test('classifies platform-dependent pipe prefixes without accepting mismatches', () => {
+    const raw = Buffer.from(`${'a'.repeat(64 * 1024)}tail`, 'utf8');
 
-    assert.strictEqual(Buffer.byteLength(byteBoundaryPrefix, 'utf8'), 64 * 1024);
-    assert.strictEqual(Buffer.byteLength(characterBoundaryPrefix, 'utf8'), 128 * 1024);
-    assert.strictEqual(isRawPassthrough(`${byteBoundaryPrefix}tail`, byteBoundaryPrefix), true);
-    assert.strictEqual(
-      isRawPassthrough(`${characterBoundaryPrefix}tail`, characterBoundaryPrefix),
-      false,
-      '64K JavaScript characters must not be treated as a 64 KiB byte boundary'
-    );
+    for (const prefixLength of [8 * 1024, 16 * 1024, 64 * 1024]) {
+      assert.strictEqual(
+        isRawPassthrough(raw, raw.subarray(0, prefixLength)),
+        true,
+        `${prefixLength}-byte raw prefix must be classified as passthrough`
+      );
+    }
+
+    const mismatchedPrefix = Buffer.from(raw.subarray(0, 8 * 1024));
+    mismatchedPrefix[mismatchedPrefix.length - 1] ^= 1;
+    assert.strictEqual(isRawPassthrough(raw, mismatchedPrefix), false);
   })
 )
   passed++;


### PR DESCRIPTION
## Summary

Follow-up to #2380. The exact post-merge matrix showed that synchronous raw-input echoes can be truncated at platform-dependent pipe sizes: macOS Node 18 returned a 16 KiB prefix and macOS Node 20 returned an 8 KiB prefix, while the original classifier recognized only an exact 64 KiB prefix.

This patch removes the fixed buffer-size assumption. A non-empty stdout value is classified as passthrough only when it is a byte-exact prefix of the original hook event. A mismatched prefix remains genuine child output. The hook contract expects complete JSON output, so a truncated raw-event prefix is not a valid replacement result and must be suppressed.

## Validation

- plugin-hook-bootstrap-no-echo.test.js: 13 passed, including deterministic 8 KiB, 16 KiB, and 64 KiB prefix cases plus a mismatch guard
- plugin-hook-bootstrap.test.js: 15 passed
- hooks.test.js: 250 passed
- bash-hook-dispatcher.test.js: 6 passed
- run-with-flags-truncation.test.js: 7 passed
- ESLint passed on all affected source and test files
- git diff --check passed

## Failure evidence

- macOS Node 18 Yarn: raw prefix escaped at 16,384 bytes
- macOS Node 20 Yarn: raw prefix escaped at 8,192 bytes

This restores the intended #2380 behavior without changing genuine hook output or fail-open handling.