### PR TITLE
docs: fix stale README counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Instead of rebuilding that process in every prompt, you install it once and make
 
 ECC is MIT-licensed open source. It works best with Claude Code today, has a supported Codex sync path, and provides capability-limited adapters for Cursor, OpenCode, Gemini, Zed, GitHub Copilot, Antigravity, Qwen, and other harnesses. See the [support status matrix](#platform-support) before assuming feature parity.
 
-Access to 68 agents, 286 skills, and 94 legacy command shims, plus hooks, rules, memory, continuous learning, and AgentShield security scanning. The agents are specialized for planning, review, build repair, security, architecture, and domain work.
+Access to 68 agents, 286 skills, and 94 commands, plus hooks, rules, memory, continuous learning, and AgentShield security scanning. The agents are specialized for planning, review, build repair, security, architecture, and domain work.
 
 | Included         |       Count | What it gives you                                                                    |
 | ---------------- | ----------: | ------------------------------------------------------------------------------------ |
@@ -1074,7 +1074,7 @@ This repo is the raw code. The guides explain everything.
 ```text
 ECC/
 |-- agents/           # 68 specialized subagents for delegation
-|-- skills/           # 284 reusable workflows loaded on demand
+|-- skills/           # 286 reusable workflows loaded on demand
 |-- commands/         # 94 maintained slash-command shims
 |-- rules/            # opt-in common and language standards
 |-- hooks/            # runtime automation and enforcement


### PR DESCRIPTION
## What Changed
Fixed two stale/incorrect facts in README.md:
1. Directory tree comment said `skills/ # 284 reusable workflows loaded on demand` — actual count is 286 (verified: `find skills -name SKILL.md | wc -l` → 286, matching the two other "286 skills" mentions already in the README).
2. Intro line called the 94 files in `commands/` "legacy command shims" — they are not. The repo has a separate, genuinely legacy `legacy-command-shims/commands/` directory with only 12 files. Changed wording to "94 commands" to match the terminology already used in the feature table (`| Commands | 94 commands | ... |`) and to match scripts/ci/catalog.js's expected regex.

## Why This Change
Both numbers/wording were inconsistent with the actual repository contents and with other parts of the same README, which could confuse contributors trying to understand the skill/command surface.

## Testing Done
- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js` / `npm test`)
- [x] Edge cases considered and tested

Verified via:

find skills -maxdepth 1 -mindepth 1 -type d | wc -l # 286
find skills -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l # 286
find commands -maxdepth 1 -type f | wc -l # 94
find legacy-command-shims/commands -maxdepth 1 -type f | wc -l # 12
npm test # all checks pass including catalog:check


## Type of Change
- [x] `docs:` Documentation

## Security & Quality Checklist
- [x] No secrets or API keys committed
- [x] JSON files validate cleanly (no JSON touched)
- [x] Shell scripts pass shellcheck (n/a — no shell scripts changed)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## If you changed dependencies or package.json
N/A — no dependency or package.json changes.

## If you added a skill, command, agent, hook, or CLI tool
N/A — no new skill/command/agent/hook added, only corrected existing counts in prose.

## Documentation
- [x] Updated relevant documentation (README.md)
- [ ] Added comments for complex logic (n/a)
- [x] README updated