### PR TITLE
fix(security): update fast-uri to 3.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1124,9 +1124,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -507,12 +507,12 @@
     "node": ">=18"
   },
   "overrides": {
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.7",
     "markdown-it": "14.3.0",
     "js-yaml": "4.3.1"
   },
   "resolutions": {
-    "fast-uri": "3.1.5",
+    "fast-uri": "3.1.7",
     "markdown-it": "14.3.0",
     "js-yaml": "4.3.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -804,10 +804,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:3.1.5":
-  version: 3.1.5
-  resolution: "fast-uri@npm:3.1.5"
-  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
+"fast-uri@npm:3.1.7":
+  version: 3.1.7
+  resolution: "fast-uri@npm:3.1.7"
+  checksum: 10c0/ca2baa4bde48fc7322bdc692c6636975943ebe4f6dd97e07d70b14e0ab85af2ff30de90f550f5ec2956684fe208e150d85d6cb5f3c74438c8ac1bf86bd435c13
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- update the npm override and Yarn resolution for `fast-uri` from 3.1.5 to 3.1.7
- refresh both lockfiles to the same patched runtime version
- clear four high-severity runtime advisories that began failing the Security Scan on `main` after #2877 merged

## Verification

- `npm ci --ignore-scripts`
- `npm audit signatures`
- `npm audit --omit=dev --audit-level=high`
- `npm run security:ioc-scan`
- `node scripts/ci/validate-workflow-security.js`
- full `npm test` started locally; GitHub Actions remains the cross-platform merge gate

## Scope

This is a forward security repair only. The triggering PR changed a test and did not introduce `fast-uri`; the advisory database changed while the exact post-merge `main` run was executing.