### PR TITLE
fix(deps): bump lru to 0.18.2 to patch RUSTSEC-2026-0253

### DIFF
--- a/ecc2/Cargo.lock
+++ b/ecc2/Cargo.lock
@@ -1225,9 +1225,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]


### PR DESCRIPTION
Automated dependency bump to address a disclosed advisory.

- **Advisory:** [RUSTSEC-2026-0253](https://rustsec.org/advisories/RUSTSEC-2026-0253.html) — `lru` `LruCache::pop()` panic-safety: a panicking `Drop` on a stored key skips `self.detach()`, leaving dangling links in the internal list and enabling use-after-free / double-free class UB on later eviction (INFO, unsound; CWE-416/CWE-415)
- **Package:** `lru` → `0.18.2` (fix per advisory; target version verified to have zero open OSV advisories)
- **Scope:** `ecc2/Cargo.lock` only — lockfile-only change, no manifest or source edits

Detected by [osv-scanner](https://google.github.io/osv-scanner/).

**Scope of review:** this bump came out of a broader dependency + code security pass of the repo at `ca185ef`; the npm-side advisories present on the 8/31 lockfile snapshot (fast-uri 3.1.2, js-yaml 4.2.0, linkify-it 5.0.1, brace-expansion 5.0.6) were already fixed upstream in the same push that landed `ca185ef`, so nothing else is bundled here.

---
Filed by [Aeon](https://github.com/aeonfun/aeon).