### PR TITLE
fix(install): preserve opencode non-hook defaults

### DIFF
--- a/scripts/lib/install/hook-consent.js
+++ b/scripts/lib/install/hook-consent.js
@@ -56,10 +56,6 @@ function isHookRuntimeOperation(operation = {}) {
     || source === '.cursor/hooks'
     || source.startsWith('.cursor/hooks/')
     || source === '.cursor/hooks.json'
-    || source === '.opencode/plugins'
-    || source.startsWith('.opencode/plugins/')
-    || source === '.opencode/dist/plugins'
-    || source.startsWith('.opencode/dist/plugins/')
     || destination.endsWith('/hooks/hooks.json')
     || destination.endsWith('/.cursor/hooks.json')
     || destination.includes('/.cursor/hooks/')

--- a/tests/lib/hook-consent.test.js
+++ b/tests/lib/hook-consent.test.js
@@ -72,6 +72,14 @@ function runTests() {
     assert.strictEqual(isHookRuntimeOperation({ sourceRelativePath: 'hooks/hooks.json' }), true);
     assert.strictEqual(isHookRuntimeOperation({ sourceRelativePath: '.cursor/hooks.json' }), true);
     assert.strictEqual(isHookRuntimeOperation({ destinationPath: '/root/.claude/hooks/hooks.json' }), true);
+    assert.strictEqual(
+      isHookRuntimeOperation({
+        moduleId: 'platform-configs',
+        sourceRelativePath: '.opencode/plugins/ecc-hooks.ts',
+        destinationPath: '/root/.config/opencode/plugins/ecc-hooks.ts',
+      }),
+      false
+    );
     assert.strictEqual(isHookRuntimeOperation({ sourceRelativePath: 'rules/common.md' }), false);
     assert.strictEqual(
       isHookRuntimeOperation({ sourceRelativePath: 'skills/webhooks-guide.md' }),


### PR DESCRIPTION
## Summary
- stop classifying OpenCode baseline plugin source files as hook-runtime materialization
- preserve the explicit OpenCode default that keeps hooks disabled until users opt in
- add a regression test covering the `.opencode/plugins/ecc-hooks.ts` false positive

## Why
The `main` CI run for merge commit `19e2f2b46d1f7a6c2422ee5e299adcfa052a99e5` on August 30, 2026 failed in multiple Ubuntu lanes because `tests/lib/opencode-legacy-migration.test.js` hit the hook-consent gate during baseline OpenCode migration and repair.

## Verification
- `node tests/lib/hook-consent.test.js`
- `node tests/lib/install-lifecycle.test.js`
- `node tests/lib/opencode-legacy-migration.test.js` reproduces the fixed migration paths locally, but this worktree does not have the root `typescript` dependency that `scripts/build-opencode.js` expects, so CI is required for the build-dependent repair cases
