### PR TITLE
fix(mcp): accept reserved _meta field in ping params

### DIFF
--- a/scripts/memory-mcp.mjs
+++ b/scripts/memory-mcp.mjs
@@ -417,8 +417,14 @@ function createMemoryMcpService(options = {}) {
         return jsonRpcError(message.id, -32002, 'Server is not initialized.');
       }
       if (message.method === 'ping') {
-        if (message.params && Object.keys(message.params).length > 0) {
-          return jsonRpcError(message.id, -32602, 'ping does not accept parameters.');
+        const params = message.params || {};
+        if (
+          // `_meta` is reserved by MCP for request metadata (e.g. progressToken); accept it,
+          // but when present it must be a metadata object — reject null, arrays, and scalars.
+          (Object.prototype.hasOwnProperty.call(params, '_meta') && !isRecord(params._meta))
+          || Object.keys(params).some(key => key !== '_meta')
+        ) {
+          return jsonRpcError(message.id, -32602, 'Invalid ping parameters.');
         }
         return jsonRpcResult(message.id, {});
       }

--- a/tests/scripts/memory-mcp.test.js
+++ b/tests/scripts/memory-mcp.test.js
@@ -138,6 +138,7 @@ async function withClient(fn, options = {}) {
       { name, arguments: toolArguments }
     ),
     callToolRaw: params => request('tools/call', params),
+    pingRaw: params => request('ping', params),
   };
 
   try {
@@ -222,6 +223,35 @@ async function main() {
 
       await assert.rejects(
         client.listToolsRaw({ unexpected: true }),
+        /-32602/
+      );
+    });
+  });
+
+  await test('accepts the reserved _meta param on ping and rejects malformed values', async () => {
+    await withClient(async client => {
+      // Modern MCP clients stamp `_meta` (protocolVersion, clientInfo,
+      // clientCapabilities) onto every request once a "modern" protocol
+      // version is negotiated, including bare `ping` calls — this must
+      // not be treated as an unexpected parameter.
+      const withMeta = await client.pingRaw({
+        _meta: { progressToken: 'progress-123' },
+      });
+      assert.deepStrictEqual(withMeta, {});
+
+      const withoutParams = await client.pingRaw({});
+      assert.deepStrictEqual(withoutParams, {});
+
+      for (const badMeta of [null, ['not', 'an', 'object'], 'string', 42, true]) {
+        await assert.rejects(
+          client.pingRaw({ _meta: badMeta }),
+          /-32602/,
+          `expected _meta=${JSON.stringify(badMeta)} to be rejected`
+        );
+      }
+
+      await assert.rejects(
+        client.pingRaw({ unexpected: true }),
         /-32602/
       );
     });


### PR DESCRIPTION
## Summary

`ecc-memory-mcp`'s `ping` handler rejects any non-empty `params`, including the reserved `_meta` object. Modern MCP clients (e.g. the `mcp` Python SDK, once a "modern" protocol version like `2025-11-25` is negotiated) stamp `_meta` (`protocolVersion`, `clientInfo`, `clientCapabilities`) onto **every** request, including bare `ping` calls. That made every `ping` from such a client fail with `"ping does not accept parameters."`, which in at least one real client (Hermes, an MCP host) escalated into 3 failed connection attempts and the whole server being parked as broken.

`tools/list` and `tools/call` already special-case `_meta` for exactly this reason (#2670, c5ea82f6). This PR applies the same treatment to `ping`, matching the existing pattern/style exactly: `_meta` is accepted when present and is a plain object; any other key is still rejected.

## Type
- [x] Bug fix (MCP server)

## Testing

- Added a test mirroring the existing `tools/list` `_meta` coverage: `ping` accepts a valid `_meta` object, accepts no params at all, rejects malformed `_meta` (null/array/string/number/boolean), and still rejects genuinely unexpected keys.
- `node tests/scripts/memory-mcp.test.js` — 14/14 passing (was 13/13 before this change; the new test is additive).
- Manually verified against the server binary with a raw JSON-RPC handshake sending the modern-protocol `_meta` stamp on `initialize` → `tools/list` → `tools/call` → `ping`; all now succeed (previously `ping` alone would 400 with `"ping does not accept parameters."`).

## Checklist
- [x] Follows format guidelines (matches the existing `_meta`-handling pattern in the same file/tests)
- [x] Tested with the repo's own test harness
- [x] No sensitive info
- [x] Clear description