### PR TITLE
fix(llm): serialize OpenAI tool call messages

### DIFF
--- a/src/llm/core/types.py
+++ b/src/llm/core/types.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -41,22 +40,6 @@ class Message:
         if self.tool_calls:
             result["tool_calls"] = [
                 {"id": tc.id, "function": {"name": tc.name, "arguments": tc.arguments}}
-                for tc in self.tool_calls
-            ]
-        return result
-
-    def to_openai_dict(self) -> dict[str, Any]:
-        result = self.to_dict()
-        if self.tool_calls:
-            result["tool_calls"] = [
-                {
-                    "id": tc.id,
-                    "type": "function",
-                    "function": {
-                        "name": tc.name,
-                        "arguments": json.dumps(tc.arguments),
-                    },
-                }
                 for tc in self.tool_calls
             ]
         return result

--- a/src/llm/core/types.py
+++ b/src/llm/core/types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
@@ -40,6 +41,22 @@ class Message:
         if self.tool_calls:
             result["tool_calls"] = [
                 {"id": tc.id, "function": {"name": tc.name, "arguments": tc.arguments}}
+                for tc in self.tool_calls
+            ]
+        return result
+
+    def to_openai_dict(self) -> dict[str, Any]:
+        result = self.to_dict()
+        if self.tool_calls:
+            result["tool_calls"] = [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {
+                        "name": tc.name,
+                        "arguments": json.dumps(tc.arguments),
+                    },
+                }
                 for tc in self.tool_calls
             ]
         return result

--- a/src/llm/providers/astraflow.py
+++ b/src/llm/providers/astraflow.py
@@ -70,7 +70,7 @@ class _AstraflowBaseProvider(LLMProvider):
         try:
             params: dict[str, Any] = {
                 "model": llm_input.model or self.default_model,
-                "messages": [msg.to_dict() for msg in llm_input.messages],
+                "messages": [msg.to_openai_dict() for msg in llm_input.messages],
             }
             if llm_input.temperature != 1.0:
                 params["temperature"] = llm_input.temperature

--- a/src/llm/providers/astraflow.py
+++ b/src/llm/providers/astraflow.py
@@ -16,6 +16,7 @@ from llm.core.interface import (
 )
 from llm.core.types import LLMInput, LLMOutput, ModelInfo, ProviderType, ToolCall
 from llm.providers.constants import EMPTY_FILTERED_RESPONSE_ERROR
+from llm.providers.openai_compat import to_openai_message_param
 
 ASTRAFLOW_BASE_URL = "https://api.umodelverse.ai/v1"
 ASTRAFLOW_CN_BASE_URL = "https://api.modelverse.cn/v1"
@@ -70,7 +71,7 @@ class _AstraflowBaseProvider(LLMProvider):
         try:
             params: dict[str, Any] = {
                 "model": llm_input.model or self.default_model,
-                "messages": [msg.to_openai_dict() for msg in llm_input.messages],
+                "messages": [to_openai_message_param(msg) for msg in llm_input.messages],
             }
             if llm_input.temperature != 1.0:
                 params["temperature"] = llm_input.temperature

--- a/src/llm/providers/atlas.py
+++ b/src/llm/providers/atlas.py
@@ -16,6 +16,7 @@ from llm.core.interface import (
 )
 from llm.core.types import LLMInput, LLMOutput, ModelInfo, ProviderType, ToolCall
 from llm.providers.constants import EMPTY_FILTERED_RESPONSE_ERROR
+from llm.providers.openai_compat import to_openai_message_param
 
 ATLAS_BASE_URL = "https://api.atlascloud.ai/v1"
 DEFAULT_ATLAS_MODEL = "deepseek-ai/deepseek-v4-pro"
@@ -83,7 +84,7 @@ class AtlasProvider(LLMProvider):
         try:
             params: dict[str, Any] = {
                 "model": llm_input.model or self.default_model,
-                "messages": [msg.to_openai_dict() for msg in llm_input.messages],
+                "messages": [to_openai_message_param(msg) for msg in llm_input.messages],
             }
             if llm_input.temperature != 1.0:
                 params["temperature"] = llm_input.temperature

--- a/src/llm/providers/atlas.py
+++ b/src/llm/providers/atlas.py
@@ -83,7 +83,7 @@ class AtlasProvider(LLMProvider):
         try:
             params: dict[str, Any] = {
                 "model": llm_input.model or self.default_model,
-                "messages": [msg.to_dict() for msg in llm_input.messages],
+                "messages": [msg.to_openai_dict() for msg in llm_input.messages],
             }
             if llm_input.temperature != 1.0:
                 params["temperature"] = llm_input.temperature

