### PR TITLE
docs(rules): namespace ECC agent references with ecc: prefix

### DIFF
--- a/.cursor/rules/common-agents.md
+++ b/.cursor/rules/common-agents.md
@@ -1,47 +1,163 @@
 ---
-description: "Agent orchestration: available agents, parallel execution, multi-perspective analysis"
+description: "Agent orchestration: ecc: namespacing, agent catalog, parallel execution, multi-perspective analysis"
 alwaysApply: true
 ---
+
 # Agent Orchestration
 
-## Available Agents
+## Agent Names Are Namespaced (CRITICAL)
 
-Located in `~/.claude/agents/`:
+ECC agents are plugin agents. They MUST be referenced with the `ecc:` prefix:
 
-| Agent | Purpose | When to Use |
-|-------|---------|-------------|
-| planner | Implementation planning | Complex features, refactoring |
-| architect | System design | Architectural decisions |
-| tdd-guide | Test-driven development | New features, bug fixes |
-| code-reviewer | Code review | After writing code |
-| security-reviewer | Security analysis | Before commits |
-| build-error-resolver | Fix build errors | When build fails |
-| e2e-runner | E2E testing | Critical user flows |
-| refactor-cleaner | Dead code cleanup | Code maintenance |
-| doc-updater | Documentation | Updating docs |
+- `ecc:planner` ✅ resolves
+- `planner` ❌ does not resolve
+
+The 68 ECC agent definitions live in the plugin at `~/.claude/plugins/marketplaces/ecc/agents/`.
+
+### Exception: local user agents
+
+Agents you define yourself under `~/.claude/agents/` are user agents, not plugin agents, and
+resolve **without** the `ecc:` prefix — even when the file sits in an `ecc/` subfolder. That
+folder is organization only; it does not create a namespace.
+
+```
+~/.claude/plugins/marketplaces/ecc/agents/planner.md   -> ecc:planner
+~/.claude/agents/my-agent.md                           -> my-agent
+~/.claude/agents/ecc/my-agent.md                       -> my-agent   (still no prefix)
+```
+
+Rule of thumb: if the name appears in the tables below, use `ecc:`. If it is your own file
+under `~/.claude/agents/`, use the bare name. When in doubt, check `/agents`.
+
+## Core Agents
+
+Daily workflow agents, all namespaced:
+
+| Agent | Purpose |
+|-------|---------|
+| **ecc:planner** | Implementation planning |
+| **ecc:architect** | System design and architectural decisions |
+| **ecc:code-architect** | Feature architecture blueprints from existing codebase patterns |
+| **ecc:code-explorer** | Deep analysis of existing features and execution paths |
+| **ecc:code-reviewer** | Code review after writing/modifying code |
+| **ecc:security-reviewer** | Security analysis before commits |
+| **ecc:tdd-guide** | Test-driven development for new features and bug fixes |
+| **ecc:build-error-resolver** | General build/type error resolution |
+| **ecc:e2e-runner** | E2E testing of critical user flows |
+| **ecc:refactor-cleaner** | Dead code cleanup and code maintenance |
+| **ecc:doc-updater** | Documentation and codemaps |
+| **ecc:performance-optimizer** | Bottleneck identification and optimization |
+| **ecc:code-simplifier** | Simplification while preserving behavior |
+| **ecc:agent-evaluator** | Output quality scoring on a 5-axis rubric |
+
+## Language & Framework Reviewers
+
+Choose by the language/framework of the files under review:
+
+| Agent | Scope |
+|-------|-------|
+| **ecc:typescript-reviewer** | TypeScript/JavaScript |
+| **ecc:react-reviewer** | React/JSX |
+| **ecc:vue-reviewer** | Vue/Nuxt/Pinia |
+| **ecc:python-reviewer** | Python |
+| **ecc:fastapi-reviewer** | FastAPI |
+| **ecc:django-reviewer** | Django/DRF |
+| **ecc:go-reviewer** | Go |
+| **ecc:rust-reviewer** | Rust |
+| **ecc:java-reviewer** | Java (Spring Boot/Quarkus) |
+| **ecc:kotlin-reviewer** | Kotlin/Android/KMP |
+| **ecc:swift-reviewer** | Swift |
+| **ecc:flutter-reviewer** | Flutter/Dart |
+| **ecc:php-reviewer** | PHP |
+| **ecc:csharp-reviewer** | C#/.NET |
+| **ecc:fsharp-reviewer** | F# |
+| **ecc:cpp-reviewer** | C++ |
+| **ecc:database-reviewer** | PostgreSQL/SQL/Supabase |
+| **ecc:mle-reviewer** | ML/MLOps code |
+| **ecc:rag-pipeline-reviewer** | RAG pipelines, vector stores, retrieval quality |
+
+## Build Error Resolvers
+
+Choose by the toolchain that failed. For generic TypeScript/build errors, use **ecc:build-error-resolver** (Core):
+
+| Agent | Toolchain |
+|-------|-----------|
+| **ecc:react-build-resolver** | React (Vite, webpack, Next.js, CRA, esbuild, Bun) |
+| **ecc:django-build-resolver** | Django/Python (pip, Poetry, migrations) |
+| **ecc:go-build-resolver** | Go (build, vet, linters) |
+| **ecc:rust-build-resolver** | Rust/Cargo |
+| **ecc:java-build-resolver** | Java/Maven/Gradle (Spring Boot, Quarkus) |
+| **ecc:kotlin-build-resolver** | Kotlin/Gradle |
+| **ecc:swift-build-resolver** | Swift/Xcode/SPM |
+| **ecc:cpp-build-resolver** | C++/CMake |
+| **ecc:dart-build-resolver** | Dart/Flutter |
+| **ecc:pytorch-build-resolver** | PyTorch/CUDA |
+| **ecc:harmonyos-app-resolver** | HarmonyOS/ArkTS |
+
+## Specialist Agents
+
+The rest of the fleet — delegate when the task matches their specialty:
+
+| Agent | Purpose |
+|-------|---------|
+| **ecc:a11y-architect** | WCAG 2.2 accessibility design and audits |
+| **ecc:chief-of-staff** | Email/Slack/LINE/Messenger triage |
+| **ecc:comment-analyzer** | Code comment accuracy and rot risk |
+| **ecc:conversation-analyzer** | Find behaviors worth preventing with hooks |
+| **ecc:docs-lookup** | Context7 documentation lookup |
+| **ecc:gan-planner** | GAN harness: expand prompt into full spec |
+| **ecc:gan-generator** | GAN harness: implement to spec |
+| **ecc:gan-evaluator** | GAN harness: score live app against rubric |
+| **ecc:harness-optimizer** | Improve local agent harness config |
+| **ecc:healthcare-reviewer** | EMR/EHR clinical safety and PHI compliance |
+| **ecc:homelab-architect** | Home/small-lab network plans |
+| **ecc:loop-operator** | Operate and intervene in autonomous loops |
+| **ecc:marketing-agent** | Marketing strategy and copy |
+| **ecc:network-architect** | Enterprise/multi-site network design |
+| **ecc:network-config-reviewer** | Router/switch config review |
+| **ecc:network-troubleshooter** | Connectivity/routing/DNS diagnostics |
+| **ecc:opensource-forker** | Open-source pipeline: fork and strip |
+| **ecc:opensource-sanitizer** | Open-source pipeline: verify sanitization |
+| **ecc:opensource-packager** | Open-source pipeline: packaging |
+| **ecc:pr-test-analyzer** | PR test coverage quality |
+| **ecc:seo-specialist** | Technical SEO audits |
+| **ecc:silent-failure-hunter** | Swallowed errors, bad fallbacks |
+| **ecc:spec-miner** | Extract behavioral specs for OpenSpec |
+| **ecc:type-design-analyzer** | Type design analysis |
 
 ## Immediate Agent Usage
 
 No user prompt needed:
