### PR TITLE
fix: forward-port approved truth and privacy fixes (5 PRs)

### DIFF
--- a/scripts/ci/validate-skills.js
+++ b/scripts/ci/validate-skills.js
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 /**
- * Validate curated skill directories (skills/ in repo).
+ * Validate curated skill directories (skills/ in repo) and their
+ * translated mirrors (docs/{locale}/skills/ in repo).
  *
  * Checks:
  *   1. Each sub-directory of skills/ contains a SKILL.md file.
  *   2. SKILL.md is non-empty.
- *   3. SKILL.md frontmatter (if present) declares a `name:` field.
+ *   3. SKILL.md frontmatter is present and declares both `name:` and
+ *      `description:` fields.
  *   4. SKILL.md frontmatter `description:` uses an inline scalar — not a
  *      literal block scalar (`|` / `|-` / `|+`), which preserves internal
  *      newlines and breaks flat-table renderers keyed off `description`.
@@ -17,14 +19,16 @@
  *
  * Structural findings (missing/empty SKILL.md) are always errors.
  *
- * Scope: curated only. Learned/imported/evolved roots are out of scope.
- * If skills/ does not exist, exit 0 (no curated skills to validate).
+ * Scope: curated skills/ plus translated docs/{locale}/skills/ mirrors.
+ * Learned/imported/evolved roots are out of scope. If neither root
+ * exists, exit 0 (nothing to validate).
  */
 
 const fs = require('fs');
 const path = require('path');
 
 const SKILLS_DIR = path.join(__dirname, '../../skills');
+const DOCS_DIR = path.join(__dirname, '../../docs');
 
 const STRICT = process.argv.includes('--strict') || process.env.CI_STRICT_SKILLS === '1';
 
