### PR TITLE
test(ci): tolerate loaded macOS hook runners

### DIFF
--- a/tests/hooks/plugin-hook-bootstrap-no-echo.test.js
+++ b/tests/hooks/plugin-hook-bootstrap-no-echo.test.js
@@ -42,6 +42,9 @@ const repoRoot = path.join(__dirname, '..', '..');
 const bootstrap = path.join(repoRoot, 'scripts', 'hooks', 'plugin-hook-bootstrap.js');
 const { isRawPassthrough } = require(bootstrap);
 const FIXTURE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-pr2380-fixtures-'));
+const SUBPROCESS_TIMEOUT_MS = process.platform === 'darwin' && process.env.CI === 'true'
+  ? 120_000
+  : 30_000;
 
 function cleanupFixtureDir() {
   fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
@@ -67,7 +70,7 @@ function runBootstrap(args, input, env) {
     encoding: 'utf8',
     cwd: repoRoot,
     env: { ...process.env, ...(env || {}) },
-    timeout: 30000,
+    timeout: SUBPROCESS_TIMEOUT_MS,
     maxBuffer: 16 * 1024 * 1024,
     stdio: ['pipe', 'pipe', 'pipe']
   });
@@ -80,7 +83,7 @@ function runHookEntry(args, input, env) {
     encoding: 'utf8',
     cwd: repoRoot,
     env: { ...process.env, ...(env || {}) },
-    timeout: 30000,
+    timeout: SUBPROCESS_TIMEOUT_MS,
     maxBuffer: 16 * 1024 * 1024,
     stdio: ['pipe', 'pipe', 'pipe']
   });

--- a/tests/hooks/stop-hooks-stdout.test.js
+++ b/tests/hooks/stop-hooks-stdout.test.js
@@ -29,6 +29,9 @@ const hooksConfig = JSON.parse(
 );
 
 const MAX_STDIN = 1024 * 1024;
+const SUBPROCESS_TIMEOUT_MS = process.platform === 'darwin' && process.env.CI === 'true'
+  ? 120_000
+  : 60_000;
 
 const workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-stop-stdout-')); // non-git cwd
 const dataHome = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-stop-data-'));
@@ -75,7 +78,7 @@ function runViaRunner(hookId, script, input) {
     encoding: 'utf8',
     cwd: workDir,
     env: hookEnv(),
-    timeout: 60000,
+    timeout: SUBPROCESS_TIMEOUT_MS,
     maxBuffer: 16 * 1024 * 1024,
     stdio: ['pipe', 'pipe', 'pipe']
   });
@@ -87,7 +90,7 @@ function runDirect(script, input) {
     encoding: 'utf8',
     cwd: workDir,
     env: hookEnv(),
-    timeout: 60000,
+    timeout: SUBPROCESS_TIMEOUT_MS,
     maxBuffer: 16 * 1024 * 1024,
     stdio: ['pipe', 'pipe', 'pipe']
   });
@@ -107,7 +110,7 @@ function runRegisteredStopHook(entry, input, envOverrides = {}) {
     cwd: workDir,
     env,
     shell: true,
-    timeout: 60000,
+    timeout: SUBPROCESS_TIMEOUT_MS,
     maxBuffer: 16 * 1024 * 1024,
     stdio: ['pipe', 'pipe', 'pipe']
   });


### PR DESCRIPTION
## Summary

- give hook subprocess contract tests a macOS-CI-only 120 second deadline
- preserve the existing 30 second and 60 second local deadlines
- cover both hook test files that timed out under runner load

## Evidence

Exact-main CI run 33671997933 passed 4,153 of 4,154 tests on the repeated macOS Node 20/yarn attempt. The single failure was a `spawnSync` status of `null` at the existing 30 second deadline in `plugin-hook-bootstrap-no-echo.test.js`; the first attempt produced the same timeout family across that test and `stop-hooks-stdout.test.js`. The same product and contract tests pass outside the loaded hosted macOS lane.

## Verification

- `node tests/hooks/plugin-hook-bootstrap-no-echo.test.js`
- `node tests/hooks/stop-hooks-stdout.test.js`
- `CI=true node tests/hooks/plugin-hook-bootstrap-no-echo.test.js`
- `CI=true node tests/hooks/stop-hooks-stdout.test.js`
- `npm run lint -- --quiet`
- `git diff --check`

This is a recovery-only test reliability patch. It does not change hook runtime behavior or weaken any assertion.