### PR TITLE
fix(hooks): avoid recursive OMP hook execution

### DIFF
--- a/.pi/README.md
+++ b/.pi/README.md
@@ -99,6 +99,11 @@ The `extensions/index.ts` file handles:
 All hook execution is non-shell (`execFile` without shell interpretation), so paths containing
 spaces, tabs, or shell metacharacters are safe.
 
+Hook runtime selection is defensive: a normal Node process uses its own
+`process.execPath`, while compiled OMP/Bun falls back to `node` instead of
+recursively launching the OMP binary as a hook runner. Set `ECC_HOOK_NODE` to
+an explicit Node executable path when `node` is not available on `PATH`.
+
 ## Scope
 
 Intentionally **out of scope** for this first adapter (to be added independently):

--- a/.pi/README.md
+++ b/.pi/README.md
@@ -90,8 +90,9 @@ The `extensions/index.ts` file handles:
 4. **Context injection** — Parses `hookSpecificOutput.additionalContext` from the SessionStart
    hook and appends it to the system prompt on the next `before_agent_start`, wrapped in an
    `<ecc-session-context>` block. Non-JSON hook output is tolerated, not treated as an error
-5. **Hook isolation** — Failing, missing, or slow hooks degrade to a warning and never
-   terminate the Pi session. Hook execution is bounded by a timeout and an output limit
+5. **Hook isolation** — Failing, missing, slow, or misconfigured hooks degrade to
+   a warning and never terminate the Pi session. Hook execution is bounded by a
+   timeout and an output limit
 6. **Package resolution** — Resolves hook scripts from the installed package via `__dirname`,
    never from `process.cwd()`, so a global install works from any project directory. Hooks
    still *run* in the user's project directory, so project detection stays correct
@@ -100,9 +101,11 @@ All hook execution is non-shell (`execFile` without shell interpretation), so pa
 spaces, tabs, or shell metacharacters are safe.
 
 Hook runtime selection uses the host `process.execPath` only under Node.
-Compiled OMP/Bun falls back to `node` instead of recursively launching the OMP
-binary as a hook runner. Set `ECC_HOOK_NODE` to an explicit absolute Node
-executable path when `node` is not available on `PATH`.
+Without an override, compiled OMP/Bun falls back to `node` instead of
+recursively launching the OMP binary as a hook runner. Set `ECC_HOOK_NODE` to
+an explicit absolute Node executable path when `node` is not available on
+`PATH`.
+Relative values are rejected when the hook runs and surfaced as a warning.
 
 ## Scope
 

--- a/.pi/README.md
+++ b/.pi/README.md
@@ -102,7 +102,8 @@ spaces, tabs, or shell metacharacters are safe.
 Hook runtime selection is defensive: a normal Node process uses its own
 `process.execPath`, while compiled OMP/Bun falls back to `node` instead of
 recursively launching the OMP binary as a hook runner. Set `ECC_HOOK_NODE` to
-an explicit Node executable path when `node` is not available on `PATH`.
+an explicit absolute Node executable path when `node` is not available on
+`PATH`.
 
 ## Scope
 

--- a/.pi/README.md
+++ b/.pi/README.md
@@ -99,11 +99,10 @@ The `extensions/index.ts` file handles:
 All hook execution is non-shell (`execFile` without shell interpretation), so paths containing
 spaces, tabs, or shell metacharacters are safe.
 
-Hook runtime selection is defensive: a normal Node process uses its own
-`process.execPath`, while compiled OMP/Bun falls back to `node` instead of
-recursively launching the OMP binary as a hook runner. Set `ECC_HOOK_NODE` to
-an explicit absolute Node executable path when `node` is not available on
-`PATH`.
+Hook runtime selection uses the host `process.execPath` only under Node.
+Compiled OMP/Bun falls back to `node` instead of recursively launching the OMP
+binary as a hook runner. Set `ECC_HOOK_NODE` to an explicit absolute Node
+executable path when `node` is not available on `PATH`.
 
 ## Scope
 