-1. Complex feature requests - Use **planner** agent
-2. Code just written/modified - Use **code-reviewer** agent
-3. Bug fix or new feature - Use **tdd-guide** agent
-4. Architectural decision - Use **architect** agent
+1. Complex feature requests - Use **ecc:planner** agent
+2. Code just written/modified - Use **ecc:code-reviewer** agent
+3. Bug fix or new feature - Use **ecc:tdd-guide** agent
+4. Architectural decision - Use **ecc:architect** agent
+5. Security-sensitive change (auth, user input, secrets, DB, external API) - Use **ecc:security-reviewer** agent
 
 ## Parallel Task Execution
 
 ALWAYS use parallel Task execution for independent operations:
 
 ```markdown
-# GOOD: Parallel execution
+# GOOD: Parallel execution — one message, multiple agent calls
 Launch 3 agents in parallel:
-1. Agent 1: Security analysis of auth module
-2. Agent 2: Performance review of cache system
-3. Agent 3: Type checking of utilities
+1. Agent 1: **ecc:security-reviewer** — security analysis of auth module
+2. Agent 2: **ecc:performance-optimizer** — performance review of cache system
+3. Agent 3: **ecc:typescript-reviewer** — type checking of utilities
 
 # BAD: Sequential when unnecessary
 First agent 1, then agent 2, then agent 3
 ```