--- a/src/llm/providers/openai.py
+++ b/src/llm/providers/openai.py
@@ -72,7 +72,7 @@ class OpenAIProvider(LLMProvider):
         try:
             params: dict[str, Any] = {
                 "model": input.model or "gpt-4o-mini",
-                "messages": [msg.to_dict() for msg in input.messages],
+                "messages": [msg.to_openai_dict() for msg in input.messages],
                 "temperature": input.temperature,
             }
             if input.max_tokens:

--- a/src/llm/providers/openai.py
+++ b/src/llm/providers/openai.py
@@ -22,6 +22,7 @@ from llm.core.types import (
     ToolCall,
 )
 from llm.providers.constants import EMPTY_FILTERED_RESPONSE_ERROR
+from llm.providers.openai_compat import to_openai_message_param
 
 
 class OpenAIProvider(LLMProvider):
@@ -72,7 +73,7 @@ class OpenAIProvider(LLMProvider):
         try:
             params: dict[str, Any] = {
                 "model": input.model or "gpt-4o-mini",
-                "messages": [msg.to_openai_dict() for msg in input.messages],
+                "messages": [to_openai_message_param(msg) for msg in input.messages],
                 "temperature": input.temperature,
             }
             if input.max_tokens:

--- a/src/llm/providers/openai_compat.py
+++ b/src/llm/providers/openai_compat.py
@@ -1,0 +1,79 @@
+"""Message adapters shared by OpenAI-compatible providers."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from llm.core.types import Message, Role, ToolCall
+
+if TYPE_CHECKING:
+    from openai.types.chat import (
+        ChatCompletionAssistantMessageParam,
+        ChatCompletionMessageParam,
+        ChatCompletionMessageToolCallParam,
+        ChatCompletionSystemMessageParam,
+        ChatCompletionToolMessageParam,
+        ChatCompletionUserMessageParam,
+    )
+
+
+def _to_openai_tool_call_param(
+    tool_call: ToolCall,
+) -> ChatCompletionMessageToolCallParam:
+    """Convert a domain tool call to the OpenAI request schema."""
+    return {
+        "id": tool_call.id,
+        "type": "function",
+        "function": {
+            "name": tool_call.name,
+            "arguments": json.dumps(tool_call.arguments),
+        },
+    }
+
+
+def to_openai_message_param(message: Message) -> ChatCompletionMessageParam:
+    """Convert a domain message to the OpenAI chat-completions schema."""
+    if message.role == Role.SYSTEM:
+        system_message: ChatCompletionSystemMessageParam = {
+            "role": "system",
+            "content": message.content,
+        }
+        if message.name:
+            system_message["name"] = message.name
+        return system_message
+
+    if message.role == Role.USER:
+        user_message: ChatCompletionUserMessageParam = {
+            "role": "user",
+            "content": message.content,
+        }
+        if message.name:
+            user_message["name"] = message.name
+        return user_message
+
+    if message.role == Role.ASSISTANT:
+        assistant_message: ChatCompletionAssistantMessageParam = {
+            "role": "assistant",
+            "content": message.content,
+        }
+        if message.name:
+            assistant_message["name"] = message.name
+        if message.tool_calls:
+            assistant_message["tool_calls"] = [
+                _to_openai_tool_call_param(tool_call)
+                for tool_call in message.tool_calls
+            ]
+        return assistant_message
+
+    if message.role == Role.TOOL:
+        if not message.tool_call_id:
+            raise ValueError("OpenAI tool messages require a tool_call_id")
+        tool_message: ChatCompletionToolMessageParam = {
+            "role": "tool",
+            "content": message.content,
+            "tool_call_id": message.tool_call_id,
+        }
+        return tool_message
+
+    raise ValueError(f"Unsupported OpenAI message role: {message.role}")

--- a/src/llm/providers/openai_compat.py
+++ b/src/llm/providers/openai_compat.py
@@ -22,12 +22,17 @@ def _to_openai_tool_call_param(
     tool_call: ToolCall,
 ) -> ChatCompletionMessageToolCallParam:
     """Convert a domain tool call to the OpenAI request schema."""
+    try:
+        arguments = json.dumps(tool_call.arguments, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("OpenAI tool call arguments must be valid JSON") from exc
+
     return {
         "id": tool_call.id,
         "type": "function",
         "function": {
             "name": tool_call.name,
-            "arguments": json.dumps(tool_call.arguments),
+            "arguments": arguments,
         },
     }
 

--- a/tests/test_provider_tools.py
+++ b/tests/test_provider_tools.py
@@ -2,7 +2,9 @@ from types import SimpleNamespace
 
 import pytest
 
-from llm.core.types import LLMInput, Message, Role, ToolDefinition
+from llm.core.types import LLMInput, Message, Role, ToolCall, ToolDefinition
+from llm.providers.astraflow import AstraflowProvider
+from llm.providers.atlas import AtlasProvider
 from llm.providers.claude import ClaudeProvider
 from llm.providers.constants import EMPTY_FILTERED_RESPONSE_ERROR
 from llm.providers.openai import OpenAIProvider
@@ -82,6 +84,55 @@ def test_openai_provider_serializes_tools_for_chat_completions():
             },
         }
     ]
+
+
+@pytest.mark.parametrize(
+    "provider_type",
+    [OpenAIProvider, AstraflowProvider, AtlasProvider],
+)
+def test_openai_compatible_provider_serializes_assistant_tool_calls(provider_type):
+    provider = provider_type(api_key="test")
+    client = _OpenAIClient()
+    provider.client = client
+
+    provider.generate(
+        LLMInput(
+            messages=[
+                Message(role=Role.USER, content="Find ECC"),
+                Message(
+                    role=Role.ASSISTANT,
+                    content="",
+                    tool_calls=[
+                        ToolCall(
+                            id="call_1",
+                            name="search",
+                            arguments={"query": "ecc"},
+                        )
+                    ],
+                ),
+                Message(
+                    role=Role.TOOL,
+                    content="result",
+                    tool_call_id="call_1",
+                ),
+            ]
+        )
+    )
+
+    assert client.completions.params["messages"][1] == {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "arguments": '{"query": "ecc"}',
+                },
+            }
+        ],
+    }
 
 
 def test_openai_provider_can_be_constructed_without_credentials(monkeypatch):

--- a/tests/test_provider_tools.py
+++ b/tests/test_provider_tools.py
@@ -145,12 +145,36 @@ def test_openai_compatible_provider_serializes_assistant_tool_calls(
         {"role": "tool", "content": "result", "tool_call_id": "call_1"},
     ]
 
-    client.completions.params = None
+    submitted_params = client.completions.params
     with pytest.raises(ValueError, match="tool messages require a tool_call_id"):
         provider.generate(
             LLMInput(messages=[Message(role=Role.TOOL, content="unlinked result")])
         )
-    assert client.completions.params is None
+    assert client.completions.params is submitted_params
+
+    for invalid_arguments in ({"score": float("nan")}, {"value": object()}):
+        with pytest.raises(
+            ValueError,
+            match="tool call arguments must be valid JSON",
+        ):
+            provider.generate(
+                LLMInput(
+                    messages=[
+                        Message(
+                            role=Role.ASSISTANT,
+                            content="",
+                            tool_calls=[
+                                ToolCall(
+                                    id="call_invalid",
+                                    name="score",
+                                    arguments=invalid_arguments,
+                                )
+                            ],
+                        )
+                    ]
+                )
+            )
+        assert client.completions.params is submitted_params
 
 
 def test_openai_provider_can_be_constructed_without_credentials(monkeypatch):

--- a/tests/test_provider_tools.py
+++ b/tests/test_provider_tools.py
@@ -1,7 +1,10 @@
+from collections.abc import Callable
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
+from llm.core.interface import LLMProvider
 from llm.core.types import LLMInput, Message, Role, ToolCall, ToolDefinition
 from llm.providers.astraflow import AstraflowProvider
 from llm.providers.atlas import AtlasProvider
@@ -86,12 +89,15 @@ def test_openai_provider_serializes_tools_for_chat_completions():
     ]
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "provider_type",
     [OpenAIProvider, AstraflowProvider, AtlasProvider],
 )
-def test_openai_compatible_provider_serializes_assistant_tool_calls(provider_type):
-    provider = provider_type(api_key="test")
+def test_openai_compatible_provider_serializes_assistant_tool_calls(
+    provider_type: Callable[..., LLMProvider],
+) -> None:
+    provider = cast(Any, provider_type(api_key="test"))
     client = _OpenAIClient()
     provider.client = client
 
@@ -119,20 +125,32 @@ def test_openai_compatible_provider_serializes_assistant_tool_calls(provider_typ
         )
     )
 
-    assert client.completions.params["messages"][1] == {
-        "role": "assistant",
-        "content": "",
-        "tool_calls": [
-            {
-                "id": "call_1",
-                "type": "function",
-                "function": {
-                    "name": "search",
-                    "arguments": '{"query": "ecc"}',
+    assert client.completions.params is not None
+    assert client.completions.params["messages"] == [
+        {"role": "user", "content": "Find ECC"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "search",
+                        "arguments": '{"query": "ecc"}',
+                    },
                 },
-            }
-        ],
-    }
+            ],
+        },
+        {"role": "tool", "content": "result", "tool_call_id": "call_1"},
+    ]
+
+    client.completions.params = None
+    with pytest.raises(ValueError, match="tool messages require a tool_call_id"):
+        provider.generate(
+            LLMInput(messages=[Message(role=Role.TOOL, content="unlinked result")])
+        )
+    assert client.completions.params is None
 
 
 def test_openai_provider_can_be_constructed_without_credentials(monkeypatch):


### PR DESCRIPTION
## What Changed
<!-- Describe the specific changes made in this PR -->

- Add a typed provider-layer OpenAI message adapter that emits assistant tool
  calls with `type: "function"` and JSON-string `function.arguments`.
- Use that serializer for OpenAI, Astraflow (including AstraflowCN), and Atlas
  requests while keeping the provider-neutral, Claude, and Ollama formats unchanged.
- Reject non-standard or non-serializable function arguments before they reach the
  client, with a stable provider-boundary error.
- Reject tool-result messages without a `tool_call_id` before making a request.
- Add a provider-boundary regression test covering the exact payload, strict JSON
  failures, and no-client-call behavior for all three implementations.

## Why This Change
<!-- Explain the motivation and context for this change -->

After a model requested a tool, the ReAct loop replayed the assistant tool-call
history through `Message.to_dict()`. That representation omitted the required
tool-call `type` and kept `function.arguments` as an object instead of the JSON
string expected by the OpenAI Chat Completions wire format. A follow-up request
could therefore be rejected before the tool loop completed.

The generic serializer is intentionally unchanged because other providers use a
different message shape. An older MiniMax-specific implementation in #2510 uses
the same wire-format concepts, but it does not cover these existing providers or
the shared message boundary.

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [ ] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [x] Edge cases considered and tested

- Regression before the production change: `python -m pytest tests/test_provider_tools.py -q` — 3 expected failures, one for each provider.
- Regression after the fix: the same command — 8 passed.
- Post-review regression — 8 passed, including NaN and non-serializable arguments.
- Affected Python suite — 37 passed.
- Python project suite (`tests/test_*.py`, excluding integration) — 88 passed.
- Ruff and mypy — passed.
- Node 20.19.0 `npm test` — 4,159 passed, 0 failed.
- Node 20.19.0 `npm run coverage` — 4,159 passed; 89.04% statements/lines, 94.39% functions, 80.87% branches.
- Node 20.19.0 `npm run lint` — passed.

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (if applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

No shell files changed, and the repository does not configure a pre-commit hook
for this Python path.

## If you changed dependencies or `package.json` (`bin` / `files` / deps)
- [ ] Ran `yarn install --mode=update-lockfile` and committed the `yarn.lock` change. CI runs Yarn in hardened mode on public PRs and fails if the lockfile would be modified, so an out of date `yarn.lock` breaks the build even when nothing else is wrong.

Not applicable: no dependency, package manifest, or lockfile changed.

## If you added a skill, command, agent, hook, or CLI tool
- [ ] Registered in `package.json` (`bin` and `files`), `manifests/install-components.json`, `manifests/install-modules.json`, and `agent.yaml`
- [ ] Regenerated the catalog (`npm run catalog:sync`) and command registry (`npm run command-registry:write`)
- [ ] Updated the docs tables it belongs in (`README.md`, `COMMANDS-QUICK-REF.md`, `docs/COMMAND-AGENT-MAP.md`)
- [ ] If it ships a new script path, added it to the publish surface allowlist (`tests/scripts/npm-publish-surface.test.js`)
- [ ] Cross-harness surfaces updated if applicable (for Codex, `.agents/skills/<name>/` plus `agents/openai.yaml`; the Codex frontmatter validator allows only `name`, `description`, `metadata`, `license`, `allowed-tools`, so drop keys like `version` from that copy)
- [ ] Full gauntlet passes locally (`npm test`)

Not applicable: this change adds no skill, command, agent, hook, or CLI surface.

## Documentation
- [ ] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)

Not required: this is an internal wire-format correction covered by a regression
test and does not change the documented user interface.

## Scope

5 files changed, +184 / -4 lines. No generated, dependency, or lock files changed.