--- a/.pi/extensions/hook-runtime.js
+++ b/.pi/extensions/hook-runtime.js
@@ -1,0 +1,23 @@
+const path = require("node:path")
+
+/**
+ * Select a real Node executable for hook scripts.
+ *
+ * Compiled OMP/Bun exposes a Node-compatible process.release.name, but its
+ * process.execPath points to the OMP launcher. Use PATH node in that case;
+ * ECC_HOOK_NODE provides an explicit path for systems without Node on PATH.
+ */
+function resolveHookRuntime({
+  execPath = process.execPath,
+  releaseName = process.release?.name,
+  bunVersion = process.versions?.bun,
+  override = process.env.ECC_HOOK_NODE,
+} = {}) {
+  const isNodeRuntime =
+    releaseName === "node" &&
+    !bunVersion &&
+    /^(?:node|nodejs)(?:\.exe)?$/i.test(path.basename(execPath))
+  return override?.trim() || (isNodeRuntime ? execPath : "node")
+}
+
+module.exports = { resolveHookRuntime }

--- a/.pi/extensions/hook-runtime.js
+++ b/.pi/extensions/hook-runtime.js
@@ -5,7 +5,8 @@ const path = require("node:path")
  *
  * Compiled OMP/Bun exposes a Node-compatible process.release.name, but its
  * process.execPath points to the OMP launcher. Use PATH node in that case;