+
+## Delegation Completion Contract
+
+Applies to every agent at every depth (parent, child, grandchild):
+
+1. **Your final message IS the deliverable.** Never end your turn with "waiting for background agents" — a spawned task is not a completed task. Ending your turn while children are running orphans their results (completed children cannot notify a parent whose turn has ended).
+2. **If you delegate, you own collection.** Wait for results, integrate them, then return. Fire-and-forget delegation is forbidden.
+3. **Decompose only when the work cannot fit in one context.** Do not re-delegate a task already sized for a single agent — depth is an outcome, not a plan.
+
+> Rationale: observed failure mode — research agents followed "Parallel Task Execution" above, spawned children, and returned "waiting" as their final answer. All children completed successfully but their results were orphaned. The parallel rule without a completion contract produces zombie tasks.
 
 ## Multi-Perspective Analysis
 
@@ -51,3 +167,9 @@ For complex problems, use split role sub-agents:
 - Security expert
 - Consistency reviewer
 - Redundancy checker
+
+## If An Agent Type Fails To Resolve
+
+1. Retry once with the `ecc:` prefix (`planner` → `ecc:planner`)
+2. Check the available agents list (`/agents`) for the exact name
+3. Report the failure to the user — never absorb the work inline pretending the delegation happened

--- a/.cursor/rules/common-development-workflow.md
+++ b/.cursor/rules/common-development-workflow.md
@@ -11,19 +11,19 @@ The Feature Implementation Workflow describes the development pipeline: planning
 ## Feature Implementation Workflow
 
 1. **Plan First**
-   - Use **planner** agent to create implementation plan
+   - Use **ecc:planner** agent to create implementation plan
    - Identify dependencies and risks
    - Break down into phases
 
 2. **TDD Approach**
-   - Use **tdd-guide** agent
+   - Use **ecc:tdd-guide** agent
    - Write tests first (RED)
    - Implement to pass tests (GREEN)
    - Refactor (IMPROVE)
    - Verify 80%+ coverage
 
 3. **Code Review**
-   - Use **code-reviewer** agent immediately after writing code
+   - Use **ecc:code-reviewer** agent immediately after writing code
    - Address CRITICAL and HIGH issues
    - Fix MEDIUM issues when possible
 

--- a/.cursor/rules/common-performance.md
+++ b/.cursor/rules/common-performance.md
@@ -53,7 +53,7 @@ For complex tasks requiring deep reasoning:
 ## Build Troubleshooting
 
 If build fails:
-1. Use **build-error-resolver** agent
+1. Use **ecc:build-error-resolver** agent
 2. Analyze error messages
 3. Fix incrementally
 4. Verify after each fix

--- a/.cursor/rules/common-security.md
+++ b/.cursor/rules/common-security.md
@@ -27,7 +27,7 @@ Before ANY commit:
 
 If security issue found:
 1. STOP immediately
-2. Use **security-reviewer** agent
+2. Use **ecc:security-reviewer** agent
 3. Fix CRITICAL issues before continuing
 4. Rotate any exposed secrets
 5. Review entire codebase for similar issues

