### PR TITLE
fix(commands): distinguish prp-pr alias

### DIFF
--- a/commands/prp-pr.md
+++ b/commands/prp-pr.md
@@ -1,5 +1,5 @@
 ---
-description: "Create a GitHub PR from current branch with unpushed commits — discovers templates, analyzes changes, pushes"
+description: "Alias of /pr for the PRP workflow series. Use when creating a pull request mid-PRP workflow; otherwise use /pr."
 argument-hint: "[base-branch] (default: main)"
 ---
 

--- a/docs/COMMAND-REGISTRY.json
+++ b/docs/COMMAND-REGISTRY.json
@@ -741,7 +741,7 @@
     },
     {
       "command": "prp-pr",
-      "description": "Create a GitHub PR from current branch with unpushed commits — discovers templates, analyzes changes, pushes",
+      "description": "Alias of /pr for the PRP workflow series. Use when creating a pull request mid-PRP workflow; otherwise use /pr.",
       "type": "testing",
       "primaryAgents": [],
       "allAgents": [],


### PR DESCRIPTION
## What Changed

- distinguish `/prp-pr` from `/pr` in the command-selection description
- identify `/prp-pr` as the PRP-series alias and direct ordinary pull-request work to `/pr`
- regenerate `docs/COMMAND-REGISTRY.json`

## Why This Change

The two commands had byte-identical descriptions, so a model choosing from the flat command listing could not select between them. The alias description keeps the compatible command surface while making the PRP-specific trigger explicit.

Fixes #2905

## Testing Done

- [x] `node scripts/ci/validate-commands.js`
- [x] `npm run command-registry:check`
- [x] `corepack yarn markdownlint commands/prp-pr.md`
- [x] `git diff --check`
- [ ] Full `npm test` gauntlet: 3,954 passed and 22 failed. The emitted failures were unrelated Windows shell/symlink cases in plugin bootstrap and memory-vault tests; neither changed file is involved.

## Type of Change

- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [x] No shell scripts changed
- [x] No pre-commit hooks are configured for this focused Markdown/JSON change
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] Updated the generated command registry
- [ ] Added comments for complex logic (not applicable)
- [ ] README updated (not needed)