- * ECC_HOOK_NODE provides an explicit path for systems without Node on PATH.
+ * ECC_HOOK_NODE provides an explicit absolute path for systems without Node
+ * on PATH.
  */
 function resolveHookRuntime({
   execPath = process.execPath,
@@ -17,7 +18,14 @@ function resolveHookRuntime({
     releaseName === "node" &&
     !bunVersion &&
     /^(?:node|nodejs)(?:\.exe)?$/i.test(path.basename(execPath))
-  return override?.trim() || (isNodeRuntime ? execPath : "node")
+  const overridePath = override?.trim()
+  if (overridePath) {
+    if (!path.isAbsolute(overridePath)) {
+      throw new Error("ECC_HOOK_NODE must be an absolute path: " + overridePath)
+    }
+    return overridePath
+  }
+  return isNodeRuntime ? execPath : "node"
 }
 
 module.exports = { resolveHookRuntime }

--- a/.pi/extensions/hook-runtime.js
+++ b/.pi/extensions/hook-runtime.js
@@ -7,6 +7,10 @@ const path = require("node:path")
  * `process.execPath` points to the OMP launcher. Bun is detected separately via
  * `process.versions.bun`; both fall back to `node` unless `ECC_HOOK_NODE`
  * supplies an explicit absolute path.
+ *
+ * @param options - Runtime metadata and an optional absolute Node override.
+ * @returns The executable path to use for hook scripts.
+ * @throws {Error} If the hook runtime override is non-empty and relative.
  */
 function resolveHookRuntime({
   execPath = process.execPath,

--- a/.pi/extensions/hook-runtime.js
+++ b/.pi/extensions/hook-runtime.js
@@ -3,10 +3,10 @@ const path = require("node:path")
 /**
  * Select a real Node executable for hook scripts.
  *
- * Compiled OMP/Bun exposes a Node-compatible process.release.name, but its
- * process.execPath points to the OMP launcher. Use PATH node in that case;
- * ECC_HOOK_NODE provides an explicit absolute path for systems without Node
- * on PATH.
+ * Compiled OMP may report `process.release.name` as `node` even though its
+ * `process.execPath` points to the OMP launcher. Bun is detected separately via
+ * `process.versions.bun`; both fall back to `node` unless `ECC_HOOK_NODE`
+ * supplies an explicit absolute path.
  */
 function resolveHookRuntime({
   execPath = process.execPath,

--- a/.pi/extensions/index.ts
+++ b/.pi/extensions/index.ts
@@ -15,8 +15,10 @@
  * Design constraints (see .pi/README.md):
  *   - Hooks resolve relative to THIS file, never `process.cwd()`, so a global
  *     `pi install` works from any project directory.
- *   - Hooks execute via `execFile(process.execPath, [...])` with no shell, so
- *     paths containing spaces or shell metacharacters are safe.
+ *   - Hooks execute via `execFile(HOOK_RUNTIME, [...])` with no shell, so paths
+ *     containing spaces or shell metacharacters are safe. The hook runtime is
+ *     selected separately because compiled OMP/Bun may report a Node-compatible
+ *     release name while `process.execPath` points back to `omp`.
  *   - Hook failures are isolated: a broken, missing, or slow hook degrades to a
  *     warning and never terminates the Pi session.
  */
@@ -25,6 +27,7 @@ import { execFile } from "node:child_process"
 import * as fs from "node:fs"
 import * as os from "node:os"
 import * as path from "node:path"
+import { resolveHookRuntime } from "./hook-runtime.js"
 
 /**
  * Minimal structural types mirroring `@earendil-works/pi-coding-agent`.
@@ -105,6 +108,7 @@ const ECC_ROOT = path.resolve(__dirname, "..", "..")
 
 /** ECC's universal hook runner. It applies hook-profile and disable flags. */
 const HOOK_RUNNER = path.join(ECC_ROOT, "scripts", "hooks", "run-with-flags.js")
+const HOOK_RUNTIME = resolveHookRuntime()
 
 const HOOK_TIMEOUT_MS = 30_000
 const MAX_HOOK_OUTPUT_BYTES = 1024 * 1024
@@ -191,7 +195,7 @@ function runEccHook(
     }
 
     const child = execFile(
-      process.execPath,
+      HOOK_RUNTIME,
       [HOOK_RUNNER, spec.id, spec.script, spec.profiles],
       {
         // Hooks inspect the user's project, so they run there. Only the script

--- a/.pi/extensions/index.ts
+++ b/.pi/extensions/index.ts
@@ -15,13 +15,13 @@
  * Design constraints (see .pi/README.md):
  *   - Hooks resolve relative to THIS file, never `process.cwd()`, so a global
  *     `pi install` works from any project directory.
- *   - Hooks execute via `execFile(HOOK_RUNTIME, [...])` with no shell, so paths
+ *   - Hooks execute via `execFile(hookRuntime, [...])` with no shell, so paths
  *     containing spaces or shell metacharacters are safe. The hook runtime is
  *     selected separately because compiled OMP may report `process.release.name`
  *     as `node` while `process.execPath` points back to `omp`; Bun is detected
  *     separately via `process.versions.bun`.
- *   - Hook failures are isolated: a broken, missing, or slow hook degrades to a
- *     warning and never terminates the Pi session.
+ *   - Hook failures are isolated: a broken, missing, slow, or misconfigured hook
+ *     degrades to a warning and never terminates the Pi session.
  */
 
 import { execFile } from "node:child_process"
@@ -109,7 +109,6 @@ const ECC_ROOT = path.resolve(__dirname, "..", "..")
 
 /** ECC's universal hook runner. It applies hook-profile and disable flags. */
 const HOOK_RUNNER = path.join(ECC_ROOT, "scripts", "hooks", "run-with-flags.js")
-const HOOK_RUNTIME = resolveHookRuntime()
 
 const HOOK_TIMEOUT_MS = 30_000
 const MAX_HOOK_OUTPUT_BYTES = 1024 * 1024
@@ -180,8 +179,9 @@ interface HookResult {
 /**
  * Run an ECC hook through ECC's own runner.
  *
- * Never rejects: a missing runner, a non-zero exit, a timeout, or a spawn error
- * all resolve to a `failure` string that the caller surfaces as a warning.
+ * Never rejects: an invalid runtime override, a missing runner, a non-zero exit,
+ * a timeout, or a spawn error all resolve to a `failure` string that the caller
+ * surfaces as a warning.
  */
 function runEccHook(
   spec: HookSpec,
@@ -194,9 +194,19 @@ function runEccHook(
       resolve({ stdout: "", failure: `hook runner not found at ${HOOK_RUNNER}` })
       return
     }
+    let hookRuntime: string
+    try {
+      hookRuntime = resolveHookRuntime()
+    } catch (error) {
+      resolve({
+        stdout: "",
+        failure: `${spec.id}: ${(error as Error).message}`,
+      })
+      return
+    }
 
     const child = execFile(
-      HOOK_RUNTIME,
+      hookRuntime,
       [HOOK_RUNNER, spec.id, spec.script, spec.profiles],
       {
         // Hooks inspect the user's project, so they run there. Only the script

--- a/.pi/extensions/index.ts
+++ b/.pi/extensions/index.ts
@@ -17,8 +17,9 @@
  *     `pi install` works from any project directory.
  *   - Hooks execute via `execFile(HOOK_RUNTIME, [...])` with no shell, so paths
  *     containing spaces or shell metacharacters are safe. The hook runtime is
- *     selected separately because compiled OMP/Bun may report a Node-compatible
- *     release name while `process.execPath` points back to `omp`.
+ *     selected separately because compiled OMP may report `process.release.name`
+ *     as `node` while `process.execPath` points back to `omp`; Bun is detected
+ *     separately via `process.versions.bun`.
  *   - Hook failures are isolated: a broken, missing, or slow hook degrades to a
  *     warning and never terminates the Pi session.
  */

--- a/tests/pi/pi-extension-adapter.test.js
+++ b/tests/pi/pi-extension-adapter.test.js
@@ -73,9 +73,9 @@ function stripComments(source) {
 }
 
 /**
- * Mirrors the adapter's hook invocation (`runEccHook` in
- * .pi/extensions/index.ts): the test host's Node executable, the same argv
- * shape, the same stdin-JSON payload, and the same env keys. No shell is used.
+ * Invokes ECC's hook runner like the adapter (`runEccHook` in
+ * .pi/extensions/index.ts): it uses the test host's Node executable with the
+ * same argv shape and JSON payload on stdin. No shell is used.
  */
 function runHookRunner(eccRoot, hookId, relScript, profiles, payload, extraEnv, cwd) {
   const runner = path.join(eccRoot, "scripts", "hooks", "run-with-flags.js")

--- a/tests/pi/pi-extension-adapter.test.js
+++ b/tests/pi/pi-extension-adapter.test.js
@@ -363,19 +363,29 @@ async function main() {
       assert.ok(
         runtimeSource.includes("process.versions?.bun") &&
           runtimeSource.includes("path.basename(execPath)") &&
-          runtimeSource.includes('return override?.trim() || (isNodeRuntime ? execPath : "node")'),
-        "expected the selector to reject Bun/OMP runtimes, support explicit overrides, and " +
+          runtimeSource.includes("path.isAbsolute(overridePath)") &&
+          runtimeSource.includes(
+            'throw new Error("ECC_HOOK_NODE must be an absolute path: " + overridePath)'
+          ),
+        "expected the selector to reject Bun/OMP runtimes, require absolute overrides, and " +
           "fall back to PATH node"
       )
     }],
 
     ["resolves hook runtimes across Node, compiled OMP, and explicit override cases", () => {
-      assert.strictEqual(resolveHookRuntime({ execPath: "/usr/bin/node" }), "/usr/bin/node")
-      assert.strictEqual(resolveHookRuntime({ execPath: "/usr/bin/nodejs" }), "/usr/bin/nodejs")
+      assert.strictEqual(
+        resolveHookRuntime({ execPath: "/usr/bin/node", override: "" }),
+        "/usr/bin/node"
+      )
+      assert.strictEqual(
+        resolveHookRuntime({ execPath: "/usr/bin/nodejs", override: "" }),
+        "/usr/bin/nodejs"
+      )
       assert.strictEqual(
         resolveHookRuntime({
           execPath: "/usr/bin/node",
           bunVersion: "1.4.0",
+          override: "",
         }),
         "node"
       )
@@ -383,6 +393,7 @@ async function main() {
         resolveHookRuntime({
           execPath: "/usr/bin/node",
           releaseName: "bun",
+          override: "",
         }),
         "node"
       )
@@ -390,8 +401,17 @@ async function main() {
         resolveHookRuntime({
           execPath: "/home/user/.omp/bin/omp",
           releaseName: "node",
+          override: "",
         }),
         "node"
+      )
+      assert.throws(
+        () =>
+          resolveHookRuntime({
+            execPath: "/usr/bin/node",
+            override: "./node",
+          }),
+        /ECC_HOOK_NODE must be an absolute path: \.\/node/
       )
       assert.strictEqual(
         resolveHookRuntime({

--- a/tests/pi/pi-extension-adapter.test.js
+++ b/tests/pi/pi-extension-adapter.test.js
@@ -45,6 +45,9 @@ const fs = require("fs")
 const os = require("os")
 const path = require("path")
 const { spawnSync, execFile } = require("child_process")
+const { resolveHookRuntime } = require(
+  path.join(__dirname, "..", "..", ".pi", "extensions", "hook-runtime.js")
+)
 
 async function runTest(name, fn) {
   try {
@@ -70,9 +73,9 @@ function stripComments(source) {
 }
 
 /**
- * Mirrors the adapter's own hook invocation (`runEccHook` in
- * .pi/extensions/index.ts): same binary (`process.execPath`), same argv
- * shape, same stdin-JSON payload, same env keys. No shell is used anywhere.
+ * Mirrors the adapter's hook invocation (`runEccHook` in
+ * .pi/extensions/index.ts): the test host's Node executable, the same argv
+ * shape, the same stdin-JSON payload, and the same env keys. No shell is used.
  */
 function runHookRunner(eccRoot, hookId, relScript, profiles, payload, extraEnv, cwd) {
   const runner = path.join(eccRoot, "scripts", "hooks", "run-with-flags.js")
@@ -320,8 +323,8 @@ async function main() {
         "expected the adapter to invoke hooks via child_process.execFile(...)"
       )
       assert.ok(
-        extensionSource.includes("process.execPath"),
-        "expected hooks to be spawned with process.execPath, not a hardcoded 'node' string"
+        extensionSource.includes("HOOK_RUNTIME"),
+        "expected the adapter to pass its selected hook runtime to execFile(...)"
       )
 
       const shellExecPattern = /(?<!execFile)\bexec\s*\(/
@@ -341,6 +344,69 @@ async function main() {
         !extensionSource.includes("shell: true"),
         "found `shell: true` in .pi/extensions/index.ts; opting into a shell reintroduces " +
           "the path-with-spaces / injection risk execFile(...) with no shell was meant to avoid"
+      )
+    }],
+    ["selects a real Node runtime instead of compiled OMP's masquerading process.execPath", () => {
+      const runtimeSource = fs.readFileSync(
+        path.join(repoRoot, ".pi", "extensions", "hook-runtime.js"),
+        "utf8"
+      )
+      assert.ok(
+        extensionSource.includes('from "./hook-runtime.js"'),
+        "expected the adapter to import the shared hook runtime selector"
+      )
+      assert.ok(
+        /execFile\(\s*HOOK_RUNTIME,/.test(extensionSource),
+        "expected runEccHook to invoke the runner with HOOK_RUNTIME rather than always using " +
+          "the host process.execPath"
+      )
+      assert.ok(
+        runtimeSource.includes("process.versions?.bun") &&
+          runtimeSource.includes("path.basename(execPath)") &&
+          runtimeSource.includes('return override?.trim() || (isNodeRuntime ? execPath : "node")'),
+        "expected the selector to reject Bun/OMP runtimes, support explicit overrides, and " +
+          "fall back to PATH node"
+      )
+    }],
+
+    ["resolves hook runtimes across Node, compiled OMP, and explicit override cases", () => {
+      assert.strictEqual(resolveHookRuntime({ execPath: "/usr/bin/node" }), "/usr/bin/node")
+      assert.strictEqual(resolveHookRuntime({ execPath: "/usr/bin/nodejs" }), "/usr/bin/nodejs")
+      assert.strictEqual(
+        resolveHookRuntime({
+          execPath: "/usr/bin/node",
+          bunVersion: "1.4.0",
+        }),
+        "node"
+      )
+      assert.strictEqual(
+        resolveHookRuntime({
+          execPath: "/usr/bin/node",
+          releaseName: "bun",
+        }),
+        "node"
+      )
+      assert.strictEqual(
+        resolveHookRuntime({
+          execPath: "/home/user/.omp/bin/omp",
+          releaseName: "node",
+        }),
+        "node"
+      )
+      assert.strictEqual(
+        resolveHookRuntime({
+          execPath: "/usr/bin/node",
+          override: " /opt/node/bin/node ",
+        }),
+        "/opt/node/bin/node"
+      )
+      assert.strictEqual(
+        resolveHookRuntime({
+          execPath: "/home/user/.omp/bin/omp",
+          bunVersion: "1.4.0",
+          override: " /opt/node/bin/node ",
+        }),
+        "/opt/node/bin/node"
       )
     }],
 

--- a/tests/pi/pi-extension-adapter.test.js
+++ b/tests/pi/pi-extension-adapter.test.js
@@ -323,8 +323,8 @@ async function main() {
         "expected the adapter to invoke hooks via child_process.execFile(...)"
       )
       assert.ok(
-        extensionSource.includes("HOOK_RUNTIME"),
-        "expected the adapter to pass its selected hook runtime to execFile(...)"
+        extensionSource.includes("resolveHookRuntime"),
+        "expected the adapter to select a hook runtime before execFile(...)"
       )
 
       const shellExecPattern = /(?<!execFile)\bexec\s*\(/
@@ -351,14 +351,20 @@ async function main() {
         path.join(repoRoot, ".pi", "extensions", "hook-runtime.js"),
         "utf8"
       )
+      const runHookStart = extensionSource.indexOf("function runEccHook")
+      const runHookEnd = extensionSource.indexOf("function resolveHookCwd")
+      const runHookSource = extensionSource.slice(runHookStart, runHookEnd)
+      const beforeRunHookSource = extensionSource.slice(0, runHookStart)
       assert.ok(
         extensionSource.includes('from "./hook-runtime.js"'),
         "expected the adapter to import the shared hook runtime selector"
       )
       assert.ok(
-        /execFile\(\s*HOOK_RUNTIME,/.test(extensionSource),
-        "expected runEccHook to invoke the runner with HOOK_RUNTIME rather than always using " +
-          "the host process.execPath"
+        !beforeRunHookSource.includes("resolveHookRuntime()") &&
+          /try\s*\{\s*hookRuntime = resolveHookRuntime\(\)\s*\}\s*catch/.test(runHookSource) &&
+          /execFile\(\s*hookRuntime,/.test(runHookSource),
+        "expected runEccHook to resolve its runtime inside the guarded hook path rather than " +
+          "during module initialization"
       )
       assert.ok(
         runtimeSource.includes("process.versions?.bun") &&

--- a/tests/pi/pi-extension-adapter.test.js
+++ b/tests/pi/pi-extension-adapter.test.js
@@ -49,6 +49,7 @@ const { resolveHookRuntime } = require(
   path.join(__dirname, "..", "..", ".pi", "extensions", "hook-runtime.js")
 )
 
+/** Run a single adapter test and report the result. */
 async function runTest(name, fn) {
   try {
     await fn()
@@ -286,6 +287,7 @@ function isDisabledByEnvMirror(value) {
   return typeof value === "string" && DISABLED_VALUES_MIRROR.has(value.trim().toLowerCase())
 }
 
+/** Run the Pi adapter regression suite. */
 async function main() {
   console.log("\n=== Testing .pi/extensions/index.ts (Pi thin adapter) ===\n")
 


### PR DESCRIPTION
## What Changed
- Add a shared hook-runtime selector for the Pi adapter.
- Keep `process.execPath` only for conventional Node hosts; compiled OMP/Bun falls back to `node`.
- Add `ECC_HOOK_NODE` for an explicit Node executable path.
- Add resolver regression coverage and document the runtime behavior.

## Why This Change
When Pi runs inside compiled OMP, `process.release.name` reports `node` but `process.execPath` points to `omp`. The adapter then recursively launches OMP for `session:start`, creating child-process and CPU storms instead of running the hook script.

Fixes #2909

## Testing Done
- `corepack yarn node tests/pi/pi-extension-adapter.test.js` — 28 passed, 0 failed.
- `npm run lint` — passed.
- `node tests/scripts/npm-publish-surface.test.js` — 2 passed, 0 failed.
- Full `corepack yarn test` — 4083 passed, 5 failed; the same 5 unchanged hook-suite failures reproduce on clean `main` (baseline: 4081 passed, 5 failed). The changed Pi adapter and publish-surface tests pass.

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [x] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] No shell invocation added; hooks remain `execFile`-based
- [x] Conventional commit and focused diff
- [x] New helper is included in the npm package publish surface

## Documentation
- [x] Updated `.pi/README.md`
- [x] Added comments for runtime-selection logic