@@ -66,6 +70,7 @@ function extractFrontmatter(content) {
  */
 function inspectFrontmatter(lines) {
   const values = Object.create(null);
+  const syntaxErrors = [];
   let descriptionIndicator = null;
   let inBlockScalar = false;
   let blockScalarIndent = -1;
@@ -96,6 +101,27 @@ function inspectFrontmatter(lines) {
       .trim();
     values[key] = valueNoComment;
 
+    const isQuoted = /^"(?:[^"\\]|\\.)*"$/.test(valueNoComment) || /^'(?:[^']|'')*'$/.test(valueNoComment);
+
+    if (!isQuoted && valueNoComment !== '') {
+      // A plain (unquoted) YAML scalar can never contain ": " — that
+      // sequence starts a new mapping key. When the translation pass
+      // drops a value's quoting, or glues the next frontmatter key onto
+      // the end of a value, this is exactly what shows up (see #2630).
+      if (valueNoComment.includes(': ')) {
+        syntaxErrors.push(
+          `${key}: unquoted value contains ': ' — invalid YAML; ` + `quote the value or the next key was likely glued onto this line`
+        );
+      }
+
+      // '@' and '`' are reserved YAML indicators and cannot start a
+      // plain scalar (see #2630 — a reordering during translation moved
+      // '@' into the first column of an unquoted description).
+      if (/^[@`]/.test(valueNoComment)) {
+        syntaxErrors.push(`${key}: unquoted value starts with reserved character '${valueNoComment[0]}' — quote the value`);
+      }
+    }
+
     // Detect literal / folded block-scalar indicators. Accept chomp
     // modifiers (`-` / `+`) and optional indent-indicator digits in
     // either order, per YAML 1.2.
@@ -108,7 +134,7 @@ function inspectFrontmatter(lines) {
     }
   }
 
-  return { values, descriptionIndicator };
+  return { values, descriptionIndicator, syntaxErrors };
 }
 
 /**
@@ -120,6 +146,10 @@ function inspectFrontmatter(lines) {
  * `reportFrontmatterFinding`, which owns the WARN/ERROR decision based
  * on strict mode.
  *
+ * Curated skills/ tolerates a SKILL.md with no frontmatter block at all
+ * (frontmatter checks only apply when a block is present) — this mirrors
+ * pre-existing behavior and is covered by an explicit regression test.
+ *
  * @param {string} dir
  * @param {string} skillsDir
  * @param {(msg: string) => void} reportFrontmatterFinding
@@ -127,8 +157,35 @@ function inspectFrontmatter(lines) {
  */
 function validateSkillDir(dir, skillsDir, reportFrontmatterFinding) {
   const skillMd = path.join(skillsDir, dir, 'SKILL.md');
+  return validateSkillFile(skillMd, `${dir}/SKILL.md`, reportFrontmatterFinding, { requireFrontmatter: false });
+}
+
+/**
+ * Validate a single SKILL.md file at an arbitrary path.
+ *
+ * Shared by the curated skills/ scan and the translated
+ * docs/{locale}/skills/ scan — same checks apply to both, since a
+ * translated mirror's frontmatter must be just as parseable as the
+ * English original (see #2630).
+ *
+ * `requireFrontmatter: true` (used for docs/{locale}/skills/ mirrors)
+ * flags a completely missing frontmatter block as a finding — the
+ * translated mirror must carry the same `name`/`description` as its
+ * English original. Curated skills/ (requireFrontmatter: false) keeps
+ * the pre-existing tolerant behavior of skipping checks entirely when no
+ * block is present.
+ *
+ * @param {string} skillMd
+ * @param {string} label
+ * @param {(msg: string) => void} reportFrontmatterFinding
+ * @param {{requireFrontmatter?: boolean}} [opts]
+ * @returns {{fatal: boolean}}
+ */
+function validateSkillFile(skillMd, label, reportFrontmatterFinding, opts = {}) {
+  const { requireFrontmatter = false } = opts;
+
   if (!fs.existsSync(skillMd)) {
-    console.error(`ERROR: ${dir}/ - Missing SKILL.md`);
+    console.error(`ERROR: ${label} - Missing SKILL.md`);
     return { fatal: true };
   }
 
@@ -136,42 +193,93 @@ function validateSkillDir(dir, skillsDir, reportFrontmatterFinding) {
   try {
     content = fs.readFileSync(skillMd, 'utf-8');
   } catch (err) {
-    console.error(`ERROR: ${dir}/SKILL.md - ${err.message}`);
+    console.error(`ERROR: ${label} - ${err.message}`);
     return { fatal: true };
   }
   if (content.trim().length === 0) {
-    console.error(`ERROR: ${dir}/SKILL.md - Empty file`);
+    console.error(`ERROR: ${label} - Empty file`);
     return { fatal: true };
   }
 
   const fm = extractFrontmatter(content);
-  if (fm.present) {
-    const { values, descriptionIndicator } = inspectFrontmatter(fm.lines);
-
-    if (!Object.prototype.hasOwnProperty.call(values, 'name')) {
-      reportFrontmatterFinding(`${dir}/SKILL.md - frontmatter missing required field: name`);
-    } else if (values.name === '') {
-      reportFrontmatterFinding(`${dir}/SKILL.md - frontmatter 'name' is empty`);
+  if (!fm.present) {
+    if (requireFrontmatter) {
+      reportFrontmatterFinding(`${label} - no frontmatter block found (missing name/description)`);
     }
+    return { fatal: false };
+  }
 
-    if (descriptionIndicator && descriptionIndicator.startsWith('|')) {
-      reportFrontmatterFinding(
-        `${dir}/SKILL.md - frontmatter description uses literal block scalar ` + `'${descriptionIndicator}' which preserves internal newlines; ` + `use an inline string or folded '>' scalar instead`
-      );
-    }
+  const { values, descriptionIndicator, syntaxErrors } = inspectFrontmatter(fm.lines);
+
+  if (!Object.prototype.hasOwnProperty.call(values, 'name')) {
+    reportFrontmatterFinding(`${label} - frontmatter missing required field: name`);
+  } else if (values.name === '') {
+    reportFrontmatterFinding(`${label} - frontmatter 'name' is empty`);
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(values, 'description')) {
+    reportFrontmatterFinding(`${label} - frontmatter missing required field: description`);
+  } else if (values.description === '') {
+    reportFrontmatterFinding(`${label} - frontmatter 'description' is empty`);
+  }
+
+  if (descriptionIndicator && descriptionIndicator.startsWith('|')) {
+    reportFrontmatterFinding(
+      `${label} - frontmatter description uses literal block scalar ` + `'${descriptionIndicator}' which preserves internal newlines; ` + `use an inline string or folded '>' scalar instead`
+    );
+  }
+
+  for (const syntaxError of syntaxErrors) {
+    reportFrontmatterFinding(`${label} - frontmatter ${syntaxError}`);
   }
 
   return { fatal: false };
 }
 
-function validateSkills() {
-  if (!fs.existsSync(SKILLS_DIR)) {
-    console.log('No curated skills directory (skills/), skipping');
-    process.exit(0);
+/**
+ * Find every SKILL.md under docs/{locale}/skills/*, mirroring the
+ * curated skills/ layout one locale directory deeper.
+ *
+ * @param {string} docsDir
+ * @returns {Array<{skillMd: string, label: string}>}
+ */
+function findDocsSkillFiles(docsDir) {
+  if (!fs.existsSync(docsDir)) return [];
+
+  const files = [];
+  const locales = fs
+    .readdirSync(docsDir, { withFileTypes: true })
+    .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+    .map(e => e.name);
+
+  for (const locale of locales) {
+    const localeSkillsDir = path.join(docsDir, locale, 'skills');
+    if (!fs.existsSync(localeSkillsDir)) continue;
+
+    const skillDirs = fs
+      .readdirSync(localeSkillsDir, { withFileTypes: true })
+      .filter(e => e.isDirectory() && !e.name.startsWith('.'))
+      .map(e => e.name);
+
+    for (const skillDir of skillDirs) {
+      files.push({
+        skillMd: path.join(localeSkillsDir, skillDir, 'SKILL.md'),
+        label: `docs/${locale}/skills/${skillDir}/SKILL.md`
+      });
+    }
   }
 
-  const entries = fs.readdirSync(SKILLS_DIR, { withFileTypes: true });
-  const dirs = entries.filter(e => e.isDirectory() && !e.name.startsWith('.')).map(e => e.name);
+  return files;
+}
+
+function validateSkills() {
+  const curatedExists = fs.existsSync(SKILLS_DIR);
+  const docsSkillFiles = findDocsSkillFiles(DOCS_DIR);
+
+  if (!curatedExists && docsSkillFiles.length === 0) {
+    console.log('No skills directory (skills/ or docs/*/skills/), skipping');
+    process.exit(0);
+  }
 
   let hasErrors = false;
   let warnCount = 0;
@@ -187,8 +295,22 @@ function validateSkills() {
     }
   };
 
-  for (const dir of dirs) {
-    const { fatal } = validateSkillDir(dir, SKILLS_DIR, reportFrontmatterFinding);
+  if (curatedExists) {
+    const entries = fs.readdirSync(SKILLS_DIR, { withFileTypes: true });
+    const dirs = entries.filter(e => e.isDirectory() && !e.name.startsWith('.')).map(e => e.name);
+
+    for (const dir of dirs) {
+      const { fatal } = validateSkillDir(dir, SKILLS_DIR, reportFrontmatterFinding);
+      if (fatal) {
+        hasErrors = true;
+        continue;
+      }
+      validCount++;
+    }
+  }
+
+  for (const { skillMd, label } of docsSkillFiles) {
+    const { fatal } = validateSkillFile(skillMd, label, reportFrontmatterFinding, { requireFrontmatter: true });
     if (fatal) {
       hasErrors = true;
       continue;

--- a/scripts/ci/validate-skills.js
+++ b/scripts/ci/validate-skills.js
@@ -68,9 +68,41 @@ function extractFrontmatter(content) {
  * @param {string[]} lines
  * @returns {{values: Record<string,string>, descriptionIndicator: string|null}}
  */
+function stripUnquotedYamlComment(rawValue) {
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+
+  for (let index = 0; index < rawValue.length; index++) {
+    const character = rawValue[index];
+
+    if (inDoubleQuote && character === '\\') {
+      index += 1;
+      continue;
+    }
+    if (!inDoubleQuote && character === "'") {
+      if (inSingleQuote && rawValue[index + 1] === "'") {
+        index += 1;
+      } else {
+        inSingleQuote = !inSingleQuote;
+      }
+      continue;
+    }
+    if (!inSingleQuote && character === '"') {
+      inDoubleQuote = !inDoubleQuote;
+      continue;
+    }
+    if (!inSingleQuote && !inDoubleQuote && character === '#'
+      && (index === 0 || /\s/.test(rawValue[index - 1]))) {
+      return rawValue.slice(0, index).trim();
+    }
+  }
+
+  return rawValue.trim();
+}
+
 function inspectFrontmatter(lines) {
   const values = Object.create(null);
-  const syntaxErrors = [];
+  let syntaxErrors = [];
   let descriptionIndicator = null;
   let inBlockScalar = false;
   let blockScalarIndent = -1;
@@ -92,13 +124,8 @@ function inspectFrontmatter(lines) {
 
     const key = match[1];
     const rawValue = match[2];
-    // Strip unquoted comments for value/indicator inspection. Handles both
-    // trailing comments (`foo: bar # note`) and comment-only values
-    // (`foo: # todo`) so the latter is treated as empty.
-    const valueNoComment = rawValue
-      .replace(/^\s*#.*$/, '')
-      .replace(/\s+#.*$/, '')
-      .trim();
+    // Strip YAML comments only when # appears outside a quoted scalar.
+    const valueNoComment = stripUnquotedYamlComment(rawValue);
     values[key] = valueNoComment;
 
     const isQuoted = /^"(?:[^"\\]|\\.)*"$/.test(valueNoComment) || /^'(?:[^']|'')*'$/.test(valueNoComment);
@@ -109,16 +136,19 @@ function inspectFrontmatter(lines) {
       // drops a value's quoting, or glues the next frontmatter key onto
       // the end of a value, this is exactly what shows up (see #2630).
       if (valueNoComment.includes(': ')) {
-        syntaxErrors.push(
+        syntaxErrors = [...syntaxErrors,
           `${key}: unquoted value contains ': ' — invalid YAML; ` + `quote the value or the next key was likely glued onto this line`
-        );
+        ];
       }
 
       // '@' and '`' are reserved YAML indicators and cannot start a
       // plain scalar (see #2630 — a reordering during translation moved
       // '@' into the first column of an unquoted description).
       if (/^[@`]/.test(valueNoComment)) {
-        syntaxErrors.push(`${key}: unquoted value starts with reserved character '${valueNoComment[0]}' — quote the value`);
+        syntaxErrors = [
+          ...syntaxErrors,
+          `${key}: unquoted value starts with reserved character '${valueNoComment[0]}' — quote the value`
+        ];
       }
     }
 
@@ -246,30 +276,31 @@ function validateSkillFile(skillMd, label, reportFrontmatterFinding, opts = {}) 
 function findDocsSkillFiles(docsDir) {
   if (!fs.existsSync(docsDir)) return [];
 
-  const files = [];
-  const locales = fs
-    .readdirSync(docsDir, { withFileTypes: true })
+  const readDirectories = (directory, label) => {
+    try {
+      return fs.readdirSync(directory, { withFileTypes: true });
+    } catch {
+      throw new Error(`unable to read ${label}`);
+    }
+  };
+
+  const locales = readDirectories(docsDir, 'docs directory')
     .filter(e => e.isDirectory() && !e.name.startsWith('.'))
     .map(e => e.name);
 
-  for (const locale of locales) {
+  return locales.flatMap(locale => {
     const localeSkillsDir = path.join(docsDir, locale, 'skills');
-    if (!fs.existsSync(localeSkillsDir)) continue;
+    if (!fs.existsSync(localeSkillsDir)) return [];
 
-    const skillDirs = fs
-      .readdirSync(localeSkillsDir, { withFileTypes: true })
+    const skillDirs = readDirectories(localeSkillsDir, `docs/${locale}/skills directory`)
       .filter(e => e.isDirectory() && !e.name.startsWith('.'))
       .map(e => e.name);
 
-    for (const skillDir of skillDirs) {
-      files.push({
-        skillMd: path.join(localeSkillsDir, skillDir, 'SKILL.md'),
-        label: `docs/${locale}/skills/${skillDir}/SKILL.md`
-      });
-    }
-  }
-
-  return files;
+    return skillDirs.map(skillDir => ({
+      skillMd: path.join(localeSkillsDir, skillDir, 'SKILL.md'),
+      label: `docs/${locale}/skills/${skillDir}/SKILL.md`
+    }));
+  });
 }
 
 function validateSkills() {
@@ -329,4 +360,9 @@ function validateSkills() {
   console.log(msg);
 }
 
-validateSkills();
+try {
+  validateSkills();
+} catch (error) {
+  console.error(`ERROR: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/hooks/suggest-compact.js
+++ b/scripts/hooks/suggest-compact.js
@@ -38,7 +38,8 @@ const {
   resolveContextThreshold,
   resolveContextInterval,
   computeContextBucket,
-  formatWindowLabel
+  formatWindowLabel,
+  isContextWindowInferred
 } = require('../lib/transcript-context');
 
 const COUNTER_FILE_PREFIX = 'claude-tool-count-';
@@ -185,8 +186,13 @@ function buildContextSuggestion(transcriptPath, bucketFile, env) {
     writeFile(bucketFile, String(bucket));
 
     const approxTokens = `${Math.round(usage.tokens / 1000)}k`;
-    const percent = Math.round((usage.tokens / windowTokens) * 100);
-    return `[StrategicCompact] Context ~${approxTokens} tokens (${percent}% of ${formatWindowLabel(windowTokens)} window) - consider /compact at the next logical boundary`;
+    // Only quote a percentage when the window size was actually detected.
+    // Against an assumed 200k default the denominator is a guess, and a
+    // "97% of 200k window" line on a 1M session triggers needless compaction.
+    const scale = isContextWindowInferred(usage.tokens, usage.model)
+      ? ''
+      : ` (${Math.round((usage.tokens / windowTokens) * 100)}% of ${formatWindowLabel(windowTokens)} window)`;
+    return `[StrategicCompact] Context ~${approxTokens} tokens${scale} - consider /compact at the next logical boundary`;
   } catch (err) {
     log(`[StrategicCompact] Context signal skipped: ${err.message}`);
     return null;

--- a/scripts/hooks/suggest-compact.js
+++ b/scripts/hooks/suggest-compact.js
@@ -34,12 +34,11 @@ const {
 } = require('../lib/utils');
 const {
   readLatestContextTokens,
-  resolveContextWindowTokens,
+  resolveContextWindow,
   resolveContextThreshold,
   resolveContextInterval,
   computeContextBucket,
-  formatWindowLabel,
-  isContextWindowInferred
+  formatWindowLabel
 } = require('../lib/transcript-context');
 
 const COUNTER_FILE_PREFIX = 'claude-tool-count-';
@@ -172,7 +171,7 @@ function buildContextSuggestion(transcriptPath, bucketFile, env) {
     const usage = readLatestContextTokens(transcriptPath);
     if (!usage) return null;
 
-    const windowTokens = resolveContextWindowTokens(usage.tokens, usage.model);
+    const { windowTokens, inferred } = resolveContextWindow(usage.tokens, usage.model);
     const threshold = resolveContextThreshold(env, windowTokens);
     if (threshold <= 0) return null; // COMPACT_CONTEXT_THRESHOLD=0 disables
 
@@ -189,7 +188,7 @@ function buildContextSuggestion(transcriptPath, bucketFile, env) {
     // Only quote a percentage when the window size was actually detected.
     // Against an assumed 200k default the denominator is a guess, and a
     // "97% of 200k window" line on a 1M session triggers needless compaction.
-    const scale = isContextWindowInferred(usage.tokens, usage.model)
+    const scale = inferred
       ? ''
       : ` (${Math.round((usage.tokens / windowTokens) * 100)}% of ${formatWindowLabel(windowTokens)} window)`;
     return `[StrategicCompact] Context ~${approxTokens} tokens${scale} - consider /compact at the next logical boundary`;

--- a/scripts/lib/transcript-context.js
+++ b/scripts/lib/transcript-context.js
@@ -162,10 +162,11 @@ function readLatestContextTokens(transcriptPath, options = {}) {
  * positively detected or merely assumed.
  *
  * `inferred: false` means the size came from evidence — an explicit env
- * override, the `[1m]` marker, a known large-window family, or an observed
- * token count that already exceeds the standard window. `inferred: true` means
- * every check fell through and the standard 200k default was assumed; the
- * window may actually be larger and callers must not present it as fact.
+ * override, the `[1m]` marker, or a known large-window family. An observed
+ * token count above the standard window selects the safer large-window
+ * thresholds, but remains inferred because the true denominator could be an
+ * unmarked intermediate size such as 400k. Callers must not present inferred
+ * windows as fact.
  *
  * @returns {{ windowTokens: number, inferred: boolean }}
  */
@@ -193,7 +194,7 @@ function resolveContextWindow(tokens, model) {
   }
 
   if (Number.isFinite(tokens) && tokens > STANDARD_CONTEXT_WINDOW_TOKENS) {
-    return { windowTokens: LARGE_CONTEXT_WINDOW_TOKENS, inferred: false };
+    return { windowTokens: LARGE_CONTEXT_WINDOW_TOKENS, inferred: true };
   }
 
   return { windowTokens: STANDARD_CONTEXT_WINDOW_TOKENS, inferred: true };

--- a/scripts/lib/transcript-context.js
+++ b/scripts/lib/transcript-context.js
@@ -158,24 +158,29 @@ function readLatestContextTokens(transcriptPath, options = {}) {
 }
 
 /**
- * Detect the context window size for a turn.
- * 1M when the model id carries the `[1m]` marker, matches a known large-window
- * model family, or when the observed token count already exceeds the standard
- * 200k window (covers logs that drop the suffix); otherwise the standard 200k
- * window.
+ * Detect the context window size for a turn, and report whether that size was
+ * positively detected or merely assumed.
+ *
+ * `inferred: false` means the size came from evidence — an explicit env
+ * override, the `[1m]` marker, a known large-window family, or an observed
+ * token count that already exceeds the standard window. `inferred: true` means
+ * every check fell through and the standard 200k default was assumed; the
+ * window may actually be larger and callers must not present it as fact.
+ *
+ * @returns {{ windowTokens: number, inferred: boolean }}
  */
-function resolveContextWindowTokens(tokens, model) {
+function resolveContextWindow(tokens, model) {
   // Explicit window override wins: 400k models (e.g. Opus 4.x) match neither the
   // 200k default nor the 1M marker and would otherwise report ~double usage (#2290).
   // Honor ECC's own knob and Claude Code's native CLAUDE_CODE_AUTO_COMPACT_WINDOW.
   const env = (typeof process !== 'undefined' && process.env) || {};
   const envWindow = Number.parseInt(env.ECC_CONTEXT_WINDOW_TOKENS || env.CLAUDE_CODE_AUTO_COMPACT_WINDOW || '', 10);
   if (Number.isInteger(envWindow) && envWindow > 0) {
-    return envWindow;
+    return { windowTokens: envWindow, inferred: false };
   }
 
   if (typeof model === 'string' && model.includes(LARGE_WINDOW_MODEL_MARKER)) {
-    return LARGE_CONTEXT_WINDOW_TOKENS;
+    return { windowTokens: LARGE_CONTEXT_WINDOW_TOKENS, inferred: false };
   }
 
   // Large-window model families without a [1m] marker fall through the checks
@@ -183,15 +188,37 @@ function resolveContextWindowTokens(tokens, model) {
   if (typeof model === 'string') {
     const known = KNOWN_MODEL_WINDOW_TOKENS.find(([familyId]) => isKnownModelFamilyMatch(model, familyId));
     if (known) {
-      return known[1];
+      return { windowTokens: known[1], inferred: false };
     }
   }
 
   if (Number.isFinite(tokens) && tokens > STANDARD_CONTEXT_WINDOW_TOKENS) {
-    return LARGE_CONTEXT_WINDOW_TOKENS;
+    return { windowTokens: LARGE_CONTEXT_WINDOW_TOKENS, inferred: false };
   }
 
-  return STANDARD_CONTEXT_WINDOW_TOKENS;
+  return { windowTokens: STANDARD_CONTEXT_WINDOW_TOKENS, inferred: true };
+}
+
+/**
+ * Detect the context window size for a turn.
+ * 1M when the model id carries the `[1m]` marker, matches a known large-window
+ * model family, or when the observed token count already exceeds the standard
+ * 200k window (covers logs that drop the suffix); otherwise the standard 200k
+ * window.
+ */
+function resolveContextWindowTokens(tokens, model) {
+  return resolveContextWindow(tokens, model).windowTokens;
+}
+
+/**
+ * True when the resolved window is the assumed 200k default rather than a
+ * detected size. Opt-in large-window models that ship no `[1m]` marker in the
+ * transcript (e.g. a 1M-context Opus tier, where the base tier is 200k and the
+ * two are indistinguishable by model id) land here, so a percentage computed
+ * against 200k can be wildly wrong while usage sits below that mark.
+ */
+function isContextWindowInferred(tokens, model) {
+  return resolveContextWindow(tokens, model).inferred;
 }
 
 /**
@@ -254,7 +281,9 @@ module.exports = {
   DEFAULT_CONTEXT_INTERVAL_TOKENS,
   DEFAULT_TRANSCRIPT_TAIL_BYTES,
   readLatestContextTokens,
+  resolveContextWindow,
   resolveContextWindowTokens,
+  isContextWindowInferred,
   resolveContextThreshold,
   resolveContextInterval,
   computeContextBucket,

--- a/skills/gateguard/SKILL.md
+++ b/skills/gateguard/SKILL.md
@@ -106,6 +106,38 @@ near-identical blocks cannot accumulate in the context window and
 amplify model repetition loops (#2142). Retrying the same file or
 command after presenting facts never re-triggers the gate.
 
+#### Graduated controls
+
+`ECC_GATEGUARD=off` disables the whole gate. The variables below narrow it
+instead, so the load-bearing destructive-Bash checks keep running:
+
+| Variable | Default | Effect |
+|---|---|---|
+| `GATEGUARD_BASH_ROUTINE_DISABLED` | unset (gate on) | Disables the **routine-Bash** gate only. The destructive-Bash gate (`rm -rf`, `git reset --hard`, `drop table`, `dd if=`, …) is unaffected. |
+| `GATEGUARD_EXEMPT_GLOBS` | unset (no exemptions) | Comma-separated globs; a matching Edit/Write/MultiEdit target skips first-touch fact-forcing. Intended for low-import-value trees (tests, generated artifacts, scratch dirs) where "who imports this / what schema" carries no signal. |
+| `GATEGUARD_FACT_FORCE_FULL_DENIALS` | `3` | How many denials emit the full four-fact block before later ones condense to a single line. `0` condenses from the very first denial. |
+| `GATEGUARD_BASH_EXTRA_DESTRUCTIVE` | unset | Extra destructive-command patterns, as regex source, added to the built-in set. A malformed regex is treated as unset (built-ins still apply) and logged once to stderr. |
+| `GATEGUARD_DISABLED` | unset | `1` disables the gate entirely — equivalent to `ECC_GATEGUARD=off`. |
+| `GATEGUARD_STATE_DIR` | `~/.gateguard` | Where per-session gate state is kept. If state cannot be persisted the gate allows the operation rather than looping, and names this variable in the warning. |
+
+`GATEGUARD_BASH_ROUTINE_DISABLED` accepts `1`, `true`, `on`, `enabled`,
+`enable`, or `yes` (case- and whitespace-insensitive); any other value
+leaves the gate on. `GATEGUARD_DISABLED` recognises `1` only.
+
+`GATEGUARD_EXEMPT_GLOBS` patterns are matched against the normalized
+(forward-slash, lowercased) file path: `*` matches within a path segment,
+`**` across segments, `?` a single character. Matching is fail-open — a
+malformed pattern is dropped rather than raising.
+
+```json
+{
+  "env": {
+    "GATEGUARD_BASH_ROUTINE_DISABLED": "1",
+    "GATEGUARD_EXEMPT_GLOBS": "**/tests/**,**/*.test.*,**/docs/**,**/dist/**"
+  }
+}
+```
+
 ### Option B: Full package with config
 
 ```bash

--- a/skills/gateguard/SKILL.md
+++ b/skills/gateguard/SKILL.md
@@ -108,8 +108,9 @@ command after presenting facts never re-triggers the gate.
 
 #### Graduated controls
 
-`ECC_GATEGUARD=off` disables the whole gate. The variables below narrow it
-instead, so the load-bearing destructive-Bash checks keep running:
+`ECC_GATEGUARD=off` (or `GATEGUARD_DISABLED=1`) turns the gate off entirely.
+The variables in this table do **not** — each narrows one behaviour while the
+load-bearing destructive-Bash checks keep running:
 
 | Variable | Default | Effect |
 |---|---|---|
@@ -117,23 +118,39 @@ instead, so the load-bearing destructive-Bash checks keep running:
 | `GATEGUARD_EXEMPT_GLOBS` | unset (no exemptions) | Comma-separated globs; a matching Edit/Write/MultiEdit target skips first-touch fact-forcing. Intended for low-import-value trees (tests, generated artifacts, scratch dirs) where "who imports this / what schema" carries no signal. |
 | `GATEGUARD_FACT_FORCE_FULL_DENIALS` | `3` | How many denials emit the full four-fact block before later ones condense to a single line. `0` condenses from the very first denial. |
 | `GATEGUARD_BASH_EXTRA_DESTRUCTIVE` | unset | Extra destructive-command patterns, as regex source, added to the built-in set. A malformed regex is treated as unset (built-ins still apply) and logged once to stderr. |
-| `GATEGUARD_DISABLED` | unset | `1` disables the gate entirely — equivalent to `ECC_GATEGUARD=off`. |
 | `GATEGUARD_STATE_DIR` | `~/.gateguard` | Where per-session gate state is kept. If state cannot be persisted the gate allows the operation rather than looping, and names this variable in the warning. |
 
 `GATEGUARD_BASH_ROUTINE_DISABLED` accepts `1`, `true`, `on`, `enabled`,
 `enable`, or `yes` (case- and whitespace-insensitive); any other value
-leaves the gate on. `GATEGUARD_DISABLED` recognises `1` only.
+leaves the gate on.
 
-`GATEGUARD_EXEMPT_GLOBS` patterns are matched against the normalized
-(forward-slash, lowercased) file path: `*` matches within a path segment,
-`**` across segments, `?` a single character. Matching is fail-open — a
-malformed pattern is dropped rather than raising.
+#### Turning the gate off completely
+
+| Variable | Effect |
+|---|---|
+| `ECC_GATEGUARD=off` | Disables GateGuard for the session. Accepts `0`, `false`, `off`, `disabled`, or `disable`. |
+| `GATEGUARD_DISABLED=1` | Same effect. Recognises `1` only — the spellings above do **not** apply here. |
+
+For hook-level control, keep using `ECC_DISABLED_HOOKS` with the GateGuard hook ID.
+
+#### Glob semantics for `GATEGUARD_EXEMPT_GLOBS`
+
+Patterns are matched, unanchored, against the target path with backslashes
+normalized to `/` and the whole string lowercased — the path exactly as the
+hook receives it, which for Claude Code tool payloads is absolute. `*` matches
+within a path segment, `**` across segments, `?` a single character. Matching
+is fail-open: a malformed pattern is dropped rather than raising.
+
+Note that a leading `**/` compiles to `.*/`, so it requires at least one
+preceding separator: `**/tests/**` exempts `/repo/tests/foo.js` but would not
+match a bare relative `tests/foo.js`. Add the separator-free form too if you
+pass relative paths:
 
 ```json
 {
   "env": {
     "GATEGUARD_BASH_ROUTINE_DISABLED": "1",
-    "GATEGUARD_EXEMPT_GLOBS": "**/tests/**,**/*.test.*,**/docs/**,**/dist/**"
+    "GATEGUARD_EXEMPT_GLOBS": "**/tests/**,tests/**,**/*.test.*,**/docs/**,**/dist/**"
   }
 }
 ```

--- a/skills/skill-comply/pyproject.toml
+++ b/skills/skill-comply/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = ["pyyaml>=6.0"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+markers = ["unit: isolated tests without external services"]
 
 [dependency-groups]
 dev = [

--- a/skills/skill-comply/scripts/runner.py
+++ b/skills/skill-comply/scripts/runner.py
@@ -24,6 +24,7 @@ ALLOWED_SETUP_EXECUTABLES = frozenset({
 # controlled by the cwd= keyword. Scenarios that include these in
 # setup_commands (a common shell-style convention) must be tolerated.
 SHELL_BUILTINS = frozenset({"cd", "pushd", "popd"})
+REPORT_VALUE_LIMIT = 5000
 
 
 @dataclass(frozen=True)
@@ -132,10 +133,40 @@ def _redact_home_path(text: str) -> str:
     itself, which lives under a tempdir but scenario setup_commands or
     an agent's own tool calls can still reference $HOME directly).
     """
-    home = str(Path.home())
-    if home and home != "/" and home in text:
-        return text.replace(home, "~")
-    return text
+    home = str(Path.home()).rstrip("/\\")
+    if not home or home == "/" or re.fullmatch(r"[A-Za-z]:", home):
+        return text
+
+    parts = re.split(r"[\\/]+", home)
+    home_pattern = r"[\\/]".join(re.escape(part) for part in parts)
+    right_boundary = r"(?=$|[\\/]|[\s\"'`,;:)}\]])"
+    flags = re.IGNORECASE if re.match(r"^[A-Za-z]:[\\/]", home) else 0
+    pattern = re.compile(
+        rf"(?<![\w.~+-]){home_pattern}{right_boundary}",
+        flags,
+    )
+    return pattern.sub("~", text)
+
+
+def _redact_home_paths(value: object) -> object:
+    """Return a copy with home paths redacted from every string leaf."""
+    if isinstance(value, str):
+        return _redact_home_path(value)
+    if isinstance(value, dict):
+        return {key: _redact_home_paths(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_redact_home_paths(item) for item in value]
+    return value
+
+
+def _serialize_report_value(value: object) -> str:
+    """Redact structured report data before encoding and truncating it."""
+    redacted = _redact_home_paths(value)
+    if isinstance(redacted, (dict, list)):
+        serialized = json.dumps(redacted)
+    else:
+        serialized = str(redacted)
+    return serialized[:REPORT_VALUE_LIMIT]
 
 
 def _parse_stream_json(stdout: str) -> list[ObservationEvent]:
@@ -163,14 +194,9 @@ def _parse_stream_json(stdout: str) -> list[ObservationEvent]:
                 if block.get("type") == "tool_use":
                     tool_use_id = block.get("id", "")
                     tool_input = block.get("input", {})
-                    input_str = (
-                        json.dumps(tool_input)[:5000]
-                        if isinstance(tool_input, dict)
-                        else str(tool_input)[:5000]
-                    )
                     pending[tool_use_id] = {
                         "tool": block.get("name", "unknown"),
-                        "input": _redact_home_path(input_str),
+                        "input": _serialize_report_value(tool_input),
                         "order": event_counter,
                     }
                     event_counter += 1
@@ -183,18 +209,13 @@ def _parse_stream_json(stdout: str) -> list[ObservationEvent]:
                     if tool_use_id in pending:
                         info = pending.pop(tool_use_id)
                         output_content = block.get("content", "")
-                        if isinstance(output_content, list):
-                            output_str = json.dumps(output_content)[:5000]
-                        else:
-                            output_str = str(output_content)[:5000]
-
                         events.append(ObservationEvent(
                             timestamp=f"T{info['order']:04d}",
                             event="tool_complete",
                             tool=info["tool"],
                             session=msg.get("session_id", "unknown"),
                             input=info["input"],
-                            output=_redact_home_path(output_str),
+                            output=_serialize_report_value(output_content),
                         ))
 
     for _tool_use_id, info in pending.items():

--- a/skills/skill-comply/scripts/runner.py
+++ b/skills/skill-comply/scripts/runner.py
@@ -122,6 +122,22 @@ def _setup_sandbox(sandbox_dir: Path, scenario: Scenario) -> None:
             continue
 
 
+def _redact_home_path(text: str) -> str:
+    """Replace the operator's home directory with a portable placeholder.
+
+    Observations flow into grade() and then into a written report
+    (results/<skill>.md) that's meant to be read, diffed, and shared —
+    an absolute path bakes the operator's username into every tool call
+    that happened to touch anything under $HOME (including the sandbox
+    itself, which lives under a tempdir but scenario setup_commands or
+    an agent's own tool calls can still reference $HOME directly).
+    """
+    home = str(Path.home())
+    if home and home != "/" and home in text:
+        return text.replace(home, "~")
+    return text
+
+
 def _parse_stream_json(stdout: str) -> list[ObservationEvent]:
     """Parse claude -p stream-json output into ObservationEvents.
 
@@ -154,7 +170,7 @@ def _parse_stream_json(stdout: str) -> list[ObservationEvent]:
                     )
                     pending[tool_use_id] = {
                         "tool": block.get("name", "unknown"),
-                        "input": input_str,
+                        "input": _redact_home_path(input_str),
                         "order": event_counter,
                     }
                     event_counter += 1
@@ -178,7 +194,7 @@ def _parse_stream_json(stdout: str) -> list[ObservationEvent]:
                             tool=info["tool"],
                             session=msg.get("session_id", "unknown"),
                             input=info["input"],
-                            output=output_str,
+                            output=_redact_home_path(output_str),
                         ))
 
     for _tool_use_id, info in pending.items():

--- a/skills/skill-comply/scripts/runner.py
+++ b/skills/skill-comply/scripts/runner.py
@@ -149,11 +149,25 @@ def _redact_home_path(text: str) -> str:
 
 
 def _redact_home_paths(value: object) -> object:
-    """Return a copy with home paths redacted from every string leaf."""
+    """Return a copy with home paths redacted from string keys and leaves.
+
+    Redacted mapping keys receive a stable numeric suffix when two original
+    keys collapse to the same portable value. This preserves every observation
+    without leaking the original home path or silently dropping data.
+    """
     if isinstance(value, str):
         return _redact_home_path(value)
     if isinstance(value, dict):
-        return {key: _redact_home_paths(item) for key, item in value.items()}
+        redacted: dict[object, object] = {}
+        for key, item in value.items():
+            redacted_key = _redact_home_path(key) if isinstance(key, str) else key
+            candidate = redacted_key
+            suffix = 2
+            while candidate in redacted:
+                candidate = f"{redacted_key}#{suffix}"
+                suffix += 1
+            redacted[candidate] = _redact_home_paths(item)
+        return redacted
     if isinstance(value, list):
         return [_redact_home_paths(item) for item in value]
     return value

--- a/skills/skill-comply/tests/test_runner.py
+++ b/skills/skill-comply/tests/test_runner.py
@@ -6,9 +6,12 @@ import subprocess
 from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
+import json
+from pathlib import Path
+
 import pytest
 
-from scripts.runner import _setup_sandbox, run_scenario
+from scripts.runner import _parse_stream_json, _setup_sandbox, run_scenario
 
 
 @dataclass(frozen=True)
@@ -141,6 +144,52 @@ class TestRunScenarioMaxTurnsTermination:
         with patch("scripts.runner.subprocess.run", return_value=fake_result):
             with pytest.raises(RuntimeError, match="claude -p failed"):
                 run_scenario(scenario, model="haiku")
+
+
+class TestParseStreamJsonRedactsHomePath:
+    """Observations feed grade() and then a written report (results/<skill>.md) —
+    a raw absolute path bakes the operator's username into every tool call
+    that touched anything under $HOME. --add-dir restricts the sandbox, but
+    scenario setup_commands or the model's own tool calls can still reference
+    $HOME directly (e.g. a Bash command using ~ expansion, or a scenario that
+    legitimately needs to read a dotfile). Redact to a portable placeholder
+    rather than persisting the raw path.
+    """
+
+    def _stream_json_for(self, tool_input: dict, output_text: str) -> str:
+        return (
+            '{"type":"assistant","message":{"content":[{"type":"tool_use",'
+            '"id":"tu1","name":"Read","input":' + json.dumps(tool_input) + "}]}}\n"
+            '{"type":"user","session_id":"s1","message":{"content":[{"type":'
+            '"tool_result","tool_use_id":"tu1","content":' + json.dumps(output_text) + "}]}}\n"
+        )
+
+    def test_input_home_path_redacted(self):
+        home = str(Path.home())
+        stdout = self._stream_json_for(
+            {"file_path": f"{home}/notes/secrets.env"}, "irrelevant output"
+        )
+        events = _parse_stream_json(stdout)
+        assert len(events) == 1
+        assert home not in events[0].input
+        assert "~/notes/secrets.env" in events[0].input
+
+    def test_output_home_path_redacted(self):
+        home = str(Path.home())
+        stdout = self._stream_json_for(
+            {"file_path": "irrelevant"}, f"wrote to {home}/notes/secrets.env"
+        )
+        events = _parse_stream_json(stdout)
+        assert len(events) == 1
+        assert home not in events[0].output
+        assert "~/notes/secrets.env" in events[0].output
+
+    def test_paths_outside_home_untouched(self):
+        stdout = self._stream_json_for(
+            {"file_path": "/tmp/skill-comply-sandbox/t1/file.txt"}, "ok"
+        )
+        events = _parse_stream_json(stdout)
+        assert "/tmp/skill-comply-sandbox/t1/file.txt" in events[0].input
 
 
 class TestRunScenarioErrorIncludesStdoutTail:

--- a/skills/skill-comply/tests/test_runner.py
+++ b/skills/skill-comply/tests/test_runner.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from dataclasses import dataclass
-from unittest.mock import MagicMock, patch
-
-import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
-
 from scripts.runner import _parse_stream_json, _setup_sandbox, run_scenario
 
 
@@ -156,40 +154,115 @@ class TestParseStreamJsonRedactsHomePath:
     rather than persisting the raw path.
     """
 
-    def _stream_json_for(self, tool_input: dict, output_text: str) -> str:
+    def _stream_json_for(self, tool_input: dict, output_content: object) -> str:
         return (
             '{"type":"assistant","message":{"content":[{"type":"tool_use",'
             '"id":"tu1","name":"Read","input":' + json.dumps(tool_input) + "}]}}\n"
             '{"type":"user","session_id":"s1","message":{"content":[{"type":'
-            '"tool_result","tool_use_id":"tu1","content":' + json.dumps(output_text) + "}]}}\n"
+            '"tool_result","tool_use_id":"tu1","content":' + json.dumps(output_content) + "}]}}\n"
         )
 
-    def test_input_home_path_redacted(self):
-        home = str(Path.home())
+    @staticmethod
+    def _set_home(monkeypatch: pytest.MonkeyPatch, home: str) -> None:
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: Path(home)))
+
+    def test_posix_input_string_leaves_and_embedded_paths_redacted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = "/home/alice"
+        self._set_home(monkeypatch, home)
         stdout = self._stream_json_for(
-            {"file_path": f"{home}/notes/secrets.env"}, "irrelevant output"
+            {
+                "command": f"cat '{home}/notes/secrets.env' && echo home={home}, done",
+                "nested": {"paths": [f"{home}/one", f"{home}/two"]},
+            },
+            "irrelevant output",
         )
         events = _parse_stream_json(stdout)
+
         assert len(events) == 1
         assert home not in events[0].input
-        assert "~/notes/secrets.env" in events[0].input
+        parsed_input = json.loads(events[0].input)
+        assert parsed_input["command"] == "cat '~/notes/secrets.env' && echo home=~, done"
+        assert parsed_input["nested"]["paths"] == ["~/one", "~/two"]
 
-    def test_output_home_path_redacted(self):
-        home = str(Path.home())
+    def test_windows_home_with_unicode_and_backslashes_redacted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = r"C:\Users\Zoë"
+        self._set_home(monkeypatch, home)
         stdout = self._stream_json_for(
-            {"file_path": "irrelevant"}, f"wrote to {home}/notes/secrets.env"
+            {
+                "paths": [
+                    home + r"\Documents\résumé.txt",
+                    "C:/Users/Zoë/資料.txt",
+                ]
+            },
+            "irrelevant output",
         )
         events = _parse_stream_json(stdout)
+
         assert len(events) == 1
-        assert home not in events[0].output
-        assert "~/notes/secrets.env" in events[0].output
+        parsed_input = json.loads(events[0].input)
+        assert parsed_input["paths"] == [
+            r"~\Documents\résumé.txt",
+            "~/資料.txt",
+        ]
 
-    def test_paths_outside_home_untouched(self):
+    def test_sibling_and_embedded_prefix_paths_untouched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = "/home/alice"
+        self._set_home(monkeypatch, home)
+        outside_paths = [
+            "/home/alice-old/report.txt",
+            "/home/alice2/report.txt",
+            "/tmp/home/alice/report.txt",
+        ]
         stdout = self._stream_json_for(
-            {"file_path": "/tmp/skill-comply-sandbox/t1/file.txt"}, "ok"
+            {"paths": outside_paths},
+            [{"type": "text", "text": path} for path in outside_paths],
         )
         events = _parse_stream_json(stdout)
-        assert "/tmp/skill-comply-sandbox/t1/file.txt" in events[0].input
+
+        assert json.loads(events[0].input)["paths"] == outside_paths
+        assert [item["text"] for item in json.loads(events[0].output)] == outside_paths
+
+    def test_list_output_redacts_nested_string_leaves(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = "/Users/reviewer"
+        self._set_home(monkeypatch, home)
+        output_content = [
+            {"type": "text", "text": f"created {home}/résumé.txt"},
+            {"type": "metadata", "paths": [home, f"{home}/資料.json"]},
+        ]
+        stdout = self._stream_json_for({"file_path": "irrelevant"}, output_content)
+        events = _parse_stream_json(stdout)
+
+        assert json.loads(events[0].output) == [
+            {"type": "text", "text": "created ~/résumé.txt"},
+            {"type": "metadata", "paths": ["~", "~/資料.json"]},
+        ]
+
+    def test_redacts_before_json_serialization_and_5000_character_truncation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = "/home/alice"
+        self._set_home(monkeypatch, home)
+        boundary_value = "x" * 4977 + f" {home}/secret.txt" + "tail" * 20
+        stdout = self._stream_json_for(
+            {"command": boundary_value},
+            boundary_value,
+        )
+        events = _parse_stream_json(stdout)
+
+        assert len(events[0].input) == 5000
+        assert "~/secret" in events[0].input
+        assert "/home/" not in events[0].input
+        assert len(events[0].output) == 5000
+        assert "~/secret.txt" in events[0].output
+        assert "/home/" not in events[0].output
 
 
 class TestRunScenarioErrorIncludesStdoutTail:

--- a/skills/skill-comply/tests/test_runner.py
+++ b/skills/skill-comply/tests/test_runner.py
@@ -144,6 +144,7 @@ class TestRunScenarioMaxTurnsTermination:
                 run_scenario(scenario, model="haiku")
 
 
+@pytest.mark.unit
 class TestParseStreamJsonRedactsHomePath:
     """Observations feed grade() and then a written report (results/<skill>.md) —
     a raw absolute path bakes the operator's username into every tool call
@@ -208,6 +209,27 @@ class TestParseStreamJsonRedactsHomePath:
             r"~\Documents\résumé.txt",
             "~/資料.txt",
         ]
+
+    def test_mapping_keys_are_redacted_without_silent_collision(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = r"C:\Users\Zoë"
+        self._set_home(monkeypatch, home)
+        stdout = self._stream_json_for(
+            {
+                home + r"\private.txt": "first",
+                r"c:\users\zoë\private.txt": "second",
+            },
+            "irrelevant output",
+        )
+        events = _parse_stream_json(stdout)
+
+        parsed_input = json.loads(events[0].input)
+        assert home not in events[0].input
+        assert parsed_input == {
+            r"~\private.txt": "first",
+            r"~\private.txt#2": "second",
+        }
 
     def test_sibling_and_embedded_prefix_paths_untouched(
         self, monkeypatch: pytest.MonkeyPatch

--- a/skills/skill-stocktake/scripts/quick-diff.sh
+++ b/skills/skill-stocktake/scripts/quick-diff.sh
@@ -51,6 +51,17 @@ i=0
 
 process_dir() {
   local dir="$1"
+  local find_out="$tmpdir/.find-stdout"
+  local find_err="$tmpdir/.find-stderr"
+  # Capture find's exit status and stderr instead of discarding them: with -L,
+  # a broken symlink or unreadable directory makes find skip that entry AND
+  # exit non-zero, which would otherwise silently under-count skills.
+  if ! find -L "$dir" -name "SKILL.md" -type f >"$find_out" 2>"$find_err"; then
+    echo "Warning: find encountered errors while scanning $dir (broken symlinks or permission issues may cause skills to be missed):" >&2
+    cat "$find_err" >&2
+  fi
+  sort -o "$find_out" "$find_out"
+
   while IFS= read -r file; do
     local mtime dp is_new
     mtime=$(date -u -r "$file" +%Y-%m-%dT%H:%M:%SZ)
@@ -74,7 +85,7 @@ process_dir() {
       '{path:$path,mtime:$mtime,is_new:$is_new}' \
       > "$tmpdir/$i.json"
     i=$((i+1))
-  done < <(find -L "$dir" -name "SKILL.md" -type f 2>/dev/null | sort)
+  done < "$find_out"
 }
 
 [[ -d "$GLOBAL_DIR" ]] && process_dir "$GLOBAL_DIR"

--- a/skills/skill-stocktake/scripts/quick-diff.sh
+++ b/skills/skill-stocktake/scripts/quick-diff.sh
@@ -56,13 +56,15 @@ process_dir() {
   # Capture find's exit status and stderr instead of discarding them: with -L,
   # a broken symlink or unreadable directory makes find skip that entry AND
   # exit non-zero, which would otherwise silently under-count skills.
-  if ! find -L "$dir" -name "SKILL.md" -type f >"$find_out" 2>"$find_err"; then
+  # NUL-delimited (-print0 / sort -z / read -d '') so a path containing a
+  # literal newline can't desync record boundaries — paths here are untrusted.
+  if ! find -L "$dir" -name "SKILL.md" -type f -print0 >"$find_out" 2>"$find_err"; then
     echo "Warning: find encountered errors while scanning $dir (broken symlinks or permission issues may cause skills to be missed):" >&2
     cat "$find_err" >&2
   fi
-  sort -o "$find_out" "$find_out"
+  sort -z -o "$find_out" "$find_out"
 
-  while IFS= read -r file; do
+  while IFS= read -r -d '' file; do
     local mtime dp is_new
     mtime=$(date -u -r "$file" +%Y-%m-%dT%H:%M:%SZ)
     dp="${file/#$HOME/~}"

--- a/skills/skill-stocktake/scripts/quick-diff.sh
+++ b/skills/skill-stocktake/scripts/quick-diff.sh
@@ -74,7 +74,7 @@ process_dir() {
       '{path:$path,mtime:$mtime,is_new:$is_new}' \
       > "$tmpdir/$i.json"
     i=$((i+1))
-  done < <(find "$dir" -name "*.md" -type f 2>/dev/null | sort)
+  done < <(find -L "$dir" -name "SKILL.md" -type f 2>/dev/null | sort)
 }
 
 [[ -d "$GLOBAL_DIR" ]] && process_dir "$GLOBAL_DIR"

--- a/skills/skill-stocktake/scripts/quick-diff.sh
+++ b/skills/skill-stocktake/scripts/quick-diff.sh
@@ -13,6 +13,27 @@
 
 set -euo pipefail
 
+sort_nul_file() {
+  local input_file="$1"
+  local sorted_file="${input_file}.sorted"
+  node -e '
+    const fs = require("fs");
+    const input = fs.readFileSync(0);
+    const records = [];
+    let start = 0;
+    for (let index = 0; index < input.length; index += 1) {
+      if (input[index] === 0) {
+        records.push(input.subarray(start, index + 1));
+        start = index + 1;
+      }
+    }
+    if (start < input.length) records.push(input.subarray(start));
+    records.sort(Buffer.compare);
+    process.stdout.write(Buffer.concat(records));
+  ' <"$input_file" >"$sorted_file"
+  mv "$sorted_file" "$input_file"
+}
+
 RESULTS_JSON="${1:-}"
 CWD_SKILLS_DIR="${SKILL_STOCKTAKE_PROJECT_DIR:-${2:-$PWD/.claude/skills}}"
 GLOBAL_DIR="${SKILL_STOCKTAKE_GLOBAL_DIR:-$HOME/.claude/skills}"
@@ -56,13 +77,13 @@ process_dir() {
   # Capture find's exit status and stderr instead of discarding them: with -L,
   # a broken symlink or unreadable directory makes find skip that entry AND
   # exit non-zero, which would otherwise silently under-count skills.
-  # NUL-delimited (-print0 / sort -z / read -d '') so a path containing a
+  # NUL-delimited (-print0 / sort_nul_file / read -d '') so a path containing a
   # literal newline can't desync record boundaries — paths here are untrusted.
   if ! find -L "$dir" -name "SKILL.md" -type f -print0 >"$find_out" 2>"$find_err"; then
     echo "Warning: find encountered errors while scanning $dir (broken symlinks or permission issues may cause skills to be missed):" >&2
     cat "$find_err" >&2
   fi
-  sort -z -o "$find_out" "$find_out"
+  sort_nul_file "$find_out"
 
   while IFS= read -r -d '' file; do
     local mtime dp is_new

--- a/skills/skill-stocktake/scripts/scan.sh
+++ b/skills/skill-stocktake/scripts/scan.sh
@@ -118,7 +118,7 @@ scan_dir_to_json() {
       '{path:$path,name:$name,description:$description,use_7d:$use_7d,use_30d:$use_30d,mtime:$mtime}' \
       > "$tmpdir/$i.json"
     i=$((i+1))
-  done < <(find "$dir" -name "*.md" -type f 2>/dev/null | sort)
+  done < <(find -L "$dir" -name "SKILL.md" -type f 2>/dev/null | sort)
 
   if [[ $i -eq 0 ]]; then
     echo "[]"

--- a/skills/skill-stocktake/scripts/scan.sh
+++ b/skills/skill-stocktake/scripts/scan.sh
@@ -95,6 +95,17 @@ scan_dir_to_json() {
   fi
 
   local i=0
+  local find_out="$tmpdir/.find-stdout"
+  local find_err="$tmpdir/.find-stderr"
+  # Capture find's exit status and stderr instead of discarding them: with -L,
+  # a broken symlink or unreadable directory makes find skip that entry AND
+  # exit non-zero, which would otherwise silently under-count skills.
+  if ! find -L "$dir" -name "SKILL.md" -type f >"$find_out" 2>"$find_err"; then
+    echo "Warning: find encountered errors while scanning $dir (broken symlinks or permission issues may cause skills to be missed):" >&2
+    cat "$find_err" >&2
+  fi
+  sort -o "$find_out" "$find_out"
+
   while IFS= read -r file; do
     local name desc mtime u7 u30 dp
     name=$(extract_field "$file" "name")
@@ -118,7 +129,7 @@ scan_dir_to_json() {
       '{path:$path,name:$name,description:$description,use_7d:$use_7d,use_30d:$use_30d,mtime:$mtime}' \
       > "$tmpdir/$i.json"
     i=$((i+1))
-  done < <(find -L "$dir" -name "SKILL.md" -type f 2>/dev/null | sort)
+  done < "$find_out"
 
   if [[ $i -eq 0 ]]; then
     echo "[]"

--- a/skills/skill-stocktake/scripts/scan.sh
+++ b/skills/skill-stocktake/scripts/scan.sh
@@ -100,13 +100,15 @@ scan_dir_to_json() {
   # Capture find's exit status and stderr instead of discarding them: with -L,
   # a broken symlink or unreadable directory makes find skip that entry AND
   # exit non-zero, which would otherwise silently under-count skills.
-  if ! find -L "$dir" -name "SKILL.md" -type f >"$find_out" 2>"$find_err"; then
+  # NUL-delimited (-print0 / sort -z / read -d '') so a path containing a
+  # literal newline can't desync record boundaries — paths here are untrusted.
+  if ! find -L "$dir" -name "SKILL.md" -type f -print0 >"$find_out" 2>"$find_err"; then
     echo "Warning: find encountered errors while scanning $dir (broken symlinks or permission issues may cause skills to be missed):" >&2
     cat "$find_err" >&2
   fi
-  sort -o "$find_out" "$find_out"
+  sort -z -o "$find_out" "$find_out"
 
-  while IFS= read -r file; do
+  while IFS= read -r -d '' file; do
     local name desc mtime u7 u30 dp
     name=$(extract_field "$file" "name")
     desc=$(extract_field "$file" "description")

--- a/skills/skill-stocktake/scripts/scan.sh
+++ b/skills/skill-stocktake/scripts/scan.sh
@@ -13,6 +13,27 @@
 
 set -euo pipefail
 
+sort_nul_file() {
+  local input_file="$1"
+  local sorted_file="${input_file}.sorted"
+  node -e '
+    const fs = require("fs");
+    const input = fs.readFileSync(0);
+    const records = [];
+    let start = 0;
+    for (let index = 0; index < input.length; index += 1) {
+      if (input[index] === 0) {
+        records.push(input.subarray(start, index + 1));
+        start = index + 1;
+      }
+    }
+    if (start < input.length) records.push(input.subarray(start));
+    records.sort(Buffer.compare);
+    process.stdout.write(Buffer.concat(records));
+  ' <"$input_file" >"$sorted_file"
+  mv "$sorted_file" "$input_file"
+}
+
 GLOBAL_DIR="${SKILL_STOCKTAKE_GLOBAL_DIR:-$HOME/.claude/skills}"
 CWD_SKILLS_DIR="${SKILL_STOCKTAKE_PROJECT_DIR:-${1:-$PWD/.claude/skills}}"
 # Path to JSONL file containing tool-use observations (optional; used for usage frequency counts).
@@ -100,13 +121,13 @@ scan_dir_to_json() {
   # Capture find's exit status and stderr instead of discarding them: with -L,
   # a broken symlink or unreadable directory makes find skip that entry AND
   # exit non-zero, which would otherwise silently under-count skills.
-  # NUL-delimited (-print0 / sort -z / read -d '') so a path containing a
+  # NUL-delimited (-print0 / sort_nul_file / read -d '') so a path containing a
   # literal newline can't desync record boundaries — paths here are untrusted.
   if ! find -L "$dir" -name "SKILL.md" -type f -print0 >"$find_out" 2>"$find_err"; then
     echo "Warning: find encountered errors while scanning $dir (broken symlinks or permission issues may cause skills to be missed):" >&2
     cat "$find_err" >&2
   fi
-  sort -z -o "$find_out" "$find_out"
+  sort_nul_file "$find_out"
 
   while IFS= read -r -d '' file; do
     local name desc mtime u7 u30 dp

--- a/tests/ci/gateguard-env-documented.test.js
+++ b/tests/ci/gateguard-env-documented.test.js
@@ -8,6 +8,18 @@
  * This pins the surface: adding a knob to the hook without documenting it
  * fails here.
  *
+ * The env reads are extracted from *code only* — comments, string literals,
+ * template-literal text and regex literals are blanked out first, so a knob
+ * named in a comment or an error message is never mistaken for a read. And
+ * because a regex scanner cannot see every possible access form, the supported
+ * forms are enforced as a convention rather than assumed: any other way of
+ * reaching `process.env` fails the guard below with instructions, instead of
+ * silently letting an undocumented knob through.
+ *
+ * Supported (and enforced) read forms:
+ *   process.env.GATEGUARD_X
+ *   process.env['GATEGUARD_X']   // or "GATEGUARD_X"
+ *
  * Run with: node tests/ci/gateguard-env-documented.test.js
  */
 
@@ -36,14 +48,170 @@ function test(name, fn) {
   }
 }
 
+/** A `/` here starts a regex literal, not a division. */
+const REGEX_CAN_FOLLOW = new Set([
+  '', '(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';', '+', '-', '*', '%', '~', '^', '<', '>',
+]);
+
+/**
+ * Blank out comments and literal text, preserving length and line breaks so
+ * offsets stay comparable with the raw source.
+ *
+ * Code inside a template literal's `${...}` is preserved — it is real code and
+ * may contain an env read — while the surrounding literal text is blanked.
+ */
+function blankCommentsAndLiterals(source) {
+  const out = [];
+  const emit = (ch) => out.push(ch === '\n' ? '\n' : ' ');
+  const keep = (ch) => out.push(ch);
+
+  let i = 0;
+  let prev = '';
+  // Stack of open template literals. 0 = in literal text, >=1 = inside `${...}`
+  // (the number tracks brace nesting within the expression).
+  const templates = [];
+  const inTemplateText = () => templates.length > 0 && templates[templates.length - 1] === 0;
+
+  while (i < source.length) {
+    const ch = source[i];
+    const next = source[i + 1];
+
+    // Template-literal TEXT is handled first: inside it, `//`, quotes and `/`
+    // are literal characters, not comments, strings or regexes.
+    if (inTemplateText()) {
+      if (ch === '\\') { emit(ch); if (i + 1 < source.length) { emit(source[i + 1]); } i += 2; continue; }
+      if (ch === '`') { templates.pop(); emit(ch); prev = '`'; i += 1; continue; }
+      if (ch === '$' && next === '{') {
+        templates[templates.length - 1] = 1;
+        keep(ch); keep(next); prev = '{'; i += 2;
+        continue;
+      }
+      emit(ch); i += 1;
+      continue;
+    }
+
+    if (ch === '/' && next === '/') {
+      while (i < source.length && source[i] !== '\n') { emit(source[i]); i += 1; }
+      continue;
+    }
+
+    if (ch === '/' && next === '*') {
+      emit(ch); emit(next); i += 2;
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) { emit(source[i]); i += 1; }
+      if (i < source.length) { emit('*'); emit('/'); i += 2; }
+      continue;
+    }
+
+    if (ch === '/' && REGEX_CAN_FOLLOW.has(prev)) {
+      emit(ch); i += 1;
+      let inClass = false;
+      while (i < source.length) {
+        const r = source[i];
+        if (r === '\\') { emit(r); if (i + 1 < source.length) { emit(source[i + 1]); } i += 2; continue; }
+        if (r === '[') { inClass = true; }
+        else if (r === ']') { inClass = false; }
+        else if (r === '/' && !inClass) { emit(r); i += 1; break; }
+        else if (r === '\n') { break; }
+        emit(r); i += 1;
+      }
+      prev = '/';
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      emit(ch); i += 1;
+      while (i < source.length) {
+        const s = source[i];
+        if (s === '\\') { emit(s); if (i + 1 < source.length) { emit(source[i + 1]); } i += 2; continue; }
+        if (s === quote) { emit(s); i += 1; break; }
+        if (s === '\n') { break; }
+        emit(s); i += 1;
+      }
+      prev = quote;
+      continue;
+    }
+
+    if (ch === '`') {
+      templates.push(0);
+      emit(ch); i += 1;
+      continue;
+    }
+
+    if (templates.length > 0 && ch === '}') {
+      const depth = templates[templates.length - 1];
+      if (depth === 1) { templates[templates.length - 1] = 0; keep(ch); i += 1; prev = '}'; continue; }
+      if (depth > 1) { templates[templates.length - 1] = depth - 1; }
+    }
+    if (templates.length > 0 && ch === '{' && templates[templates.length - 1] >= 1) {
+      templates[templates.length - 1] += 1;
+    }
+
+    keep(ch);
+    if (!/\s/.test(ch)) { prev = ch; }
+    i += 1;
+  }
+
+  return out.join('');
+}
+
+const DOTTED_READ = /process\.env\.(GATEGUARD_[A-Z0-9_]+)/g;
+const QUOTED_KEY = /^(['"])(GATEGUARD_[A-Z0-9_]+)\1$/;
+const PLAIN_QUOTED_KEY = /^(['"])[A-Za-z0-9_]+\1$/;
+
+function matchAll(source, pattern) {
+  return [...source.matchAll(pattern)].map(m => m[1]);
+}
+
+/**
+ * Keys used in `process.env[...]`, located in code but read from the raw source.
+ *
+ * Blanking replaces literal *text* with spaces, which would erase the key
+ * itself — so the bracket positions are found in the blanked code (proving the
+ * access is real code, not a comment or a doc string) and the key is then read
+ * back out of the raw source at the same offset. `blankCommentsAndLiterals`
+ * preserves length, which is what makes the offsets interchangeable.
+ */
+function bracketedEnvKeys(source) {
+  const code = blankCommentsAndLiterals(source);
+  return [...code.matchAll(/process\.env\s*\[/g)]
+    .map((m) => {
+      const at = source.slice(m.index).match(/^process\.env\s*\[\s*([^\]]*?)\s*\]/);
+      return at ? at[1] : null;
+    })
+    .filter(key => key !== null);
+}
+
+/** GATEGUARD_* env reads present in real code (comments and literals excluded). */
 function readGateguardEnvNames(source) {
-  // process.env.GATEGUARD_X and process.env['GATEGUARD_X']
-  const dotted = source.match(/process\.env\.GATEGUARD_[A-Z0-9_]+/g) || [];
-  const bracketed = source.match(/process\.env\[\s*['"]GATEGUARD_[A-Z0-9_]+['"]\s*\]/g) || [];
-  const names = [...dotted, ...bracketed]
-    .map(hit => (hit.match(/GATEGUARD_[A-Z0-9_]+/) || [])[0])
+  const code = blankCommentsAndLiterals(source);
+  const bracketed = bracketedEnvKeys(source)
+    .map(key => (key.match(QUOTED_KEY) || [])[2])
     .filter(Boolean);
-  return new Set(names);
+  return new Set([...matchAll(code, DOTTED_READ), ...bracketed]);
+}
+
+/**
+ * Access forms this parser cannot follow. Each would let a GATEGUARD_* read
+ * escape the documentation check, so they are rejected outright.
+ */
+const UNSUPPORTED_ACCESS = [
+  { label: 'destructuring from process.env', pattern: /\}\s*=\s*process\.env\b/ },
+  { label: 'process.env aliased to a binding', pattern: /(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*=\s*process\.env\s*(?:[;,)\]]|$)/m },
+  { label: 'spread of process.env', pattern: /\.\.\.\s*process\.env\b/ },
+  { label: 'enumeration of process.env', pattern: /Object\.(?:keys|values|entries|assign|fromEntries)\(\s*process\.env\b/ },
+];
+
+/** `process.env[...]` whose key is not a plain quoted string. */
+function findComputedEnvAccess(source) {
+  return bracketedEnvKeys(source).filter(key => !PLAIN_QUOTED_KEY.test(key));
+}
+
+function findUnsupportedAccess(source) {
+  const code = blankCommentsAndLiterals(source);
+  const structural = UNSUPPORTED_ACCESS.filter(rule => rule.pattern.test(code)).map(rule => rule.label);
+  const computed = findComputedEnvAccess(source).map(key => `computed process.env[${key}]`);
+  return [...structural, ...computed];
 }
 
 console.log('\nGateGuard env-var documentation surface\n');
@@ -77,6 +245,74 @@ if (test('the documented knobs are the ones the hook actually reads', () => {
   const documented = [...new Set(skillDoc.match(/GATEGUARD_[A-Z0-9_]+/g) || [])];
   const stale = documented.filter(name => !envNames.has(name)).sort();
   assert.deepStrictEqual(stale, [], `documented but unread by the hook: ${stale.join(', ')}`);
+})) passed++; else failed++;
+
+if (test('the hook reaches process.env only through the supported literal forms', () => {
+  const unsupported = findUnsupportedAccess(hookSource).sort();
+  assert.deepStrictEqual(
+    unsupported,
+    [],
+    'the hook uses an env access form this test cannot follow, so an undocumented '
+    + 'GATEGUARD_* knob could bypass the check. Either keep to '
+    + "`process.env.GATEGUARD_X` / `process.env['GATEGUARD_X']`, or teach "
+    + `readGateguardEnvNames the new form. Found: ${unsupported.join(', ')}`
+  );
+})) passed++; else failed++;
+
+// --- parser self-checks: the convention above is only worth as much as these ---
+
+if (test('blanking preserves offsets and line count', () => {
+  const blanked = blankCommentsAndLiterals(hookSource);
+  assert.strictEqual(blanked.length, hookSource.length, 'blanking changed the source length');
+  assert.strictEqual(
+    blanked.split('\n').length,
+    hookSource.split('\n').length,
+    'blanking changed the line count'
+  );
+})) passed++; else failed++;
+
+if (test('env reads are read from code, not from comments, strings or regexes', () => {
+  const fixture = [
+    "const a = process.env.GATEGUARD_REAL_ONE;",
+    "const b = process.env['GATEGUARD_REAL_TWO'];",
+    '// process.env.GATEGUARD_IN_LINE_COMMENT is only mentioned here',
+    '/* process.env.GATEGUARD_IN_BLOCK_COMMENT */',
+    "const msg = 'process.env.GATEGUARD_IN_STRING';",
+    'const tpl = `process.env.GATEGUARD_IN_TEMPLATE ${process.env.GATEGUARD_REAL_THREE}`;',
+    'const re = /process\\.env\\.GATEGUARD_IN_REGEX\\/\\//;',
+  ].join('\n');
+  const found = [...readGateguardEnvNames(fixture)].sort();
+  assert.deepStrictEqual(found, ['GATEGUARD_REAL_ONE', 'GATEGUARD_REAL_THREE', 'GATEGUARD_REAL_TWO']);
+})) passed++; else failed++;
+
+if (test('a regex literal containing a slash does not swallow the code after it', () => {
+  const fixture = 'const re = /a\\/\\/b/;\nconst x = process.env.GATEGUARD_AFTER_REGEX;';
+  assert.deepStrictEqual([...readGateguardEnvNames(fixture)], ['GATEGUARD_AFTER_REGEX']);
+})) passed++; else failed++;
+
+if (test('the access guard rejects every form the parser cannot follow', () => {
+  const cases = [
+    ['destructuring', 'const { GATEGUARD_HIDDEN } = process.env;'],
+    ['alias', 'const env = process.env;\nconst v = env.GATEGUARD_HIDDEN;'],
+    ['computed template', 'const v = process.env[`GATEGUARD_${suffix}`];'],
+    ['computed variable', 'const v = process.env[name];'],
+    ['spread', 'const all = { ...process.env };'],
+    ['enumeration', 'const ks = Object.keys(process.env);'],
+  ];
+  const missed = cases.filter(([, code]) => findUnsupportedAccess(code).length === 0).map(([label]) => label);
+  assert.deepStrictEqual(missed, [], `access guard missed: ${missed.join(', ')}`);
+})) passed++; else failed++;
+
+if (test('the access guard accepts the supported forms and ignores commented ones', () => {
+  const ok = [
+    'const v = process.env.GATEGUARD_STATE_DIR;',
+    "const v = process.env['GATEGUARD_STATE_DIR'];",
+    'const v = process.env["GATEGUARD_STATE_DIR"];',
+    '// const { GATEGUARD_HIDDEN } = process.env;',
+    "const doc = 'const { GATEGUARD_HIDDEN } = process.env;';",
+  ];
+  const wrong = ok.filter(code => findUnsupportedAccess(code).length > 0);
+  assert.deepStrictEqual(wrong, [], `false positives from the access guard: ${wrong.join(' | ')}`);
 })) passed++; else failed++;
 
 console.log(`\nPassed: ${passed}`);

--- a/tests/ci/gateguard-env-documented.test.js
+++ b/tests/ci/gateguard-env-documented.test.js
@@ -38,13 +38,12 @@ function test(name, fn) {
 
 function readGateguardEnvNames(source) {
   // process.env.GATEGUARD_X and process.env['GATEGUARD_X']
-  const names = new Set();
-  const dotted = /process\.env\.(GATEGUARD_[A-Z0-9_]+)/g;
-  const bracketed = /process\.env\[\s*['"](GATEGUARD_[A-Z0-9_]+)['"]\s*\]/g;
-  let m;
-  while ((m = dotted.exec(source)) !== null) names.add(m[1]);
-  while ((m = bracketed.exec(source)) !== null) names.add(m[1]);
-  return names;
+  const dotted = source.match(/process\.env\.GATEGUARD_[A-Z0-9_]+/g) || [];
+  const bracketed = source.match(/process\.env\[\s*['"]GATEGUARD_[A-Z0-9_]+['"]\s*\]/g) || [];
+  const names = [...dotted, ...bracketed]
+    .map(hit => (hit.match(/GATEGUARD_[A-Z0-9_]+/) || [])[0])
+    .filter(Boolean);
+  return new Set(names);
 }
 
 console.log('\nGateGuard env-var documentation surface\n');
@@ -73,10 +72,10 @@ if (test('every GATEGUARD_* variable the hook reads is documented', () => {
 
 if (test('the documented knobs are the ones the hook actually reads', () => {
   // Guards the reverse drift: a doc naming a knob the hook no longer reads.
-  const documented = [...new Set(
-    (skillDoc.match(/GATEGUARD_[A-Z0-9_]+/g) || [])
-  )];
-  const stale = documented.filter(name => !hookSource.includes(name)).sort();
+  // Compared against the parsed env reads, not raw source — a name surviving
+  // only in a comment or error string must not satisfy this.
+  const documented = [...new Set(skillDoc.match(/GATEGUARD_[A-Z0-9_]+/g) || [])];
+  const stale = documented.filter(name => !envNames.has(name)).sort();
   assert.deepStrictEqual(stale, [], `documented but unread by the hook: ${stale.join(', ')}`);
 })) passed++; else failed++;
 

--- a/tests/ci/gateguard-env-documented.test.js
+++ b/tests/ci/gateguard-env-documented.test.js
@@ -1,0 +1,88 @@
+/**
+ * Surface test for #2573: every GATEGUARD_* environment variable the hook
+ * reads must be documented in the GateGuard skill doc.
+ *
+ * `GATEGUARD_BASH_ROUTINE_DISABLED` shipped with no documentation at all and
+ * `GATEGUARD_EXEMPT_GLOBS` was mentioned only in a release note, so operators
+ * had no discoverable way to narrow the gate short of disabling it outright.
+ * This pins the surface: adding a knob to the hook without documenting it
+ * fails here.
+ *
+ * Run with: node tests/ci/gateguard-env-documented.test.js
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const hookPath = path.join(repoRoot, 'scripts', 'hooks', 'gateguard-fact-force.js');
+const skillPath = path.join(repoRoot, 'skills', 'gateguard', 'SKILL.md');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \u2713 ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  \u2717 ${name}`);
+    console.log(`    Error: ${err.message}`);
+    return false;
+  }
+}
+
+function readGateguardEnvNames(source) {
+  // process.env.GATEGUARD_X and process.env['GATEGUARD_X']
+  const names = new Set();
+  const dotted = /process\.env\.(GATEGUARD_[A-Z0-9_]+)/g;
+  const bracketed = /process\.env\[\s*['"](GATEGUARD_[A-Z0-9_]+)['"]\s*\]/g;
+  let m;
+  while ((m = dotted.exec(source)) !== null) names.add(m[1]);
+  while ((m = bracketed.exec(source)) !== null) names.add(m[1]);
+  return names;
+}
+
+console.log('\nGateGuard env-var documentation surface\n');
+
+if (test('hook and skill doc both exist', () => {
+  assert.ok(fs.existsSync(hookPath), `missing ${hookPath}`);
+  assert.ok(fs.existsSync(skillPath), `missing ${skillPath}`);
+})) passed++; else failed++;
+
+const hookSource = fs.existsSync(hookPath) ? fs.readFileSync(hookPath, 'utf8') : '';
+const skillDoc = fs.existsSync(skillPath) ? fs.readFileSync(skillPath, 'utf8') : '';
+const envNames = readGateguardEnvNames(hookSource);
+
+if (test('hook reads at least one GATEGUARD_* variable', () => {
+  assert.ok(envNames.size > 0, 'no GATEGUARD_* env reads found - has the hook moved?');
+})) passed++; else failed++;
+
+if (test('every GATEGUARD_* variable the hook reads is documented', () => {
+  const undocumented = [...envNames].filter(name => !skillDoc.includes(name)).sort();
+  assert.deepStrictEqual(
+    undocumented,
+    [],
+    `undocumented in skills/gateguard/SKILL.md: ${undocumented.join(', ')}`
+  );
+})) passed++; else failed++;
+
+if (test('the documented knobs are the ones the hook actually reads', () => {
+  // Guards the reverse drift: a doc naming a knob the hook no longer reads.
+  const documented = [...new Set(
+    (skillDoc.match(/GATEGUARD_[A-Z0-9_]+/g) || [])
+  )];
+  const stale = documented.filter(name => !hookSource.includes(name)).sort();
+  assert.deepStrictEqual(stale, [], `documented but unread by the hook: ${stale.join(', ')}`);
+})) passed++; else failed++;
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}\n`);
+
+if (failed > 0) {
+  process.exit(1);
+}

--- a/tests/ci/gateguard-env-documented.test.js
+++ b/tests/ci/gateguard-env-documented.test.js
@@ -52,6 +52,15 @@ function test(name, fn) {
 const REGEX_CAN_FOLLOW = new Set([
   '', '(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';', '+', '-', '*', '%', '~', '^', '<', '>',
 ]);
+const REGEX_CAN_FOLLOW_KEYWORD = new Set([
+  'await', 'case', 'delete', 'do', 'else', 'in', 'instanceof', 'new', 'of',
+  'return', 'throw', 'typeof', 'void', 'yield',
+]);
+
+function regexFollowsKeyword(source, slashIndex) {
+  const match = source.slice(0, slashIndex).match(/([A-Za-z_$][\w$]*)\s*$/);
+  return Boolean(match && REGEX_CAN_FOLLOW_KEYWORD.has(match[1]));
+}
 
 /**
  * Blank out comments and literal text, preserving length and line breaks so
@@ -102,7 +111,7 @@ function blankCommentsAndLiterals(source) {
       continue;
     }
 
-    if (ch === '/' && REGEX_CAN_FOLLOW.has(prev)) {
+    if (ch === '/' && (REGEX_CAN_FOLLOW.has(prev) || regexFollowsKeyword(source, i))) {
       emit(ch); i += 1;
       let inClass = false;
       while (i < source.length) {
@@ -289,6 +298,11 @@ if (test('env reads are read from code, not from comments, strings or regexes', 
 if (test('a regex literal containing a slash does not swallow the code after it', () => {
   const fixture = 'const re = /a\\/\\/b/;\nconst x = process.env.GATEGUARD_AFTER_REGEX;';
   assert.deepStrictEqual([...readGateguardEnvNames(fixture)], ['GATEGUARD_AFTER_REGEX']);
+})) passed++; else failed++;
+
+if (test('a regex literal after a statement keyword is ignored', () => {
+  const fixture = 'function matches() { return /process\\.env\\.GATEGUARD_IN_RETURN_REGEX/; }';
+  assert.deepStrictEqual([...readGateguardEnvNames(fixture)], []);
 })) passed++; else failed++;
 
 if (test('the access guard rejects every form the parser cannot follow', () => {

--- a/tests/ci/gateguard-env-documented.test.js
+++ b/tests/ci/gateguard-env-documented.test.js
@@ -200,6 +200,7 @@ const UNSUPPORTED_ACCESS = [
   { label: 'process.env aliased to a binding', pattern: /(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*=\s*process\.env\s*(?:[;,)\]]|$)/m },
   { label: 'spread of process.env', pattern: /\.\.\.\s*process\.env\b/ },
   { label: 'enumeration of process.env', pattern: /Object\.(?:keys|values|entries|assign|fromEntries)\(\s*process\.env\b/ },
+  { label: 'Reflect access on process.env', pattern: /Reflect\.(?:get|has|set|deleteProperty|defineProperty|getOwnPropertyDescriptor|ownKeys)\(\s*process\.env\b/ },
 ];
 
 /** `process.env[...]` whose key is not a plain quoted string. */
@@ -298,6 +299,9 @@ if (test('the access guard rejects every form the parser cannot follow', () => {
     ['computed variable', 'const v = process.env[name];'],
     ['spread', 'const all = { ...process.env };'],
     ['enumeration', 'const ks = Object.keys(process.env);'],
+    ['Reflect.get', "const v = Reflect.get(process.env, 'GATEGUARD_HIDDEN');"],
+    ['Reflect.has', "const v = Reflect.has(process.env, 'GATEGUARD_HIDDEN');"],
+    ['Reflect.ownKeys', 'const ks = Reflect.ownKeys(process.env);'],
   ];
   const missed = cases.filter(([, code]) => findUnsupportedAccess(code).length === 0).map(([label]) => label);
   assert.deepStrictEqual(missed, [], `access guard missed: ${missed.join(', ')}`);

--- a/tests/ci/validators.test.js
+++ b/tests/ci/validators.test.js
@@ -213,13 +213,19 @@ function runCatalogValidator(overrides = {}) {
 // Captures stderr on both success and failure (the shared
 // runSourceViaTempFile helper only surfaces stderr when the child
 // exits non-zero, which hides WARN lines in the default mode).
-function runSkillsValidator(testDir, argv = [], envOverrides = {}) {
+function runSkillsValidator(testDir, argv = [], envOverrides = {}, docsDir) {
   const validatorPath = path.join(validatorsDir, 'validate-skills.js');
   let source = fs.readFileSync(validatorPath, 'utf8');
   source = stripShebang(source);
   source = source.replace(
     /const SKILLS_DIR = .*?;/,
     `const SKILLS_DIR = ${JSON.stringify(testDir)};`,
+  );
+  // Default to a nonexistent docs root so tests exercising only
+  // SKILLS_DIR aren't polluted by this repo's real docs/*/skills/ tree.
+  source = source.replace(
+    /const DOCS_DIR = .*?;/,
+    `const DOCS_DIR = ${JSON.stringify(docsDir || '/nonexistent-docs-dir-for-tests')};`,
   );
   if (argv.length > 0) {
     const argvPreamble = argv
@@ -2798,6 +2804,95 @@ function runTests() {
     assert.strictEqual(result.code, 1, 'Should reject empty SKILL.md');
     assert.ok(result.stderr.includes('Empty file'),
       `Should report "Empty file", got: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  // ── Round 84: validate-skills docs/{locale}/skills/ mirror scan (#2630) ──
+
+  console.log('\nRound 84: validate-skills.js (docs/{locale}/skills/ frontmatter, #2630):');
+
+  if (test('flags a glued key onto description as invalid YAML', () => {
+    const testDir = createTestDir();
+    const docsDir = path.join(testDir, 'docs-root');
+    const skillDir = path.join(docsDir, 'ja-JP', 'skills', 'example');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\nname: example\ndescription: some text.license: Apache-2.0\nversion: 1.0.0\n---\n# Example');
+
+    const result = runSkillsValidator('/nonexistent/skills-dir', ['--strict'], {}, docsDir);
+    assert.strictEqual(result.code, 1, 'Should fail on glued key');
+    assert.ok(result.stderr.includes("unquoted value contains ': '"),
+      `Should report the glued-key defect, got: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('flags a dropped-quote description containing a colon as invalid YAML', () => {
+    const testDir = createTestDir();
+    const docsDir = path.join(testDir, 'docs-root');
+    const skillDir = path.join(docsDir, 'ja-JP', 'skills', 'example');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\nname: example\ndescription: Verification loop: migrations, linting\n---\n# Example');
+
+    const result = runSkillsValidator('/nonexistent/skills-dir', ['--strict'], {}, docsDir);
+    assert.strictEqual(result.code, 1, 'Should fail on unquoted colon in description');
+    assert.ok(result.stderr.includes("unquoted value contains ': '"),
+      `Should report the dropped-quote defect, got: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('flags a description starting with the reserved @ indicator', () => {
+    const testDir = createTestDir();
+    const docsDir = path.join(testDir, 'docs-root');
+    const skillDir = path.join(docsDir, 'ja-JP', 'skills', 'example');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\nname: example\ndescription: @Observable state management\n---\n# Example');
+
+    const result = runSkillsValidator('/nonexistent/skills-dir', ['--strict'], {}, docsDir);
+    assert.strictEqual(result.code, 1, 'Should fail on leading @');
+    assert.ok(result.stderr.includes("reserved character '@'"),
+      `Should report the reserved-indicator defect, got: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('flags a docs mirror SKILL.md with no frontmatter block at all', () => {
+    const testDir = createTestDir();
+    const docsDir = path.join(testDir, 'docs-root');
+    const skillDir = path.join(docsDir, 'ja-JP', 'skills', 'example');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# Example\n\nNo frontmatter here.');
+
+    const result = runSkillsValidator('/nonexistent/skills-dir', ['--strict'], {}, docsDir);
+    assert.strictEqual(result.code, 1, 'Should fail when docs mirror has no frontmatter');
+    assert.ok(result.stderr.includes('no frontmatter block found'),
+      `Should report the missing-frontmatter defect, got: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('curated skills/ still tolerates a SKILL.md with no frontmatter (unchanged)', () => {
+    const testDir = createTestDir();
+    const skillDir = path.join(testDir, 'no-frontmatter-skill');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# Example\n\nNo frontmatter here.');
+
+    const result = runSkillsValidator(testDir, ['--strict']);
+    assert.strictEqual(result.code, 0,
+      `Curated skills/ must not require frontmatter, got stderr: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('passes on a valid docs/{locale}/skills/ mirror', () => {
+    const testDir = createTestDir();
+    const docsDir = path.join(testDir, 'docs-root');
+    const skillDir = path.join(docsDir, 'zh-CN', 'skills', 'example');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\nname: example\ndescription: "Well-formed: quoted value"\n---\n# Example');
+
+    const result = runSkillsValidator('/nonexistent/skills-dir', ['--strict'], {}, docsDir);
+    assert.strictEqual(result.code, 0, `Should pass on well-formed mirror, got: ${result.stderr}`);
+    assert.ok(result.stdout.includes('Validated 1'), 'Should count the one docs skill file');
     cleanupTestDir(testDir);
   })) passed++; else failed++;
 

--- a/tests/ci/validators.test.js
+++ b/tests/ci/validators.test.js
@@ -2856,6 +2856,31 @@ function runTests() {
     cleanupTestDir(testDir);
   })) passed++; else failed++;
 
+  if (test('preserves # inside a quoted frontmatter value', () => {
+    const testDir = createTestDir();
+    const docsDir = path.join(testDir, 'docs-root');
+    const skillDir = path.join(docsDir, 'ja-JP', 'skills', 'example');
+    fs.mkdirSync(skillDir, { recursive: true });
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'),
+      '---\nname: example\ndescription: "Fix: details #tag" # translation note\n---\n# Example');
+
+    const result = runSkillsValidator('/nonexistent/skills-dir', ['--strict'], {}, docsDir);
+    assert.strictEqual(result.code, 0,
+      `Quoted # content must remain valid, got stderr: ${result.stderr}`);
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
+  if (test('reports an unreadable docs root deterministically', () => {
+    const testDir = createTestDir();
+    const docsPath = path.join(testDir, 'docs-file');
+    fs.writeFileSync(docsPath, 'not a directory');
+
+    const result = runSkillsValidator('/nonexistent/skills-dir', ['--strict'], {}, docsPath);
+    assert.strictEqual(result.code, 1, 'Should fail when the docs root cannot be read');
+    assert.strictEqual(result.stderr.trim(), 'ERROR: unable to read docs directory');
+    cleanupTestDir(testDir);
+  })) passed++; else failed++;
+
   if (test('flags a docs mirror SKILL.md with no frontmatter block at all', () => {
     const testDir = createTestDir();
     const docsDir = path.join(testDir, 'docs-root');

--- a/tests/hooks/suggest-compact.test.js
+++ b/tests/hooks/suggest-compact.test.js
@@ -694,7 +694,7 @@ function runTests() {
     };
   }
 
-  if (test('suggests compact when context exceeds the 200k-window threshold', () => {
+  if (test('omits the percentage when the context window is assumed', () => {
     const ctx = createContextContext();
     const transcript = writeTranscriptFixture(170000);
     try {
@@ -704,7 +704,7 @@ function runTests() {
       const parsed = JSON.parse(result.stdout);
       const context = parsed.hookSpecificOutput.additionalContext;
       assert.ok(context.includes('Context ~170k tokens'), `Expected token estimate. Got: ${context}`);
-      assert.ok(context.includes('85% of 200k window'), `Expected window percentage. Got: ${context}`);
+      assert.ok(!context.includes('% of'), `Expected no percentage for an assumed window. Got: ${context}`);
     } finally {
       try { fs.unlinkSync(transcript); } catch (_err) { /* ignore */ }
       ctx.cleanup();

--- a/tests/hooks/suggest-compact.test.js
+++ b/tests/hooks/suggest-compact.test.js
@@ -698,7 +698,10 @@ function runTests() {
     const ctx = createContextContext();
     const transcript = writeTranscriptFixture(170000);
     try {
-      const result = runCompactWithInput({ session_id: ctx.sessionId, transcript_path: transcript });
+      const result = runCompactWithInput(
+        { session_id: ctx.sessionId, transcript_path: transcript },
+        { ECC_CONTEXT_WINDOW_TOKENS: '', CLAUDE_CODE_AUTO_COMPACT_WINDOW: '' },
+      );
       assert.strictEqual(result.code, 0, 'Should exit 0');
       assert.ok(result.stdout.trim().length > 0, `Expected stdout payload. Got: "${result.stdout}"`);
       const parsed = JSON.parse(result.stdout);

--- a/tests/lib/transcript-context.test.js
+++ b/tests/lib/transcript-context.test.js
@@ -139,6 +139,10 @@ console.log('\nresolveContextWindowTokens:');
 
 // Isolation: an env-set window override (either knob) otherwise leaks into the
 // default-window assertions below and fails them (#2290).
+const originalContextWindowEnv = {
+  ECC_CONTEXT_WINDOW_TOKENS: process.env.ECC_CONTEXT_WINDOW_TOKENS,
+  CLAUDE_CODE_AUTO_COMPACT_WINDOW: process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW,
+};
 delete process.env.ECC_CONTEXT_WINDOW_TOKENS;
 delete process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
 
@@ -222,9 +226,6 @@ test('treats an empty model id as standard window', () => {
 // ── isContextWindowInferred ──
 console.log('\nisContextWindowInferred:');
 
-delete process.env.ECC_CONTEXT_WINDOW_TOKENS;
-delete process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
-
 test('flags the assumed 200k default as inferred', () => {
   assert.strictEqual(isContextWindowInferred(187000, 'claude-opus-9'), true);
 });
@@ -246,9 +247,14 @@ test('a known large-window family is a detected window, not inferred', () => {
   assert.strictEqual(isContextWindowInferred(187000, 'claude-fable-5'), false);
 });
 
-test('tokens above the standard window make the size detected, not inferred', () => {
-  assert.strictEqual(isContextWindowInferred(220000, 'claude-opus-9'), false);
+test('tokens above the standard window still leave the exact size inferred', () => {
+  assert.strictEqual(isContextWindowInferred(220000, 'claude-opus-9'), true);
 });
+
+for (const [name, value] of Object.entries(originalContextWindowEnv)) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
 
 // ── resolveContextThreshold ──
 console.log('\nresolveContextThreshold:');

--- a/tests/lib/transcript-context.test.js
+++ b/tests/lib/transcript-context.test.js
@@ -23,7 +23,8 @@ const {
   resolveContextThreshold,
   resolveContextInterval,
   computeContextBucket,
-  formatWindowLabel
+  formatWindowLabel,
+  isContextWindowInferred
 } = require('../../scripts/lib/transcript-context');
 
 console.log('=== Testing transcript-context.js ===\n');
@@ -216,6 +217,37 @@ test('keeps the 200k default for unknown model ids at low token counts (no false
 
 test('treats an empty model id as standard window', () => {
   assert.strictEqual(resolveContextWindowTokens(100000, ''), STANDARD_CONTEXT_WINDOW_TOKENS);
+});
+
+// ── isContextWindowInferred ──
+console.log('\nisContextWindowInferred:');
+
+delete process.env.ECC_CONTEXT_WINDOW_TOKENS;
+delete process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW;
+
+test('flags the assumed 200k default as inferred', () => {
+  assert.strictEqual(isContextWindowInferred(187000, 'claude-opus-9'), true);
+});
+
+test('an env override is a detected window, not inferred', () => {
+  process.env.ECC_CONTEXT_WINDOW_TOKENS = '1000000';
+  try {
+    assert.strictEqual(isContextWindowInferred(187000, 'claude-opus-9'), false);
+  } finally {
+    delete process.env.ECC_CONTEXT_WINDOW_TOKENS;
+  }
+});
+
+test('a [1m] marker is a detected window, not inferred', () => {
+  assert.strictEqual(isContextWindowInferred(187000, 'claude-opus-4-5[1m]'), false);
+});
+
+test('a known large-window family is a detected window, not inferred', () => {
+  assert.strictEqual(isContextWindowInferred(187000, 'claude-fable-5'), false);
+});
+
+test('tokens above the standard window make the size detected, not inferred', () => {
+  assert.strictEqual(isContextWindowInferred(220000, 'claude-opus-9'), false);
 });
 
 // ── resolveContextThreshold ──

--- a/tests/scripts/skill-stocktake-discovery.test.js
+++ b/tests/scripts/skill-stocktake-discovery.test.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const scanScript = path.join(repoRoot, 'skills', 'skill-stocktake', 'scripts', 'scan.sh');
+const quickDiffScript = path.join(repoRoot, 'skills', 'skill-stocktake', 'scripts', 'quick-diff.sh');
+
+let passed = 0;
+let failed = 0;
+
+function test(description, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${description}`);
+    passed++;
+  } catch (error) {
+    console.log(`  ✗ ${description}: ${error.message}`);
+    failed++;
+  }
+}
+
+function writeSkill(skillDir, name) {
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, 'SKILL.md'),
+    `---\nname: ${name}\ndescription: test fixture\n---\n# ${name}\n`,
+  );
+}
+
+function runBash(scriptPath, args, env) {
+  return spawnSync('bash', [scriptPath, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+}
+
+console.log('\nSkill stocktake discovery tests:');
+
+test('both scanners use canonical, error-visible, NUL-delimited discovery', () => {
+  for (const scriptPath of [scanScript, quickDiffScript]) {
+    const source = fs.readFileSync(scriptPath, 'utf8');
+    assert.match(source, /find -L "\$dir" -name "SKILL\.md" -type f -print0/);
+    assert.match(source, /sort -z -o "\$find_out" "\$find_out"/);
+    assert.match(source, /read -r -d '' file/);
+    assert.doesNotMatch(source, /find [^\n]*2>\/dev\/null/, `${path.basename(scriptPath)} still hides find errors`);
+  }
+});
+
+if (process.platform === 'win32') {
+  console.log('  ↷ POSIX symlink and newline-path integration cases skipped on Windows');
+} else {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-skill-stocktake-'));
+  try {
+    const projectSkills = path.join(tempRoot, 'project', '.claude', 'skills');
+    const directSkill = path.join(projectSkills, 'direct-skill');
+    const linkedTarget = path.join(tempRoot, 'shared', 'linked-skill');
+    const newlineSkill = path.join(projectSkills, 'newline\nskill');
+    const resultsPath = path.join(tempRoot, 'results.json');
+
+    writeSkill(directSkill, 'direct-skill');
+    writeSkill(linkedTarget, 'linked-skill');
+    writeSkill(newlineSkill, 'newline-skill');
+    fs.symlinkSync(linkedTarget, path.join(projectSkills, 'linked-skill'), 'dir');
+    fs.mkdirSync(path.join(directSkill, 'references'), { recursive: true });
+    fs.writeFileSync(path.join(directSkill, 'references', 'notes.md'), '# supporting notes\n');
+    fs.writeFileSync(
+      resultsPath,
+      JSON.stringify({ evaluated_at: '2099-01-01T00:00:00Z', skills: [] }),
+    );
+
+    const env = {
+      SKILL_STOCKTAKE_GLOBAL_DIR: path.join(tempRoot, 'missing-global'),
+      SKILL_STOCKTAKE_PROJECT_DIR: projectSkills,
+      SKILL_STOCKTAKE_OBSERVATIONS: path.join(tempRoot, 'missing-observations.jsonl'),
+    };
+
+    test('scan follows symlinked skills and ignores nested Markdown assets', () => {
+      const result = runBash(scanScript, [], env);
+      assert.strictEqual(result.status, 0, result.stderr);
+      const output = JSON.parse(result.stdout);
+      assert.strictEqual(output.scan_summary.project.count, 3);
+      assert.deepStrictEqual(
+        output.skills.map(skill => skill.name).sort(),
+        ['direct-skill', 'linked-skill', 'newline-skill'],
+      );
+    });
+
+    test('quick diff keeps newline-containing skill paths as one record', () => {
+      const result = runBash(quickDiffScript, [resultsPath], env);
+      assert.strictEqual(result.status, 0, result.stderr);
+      const output = JSON.parse(result.stdout);
+      assert.strictEqual(output.length, 3);
+      assert.strictEqual(
+        output.filter(entry => entry.path.includes('newline\nskill/SKILL.md')).length,
+        1,
+      );
+      assert.ok(output.every(entry => entry.is_new === true));
+    });
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/scripts/skill-stocktake-discovery.test.js
+++ b/tests/scripts/skill-stocktake-discovery.test.js
@@ -47,7 +47,9 @@ test('both scanners use canonical, error-visible, NUL-delimited discovery', () =
   for (const scriptPath of [scanScript, quickDiffScript]) {
     const source = fs.readFileSync(scriptPath, 'utf8');
     assert.match(source, /find -L "\$dir" -name "SKILL\.md" -type f -print0/);
-    assert.match(source, /sort -z -o "\$find_out" "\$find_out"/);
+    assert.match(source, /sort_nul_file "\$find_out"/);
+    assert.match(source, /records\.sort\(Buffer\.compare\)/);
+    assert.doesNotMatch(source, /sort -z/, `${path.basename(scriptPath)} still requires GNU sort`);
     assert.match(source, /read -r -d '' file/);
     assert.doesNotMatch(source, /find [^\n]*2>\/dev\/null/, `${path.basename(scriptPath)} still hides find errors`);
   }
@@ -103,6 +105,9 @@ if (process.platform === 'win32') {
       );
       assert.ok(output.every(entry => entry.is_new === true));
     });
+  } catch (error) {
+    console.log(`  ✗ fixture setup: ${error.message}`);
+    failed++;
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Forward-ports five previously approved community contributions onto exact current main while preserving their original commits and authorship:

- #2605 avoids claiming a context percentage when the window is only assumed
- #2611 documents and machine-checks the graduated GateGuard controls
- #2631 applies strict frontmatter validation to localized skill mirrors
- #2640 makes skill stocktake discovery symlink-aware, NUL-delimited, and error-visible
- #2731 recursively redacts operator home paths before compliance reports are serialized

This batch advances ECC 2 distribution truth and the M1 context/inventory foundation. It does not create a second profile authority, capability profile, sandbox tier, evidence contract, or canonical state model.

## Verification

- `npm test`: 4,057 passed, 0 failed
- `npm run lint`: passed
- 42 transcript-context tests
- 44 suggest-compact tests
- 10 GateGuard environment-contract tests
- 172 validator tests and strict validation of 805 canonical/localized skill directories
- 3 skill-stocktake discovery tests plus Bash syntax checks
- 12 skill-comply runner tests in a disposable Python environment
- `git diff --check`: passed

Source PRs will be closed with explicit attribution only after this exact head merges and post-merge main CI is green.