### PR TITLE
test(ci): confirm hooks in packed target smoke

### DIFF
--- a/tests/ci/packed-artifact-lifecycle.js
+++ b/tests/ci/packed-artifact-lifecycle.js
@@ -258,6 +258,7 @@ function runTargetSmoke(options) {
       'install',
       '--modules', 'workflow-quality',
       '--target', options.target,
+      '--enable-hooks',
       '--json',
     ]),
     `${options.target} packed install`

--- a/tests/ci/packed-artifact-lifecycle.test.js
+++ b/tests/ci/packed-artifact-lifecycle.test.js
@@ -144,6 +144,17 @@ test('Windows public CLI invocation accepts the exact Itô capability selection'
   );
 });
 
+test('workflow-quality target smoke explicitly opts into hooks', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, 'packed-artifact-lifecycle.js'),
+    'utf8'
+  );
+  assert.match(
+    source,
+    /'--modules', 'workflow-quality'[\s\S]*'--enable-hooks'/
+  );
+});
+
 test('lifecycle cleanup retries Windows file locks without masking results', () => {
   const source = fs.readFileSync(
     path.join(__dirname, 'packed-artifact-lifecycle.js'),


### PR DESCRIPTION
## Summary

Follow-up to merged PR #2715.

The explicit hook-consent gate is correct, but the packed-artifact lifecycle smoke still had one remaining managed install path that invoked a hook-bearing module selection without making the consent decision. That left `Packed Install (ubuntu-latest)` and `Packed Install (windows-latest)` red after #2715 merged on August 30, 2026.

This PR updates the shared packed target smoke helper so its `workflow-quality` install path passes `--enable-hooks`, and adds a regression check that keeps that explicit opt-in in place.

## Verification

- `node tests/ci/packed-artifact-lifecycle.test.js`
- `NODE_PATH=/Users/hira/Documents/ECC/everything-claude-code/node_modules node tests/scripts/install-apply.test.js`
