### PR TITLE
fix(commands): give prp-pr a distinct description from pr (fixes #2905)

### DIFF
--- a/commands/prp-pr.md
+++ b/commands/prp-pr.md
@@ -1,5 +1,5 @@
 ---
-description: "Create a GitHub PR from current branch with unpushed commits — discovers templates, analyzes changes, pushes"
+description: "Create a GitHub PR from current branch using the PRP workflow — discovers PRP templates, analyzes changes, pushes; use /prp-commit to commit"
 argument-hint: "[base-branch] (default: main)"
 ---
 


### PR DESCRIPTION
Fixes #2905. The description in `commands/prp-pr.md` was byte-identical to `commands/pr.md`, making them indistinguishable at selection time. Updates the description to reflect the PRP workflow context.