--- a/.cursor/rules/common-testing.md
+++ b/.cursor/rules/common-testing.md
@@ -23,11 +23,11 @@ MANDATORY workflow:
 
 ## Troubleshooting Test Failures
 
-1. Use **tdd-guide** agent
+1. Use **ecc:tdd-guide** agent
 2. Check test isolation
 3. Verify mocks are correct
 4. Fix implementation, not tests (unless tests are wrong)
 
 ## Agent Support
 
-- **tdd-guide** - Use PROACTIVELY for new features, enforces write-tests-first
+- **ecc:tdd-guide** - Use PROACTIVELY for new features, enforces write-tests-first

--- a/.cursor/rules/typescript-security.md
+++ b/.cursor/rules/typescript-security.md
@@ -23,4 +23,4 @@ if (!apiKey) {
 
 ## Agent Support
 
-- Use **security-reviewer** skill for comprehensive security audits
+- Use **ecc:security-reviewer** skill for comprehensive security audits

--- a/.cursor/rules/typescript-testing.md
+++ b/.cursor/rules/typescript-testing.md
@@ -13,4 +13,4 @@ Use **Playwright** as the E2E testing framework for critical user flows.
 
 ## Agent Support
 
-- **e2e-runner** - Playwright E2E testing specialist
+- **ecc:e2e-runner** - Playwright E2E testing specialist

--- a/rules/angular/security.md
+++ b/rules/angular/security.md
@@ -84,4 +84,4 @@ Configure CSP headers server-side. Avoid `unsafe-inline` in `script-src`. When u
 
 ## Agent Support
 
-- Use **security-reviewer** skill for comprehensive security audits
+- Use **ecc:security-reviewer** skill for comprehensive security audits

--- a/rules/common/agents.md
+++ b/rules/common/agents.md
@@ -1,41 +1,144 @@
 # Agent Orchestration
 
-## Available Agents
+## Agent Names Are Namespaced (CRITICAL)
 
-Located in `~/.claude/agents/`:
+ECC agents are plugin agents. They MUST be referenced with the `ecc:` prefix:
 
-| Agent | Purpose | When to Use |
-|-------|---------|-------------|
-| planner | Implementation planning | Complex features, refactoring |
-| architect | System design | Architectural decisions |
-| tdd-guide | Test-driven development | New features, bug fixes |
-| code-reviewer | Code review | After writing code |
-| security-reviewer | Security analysis | Before commits |
-| build-error-resolver | Fix build errors | When build fails |
-| e2e-runner | E2E testing | Critical user flows |
-| refactor-cleaner | Dead code cleanup | Code maintenance |
-| doc-updater | Documentation | Updating docs |
-| rust-reviewer | Rust code review | Rust projects |
-| harmonyos-app-resolver | HarmonyOS app development | HarmonyOS/ArkTS projects |
+- `ecc:planner` ✅ resolves
+- `planner` ❌ does not resolve
+
+The 68 ECC agent definitions live in the plugin at `~/.claude/plugins/marketplaces/ecc/agents/`.
+
+### Exception: local user agents
+
+Agents you define yourself under `~/.claude/agents/` are user agents, not plugin agents, and
+resolve **without** the `ecc:` prefix — even when the file sits in an `ecc/` subfolder. That
+folder is organization only; it does not create a namespace.
+
+```
+~/.claude/plugins/marketplaces/ecc/agents/planner.md   -> ecc:planner
+~/.claude/agents/my-agent.md                           -> my-agent
+~/.claude/agents/ecc/my-agent.md                       -> my-agent   (still no prefix)
+```
+
+Rule of thumb: if the name appears in the tables below, use `ecc:`. If it is your own file
+under `~/.claude/agents/`, use the bare name. When in doubt, check `/agents`.
+
+## Core Agents
+
+Daily workflow agents, all namespaced:
+
+| Agent | Purpose |
+|-------|---------|
+| **ecc:planner** | Implementation planning |
+| **ecc:architect** | System design and architectural decisions |
+| **ecc:code-architect** | Feature architecture blueprints from existing codebase patterns |
+| **ecc:code-explorer** | Deep analysis of existing features and execution paths |
+| **ecc:code-reviewer** | Code review after writing/modifying code |
+| **ecc:security-reviewer** | Security analysis before commits |
+| **ecc:tdd-guide** | Test-driven development for new features and bug fixes |
+| **ecc:build-error-resolver** | General build/type error resolution |
+| **ecc:e2e-runner** | E2E testing of critical user flows |
+| **ecc:refactor-cleaner** | Dead code cleanup and code maintenance |
+| **ecc:doc-updater** | Documentation and codemaps |
+| **ecc:performance-optimizer** | Bottleneck identification and optimization |
+| **ecc:code-simplifier** | Simplification while preserving behavior |
+| **ecc:agent-evaluator** | Output quality scoring on a 5-axis rubric |
+
+## Language & Framework Reviewers
+
+Choose by the language/framework of the files under review:
+
+| Agent | Scope |
+|-------|-------|
+| **ecc:typescript-reviewer** | TypeScript/JavaScript |
+| **ecc:react-reviewer** | React/JSX |
+| **ecc:vue-reviewer** | Vue/Nuxt/Pinia |
+| **ecc:python-reviewer** | Python |
+| **ecc:fastapi-reviewer** | FastAPI |
+| **ecc:django-reviewer** | Django/DRF |
+| **ecc:go-reviewer** | Go |
+| **ecc:rust-reviewer** | Rust |
+| **ecc:java-reviewer** | Java (Spring Boot/Quarkus) |
+| **ecc:kotlin-reviewer** | Kotlin/Android/KMP |
+| **ecc:swift-reviewer** | Swift |
+| **ecc:flutter-reviewer** | Flutter/Dart |
+| **ecc:php-reviewer** | PHP |
+| **ecc:csharp-reviewer** | C#/.NET |
+| **ecc:fsharp-reviewer** | F# |
+| **ecc:cpp-reviewer** | C++ |
+| **ecc:database-reviewer** | PostgreSQL/SQL/Supabase |
+| **ecc:mle-reviewer** | ML/MLOps code |
+| **ecc:rag-pipeline-reviewer** | RAG pipelines, vector stores, retrieval quality |
+
+## Build Error Resolvers
+
+Choose by the toolchain that failed. For generic TypeScript/build errors, use **ecc:build-error-resolver** (Core):
+
+| Agent | Toolchain |
+|-------|-----------|
+| **ecc:react-build-resolver** | React (Vite, webpack, Next.js, CRA, esbuild, Bun) |
+| **ecc:django-build-resolver** | Django/Python (pip, Poetry, migrations) |
+| **ecc:go-build-resolver** | Go (build, vet, linters) |
+| **ecc:rust-build-resolver** | Rust/Cargo |
+| **ecc:java-build-resolver** | Java/Maven/Gradle (Spring Boot, Quarkus) |
+| **ecc:kotlin-build-resolver** | Kotlin/Gradle |
+| **ecc:swift-build-resolver** | Swift/Xcode/SPM |
+| **ecc:cpp-build-resolver** | C++/CMake |
+| **ecc:dart-build-resolver** | Dart/Flutter |
+| **ecc:pytorch-build-resolver** | PyTorch/CUDA |
+| **ecc:harmonyos-app-resolver** | HarmonyOS/ArkTS |
+
+## Specialist Agents
+
+The rest of the fleet — delegate when the task matches their specialty:
+
+| Agent | Purpose |
+|-------|---------|
+| **ecc:a11y-architect** | WCAG 2.2 accessibility design and audits |
+| **ecc:chief-of-staff** | Email/Slack/LINE/Messenger triage |
+| **ecc:comment-analyzer** | Code comment accuracy and rot risk |
+| **ecc:conversation-analyzer** | Find behaviors worth preventing with hooks |
+| **ecc:docs-lookup** | Context7 documentation lookup |
+| **ecc:gan-planner** | GAN harness: expand prompt into full spec |
+| **ecc:gan-generator** | GAN harness: implement to spec |
+| **ecc:gan-evaluator** | GAN harness: score live app against rubric |
+| **ecc:harness-optimizer** | Improve local agent harness config |
+| **ecc:healthcare-reviewer** | EMR/EHR clinical safety and PHI compliance |
+| **ecc:homelab-architect** | Home/small-lab network plans |
+| **ecc:loop-operator** | Operate and intervene in autonomous loops |
+| **ecc:marketing-agent** | Marketing strategy and copy |
+| **ecc:network-architect** | Enterprise/multi-site network design |
+| **ecc:network-config-reviewer** | Router/switch config review |
+| **ecc:network-troubleshooter** | Connectivity/routing/DNS diagnostics |
+| **ecc:opensource-forker** | Open-source pipeline: fork and strip |
+| **ecc:opensource-sanitizer** | Open-source pipeline: verify sanitization |
+| **ecc:opensource-packager** | Open-source pipeline: packaging |
+| **ecc:pr-test-analyzer** | PR test coverage quality |
+| **ecc:seo-specialist** | Technical SEO audits |
+| **ecc:silent-failure-hunter** | Swallowed errors, bad fallbacks |
+| **ecc:spec-miner** | Extract behavioral specs for OpenSpec |
+| **ecc:type-design-analyzer** | Type design analysis |
 
 ## Immediate Agent Usage
 
 No user prompt needed:
-1. Complex feature requests - Use **planner** agent
-2. Code just written/modified - Use **code-reviewer** agent
-3. Bug fix or new feature - Use **tdd-guide** agent
-4. Architectural decision - Use **architect** agent
+1. Complex feature requests - Use **ecc:planner** agent
+2. Code just written/modified - Use **ecc:code-reviewer** agent
+3. Bug fix or new feature - Use **ecc:tdd-guide** agent
+4. Architectural decision - Use **ecc:architect** agent
+5. Security-sensitive change (auth, user input, secrets, DB, external API) - Use **ecc:security-reviewer** agent
 
 ## Parallel Task Execution
 
 ALWAYS use parallel Task execution for independent operations:
 
 ```markdown
-# GOOD: Parallel execution
+# GOOD: Parallel execution — one message, multiple agent calls
 Launch 3 agents in parallel:
-1. Agent 1: Security analysis of auth module
-2. Agent 2: Performance review of cache system
-3. Agent 3: Type checking of utilities
+1. Agent 1: **ecc:security-reviewer** — security analysis of auth module
+2. Agent 2: **ecc:performance-optimizer** — performance review of cache system
+3. Agent 3: **ecc:typescript-reviewer** — type checking of utilities
 
 # BAD: Sequential when unnecessary
 First agent 1, then agent 2, then agent 3
@@ -59,3 +162,9 @@ For complex problems, use split role sub-agents:
 - Security expert
 - Consistency reviewer
 - Redundancy checker
+
+## If An Agent Type Fails To Resolve
+
+1. Retry once with the `ecc:` prefix (`planner` → `ecc:planner`)
+2. Check the available agents list (`/agents`) for the exact name
+3. Report the failure to the user — never absorb the work inline pretending the delegation happened

--- a/rules/common/code-review.md
+++ b/rules/common/code-review.md
@@ -38,7 +38,7 @@ Before marking code complete:
 
 ## Security Review Triggers
 
-**STOP and use security-reviewer agent when:**
+**STOP and use ecc:security-reviewer agent when:**
 
 - Authentication or authorization code
 - User input handling
@@ -63,12 +63,12 @@ Use these agents for code review:
 
 | Agent | Purpose |
 |-------|---------|
-| **code-reviewer** | General code quality, patterns, best practices |
-| **security-reviewer** | Security vulnerabilities, OWASP Top 10 |
-| **typescript-reviewer** | TypeScript/JavaScript specific issues |
-| **python-reviewer** | Python specific issues |
-| **go-reviewer** | Go specific issues |
-| **rust-reviewer** | Rust specific issues |
+| **ecc:code-reviewer** | General code quality, patterns, best practices |
+| **ecc:security-reviewer** | Security vulnerabilities, OWASP Top 10 |
+| **ecc:typescript-reviewer** | TypeScript/JavaScript specific issues |
+| **ecc:python-reviewer** | Python specific issues |
+| **ecc:go-reviewer** | Go specific issues |
+| **ecc:rust-reviewer** | Rust specific issues |
 
 ## Review Workflow
 

--- a/rules/common/development-workflow.md
+++ b/rules/common/development-workflow.md
@@ -15,20 +15,20 @@ The Feature Implementation Workflow describes the development pipeline: research
    - Prefer adopting or porting a proven approach over writing net-new code when it meets the requirement.
 
 1. **Plan First**
-   - Use **planner** agent to create implementation plan
+   - Use **ecc:planner** agent to create implementation plan
    - Generate planning docs before coding: PRD, architecture, system_design, tech_doc, task_list
    - Identify dependencies and risks
    - Break down into phases
 
 2. **TDD Approach**
-   - Use **tdd-guide** agent
+   - Use **ecc:tdd-guide** agent
    - Write tests first (RED)
    - Implement to pass tests (GREEN)
    - Refactor (IMPROVE)
    - Verify 80%+ coverage
 
 3. **Code Review**
-   - Use **code-reviewer** agent immediately after writing code
+   - Use **ecc:code-reviewer** agent immediately after writing code
    - Address CRITICAL and HIGH issues
    - Fix MEDIUM issues when possible
 

--- a/rules/common/performance.md
+++ b/rules/common/performance.md
@@ -49,7 +49,7 @@ For complex tasks requiring deep reasoning:
 ## Build Troubleshooting
 
 If build fails:
-1. Use **build-error-resolver** agent
+1. Use **ecc:build-error-resolver** agent
 2. Analyze error messages
 3. Fix incrementally
 4. Verify after each fix

--- a/rules/common/security.md
+++ b/rules/common/security.md
@@ -23,7 +23,7 @@ Before ANY commit:
 
 If security issue found:
 1. STOP immediately
-2. Use **security-reviewer** agent
+2. Use **ecc:security-reviewer** agent
 3. Fix CRITICAL issues before continuing
 4. Rotate any exposed secrets
 5. Review entire codebase for similar issues

--- a/rules/common/testing.md
+++ b/rules/common/testing.md
@@ -19,14 +19,14 @@ MANDATORY workflow:
 
 ## Troubleshooting Test Failures
 
-1. Use **tdd-guide** agent
+1. Use **ecc:tdd-guide** agent
 2. Check test isolation
 3. Verify mocks are correct
 4. Fix implementation, not tests (unless tests are wrong)
 
 ## Agent Support
 
-- **tdd-guide** - Use PROACTIVELY for new features, enforces write-tests-first
+- **ecc:tdd-guide** - Use PROACTIVELY for new features, enforces write-tests-first
 
 ## Test Structure (AAA Pattern)
 

--- a/rules/typescript/security.md
+++ b/rules/typescript/security.md
@@ -25,4 +25,4 @@ if (!apiKey) {
 
 ## Agent Support
 
-- Use **security-reviewer** skill for comprehensive security audits
+- Use **ecc:security-reviewer** skill for comprehensive security audits

--- a/rules/typescript/testing.md
+++ b/rules/typescript/testing.md
@@ -15,4 +15,4 @@ Use **Playwright** as the E2E testing framework for critical user flows.
 
 ## Agent Support
 
-- **e2e-runner** - Playwright E2E testing specialist
+- **ecc:e2e-runner** - Playwright E2E testing specialist


### PR DESCRIPTION
## What Changed

**1. Agent references are now namespaced (`ecc:`) — 26 call sites.**
`rules/` treated ECC agents as bare names (`**planner**`, `**code-reviewer**`, `**tdd-guide**`, …). ECC agents are *plugin* agents, so only `ecc:<name>` resolves. Prefixed across `rules/` and mirrored into `.cursor/rules/`. **`.kiro/steering/` is deliberately untouched** — Kiro resolves agents from `.kiro/agents/*.json` by bare name, so the prefix does not apply there.

Includes `rules/angular/security.md`, which had the same bare `**security-reviewer**` reference.

**2. `rules/common/agents.md` rewritten.**
- New `## Agent Names Are Namespaced (CRITICAL)` section stating the rule up front.
- The stale 11-row "Available Agents" table is replaced by the full catalog — **68 agents**, grouped as Core (14), Language & Framework Reviewers (19), Build Error Resolvers (11), Specialists (24) — so contributors can pick a reviewer by language and a resolver by failing toolchain.
- Documents the one real exception: agents under `~/.claude/agents/` are *user* agents and resolve **without** the prefix, including when filed in an `ecc/` subfolder (the folder is organization, not a namespace). This was the bit most likely to bite people, since it looks like it should be namespaced.
- New `## If An Agent Type Fails To Resolve` fallback: retry with `ecc:`, check `/agents`, then report — never silently absorb the work inline.
- `Delegation Completion Contract` and `Multi-Perspective Analysis` are preserved verbatim (rebased onto `main`, so the contract section is upstream's current wording, not mine).


## Why This Change

`common/agents.md` also stated that agent definitions are "Located in `~/.claude/agents/`". That is the *user* agent directory; ECC's definitions install to `~/.claude/plugins/marketplaces/ecc/agents/`. So the file pointed at the wrong directory **and** listed names in the non-resolving form — anyone following it verbatim got a resolution failure with no hint as to why.

The stale table listed 11 of 68 agents, so most of the fleet was undiscoverable from the rules.

## Testing Done
- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`) — **4156 passed, 0 failed**, exit 0
- [x] Edge cases considered and tested

Verification performed:
- Every documented name cross-checked against `agents/*.md`: **68 documented / 68 defined**, diff empty in both directions — no ghost agents, no undocumented ones.
- Post-change sweep for bare agent names across `rules/`, `.cursor/rules/`, `.kiro/steering/`: **zero remaining**.
- `.cursor/rules/common-agents.md` body verified **byte-identical** to canonical `rules/common/agents.md` (frontmatter preserved), so the always-applied Cursor rule cannot carry a weaker contract than the canonical one.
- `.kiro/steering/` verified to contain zero `ecc:` occurrences.

## Rebase Note

Originally cut from `81af407`; rebased onto current `main`. Two things changed as a result, both in your favour:

- The `git-workflow.md` attribution note I had corrected was fixed upstream in the meantime, and your wording is the accurate one (ECC-managed installs *do* set `includeCoAuthoredBy: false`). I dropped my version entirely and kept yours.
- `rag-pipeline-reviewer` landed after my branch point, so the catalog now documents **68**, not 67. Re-verified against `agents/*.md` post-rebase.

## Review Fixes

Thanks — the automated review caught three real defects, all fixed in the amended commit:

1. **Kiro namespacing was wrong.** I had applied the `ecc:` prefix to `.kiro/steering/` by reflex. Kiro resolves its own agents from `.kiro/agents/*.json` by bare name, so `ecc:security-reviewer` was unresolvable there. All `.kiro/steering/` files are reverted to `main` — that host was already correct.
2. **Cursor mirror carried a weaker delegation contract.** After the rebase the canonical rule picked up `main`'s stronger all-depth / no-re-delegation contract, but the mirror kept my older wording. The mirror body is now regenerated from canonical and verified byte-identical, so it cannot drift again.
3. **Stale `67` in prose.** The tables said 68, the sentence said 67. Both now say 68, re-verified against `agents/*.md`.

## Type of Change
- [x] `docs:` Documentation

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly *(no JSON touched)*
- [x] Shell scripts pass shellcheck (if applicable) *(no shell touched)*
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation
- [x] Added comments for complex logic *(n/a — docs-only)*
- [x] README updated (if needed) *(not needed)*

## Note for maintainers

Scope is deliberately English-only. The translated rule sets under `docs/{ja-JP,zh-CN,zh-TW,ko-KR,es,tr,ru,de-DE,pt-BR}/rules/` carry the same bare names and the same `~/.claude/agents/` claim, and their `agents.md` still has the 11-row table. I did not touch them rather than machine-translate the new sections badly. Happy to follow up if you tell me whether translations are hand-maintained or regenerated.

Same question for `.cursor/rules/` and `.kiro/steering/`: I edited them directly to keep the tree consistent, but if they are generated from `rules/`, drop those hunks and run the generator instead.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHkovCtGTeWQSFrEQSkatT
