### PR TITLE
test(ci): scale repair timeout on Windows

### DIFF
--- a/tests/scripts/repair.test.js
+++ b/tests/scripts/repair.test.js
@@ -12,7 +12,10 @@ const INSTALL_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'install-appl
 const DOCTOR_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'doctor.js');
 const REPAIR_SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'repair.js');
 const REPO_ROOT = path.join(__dirname, '..', '..');
-const CLI_TIMEOUT_MS = 30000;
+// Windows CI file I/O is several times slower, and these cases run full
+// install, doctor, and repair passes over hundreds of files. Keep this in
+// step with the equivalent install-apply and uninstall integration tests.
+const CLI_TIMEOUT_MS = process.platform === 'win32' ? 90000 : 30000;
 const CURRENT_PACKAGE_VERSION = JSON.parse(
   fs.readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf8')
 ).version;


### PR DESCRIPTION
## Summary

- scale `repair.test.js` CLI integration timeouts to 90 seconds on Windows only
- retain the existing 30-second ceiling on Linux and macOS
- align the test with the established `install-apply` and `uninstall` Windows timeout policy

## Why

Exact-main CI after #2941 failed only in `windows-latest / Node 22.x / yarn`. The real install, doctor, and repair sequence exceeded the fixed 30-second child-process timeout under runner load. The remaining 4,045 tests passed, all other Windows package-manager and Node combinations passed, and the equivalent file-heavy integration tests already use this platform-scoped ceiling.

Failing exact-main run: https://github.com/affaan-m/ECC/actions/runs/33697262010

## Verification

- `node tests/scripts/repair.test.js`
- `npx eslint tests/scripts/repair.test.js`
- `git diff --check`
