### PR TITLE
Add Playwright MCP server to project config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "chrome-devtools": {
       "command": "npx",
       "args": ["-y", "chrome-devtools-mcp@latest"]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds the official `@playwright/mcp` server entry to `.mcp.json`, alongside the existing `chrome-devtools` server, so Playwright browser automation is available as an MCP tool in this project.

## Test plan
- [x] Validated `.mcp.json` is well-formed JSON
- [x] Confirmed the new `playwright` entry follows the same `npx`-based launch pattern as the existing `chrome-devtools` entry