### PR TITLE
fix(hooks): support Cursor ApplyPatch payloads

### DIFF
--- a/scripts/hooks/run-with-flags.js
+++ b/scripts/hooks/run-with-flags.js
@@ -150,9 +150,42 @@ function buildDryRunPreview(hookId, relScriptPath, profilesCsv, raw) {
   return parts.join(' ') + '\n';
 }
 
+function parseApplyPatchPayload(value) {
+  if (typeof value !== 'string') return null;
+
+  const lines = value.replace(/\r\n/g, '\n').split('\n');
+  if (lines.at(-1) === '') lines.pop();
+  if (lines[0] !== '*** Begin Patch' || lines.at(-1) !== '*** End Patch') {
+    return null;
+  }
+
+  const operation = lines[1]?.match(/^\*\*\* (Add|Update) File: (.+)$/);
+  if (!operation || operation[2].includes('\0') || lines.slice(2, -1).some(line => /^\*\*\* (?:Begin Patch|End Patch|(?:Add|Update) File: )/.test(line))) {
+    return null;
+  }
+
+  return {
+    toolName: operation[1] === 'Add' ? 'Write' : 'Edit',
+    filePath: operation[2]
+  };
+}
+
+function buildApplyPatchHookInput(raw, patch) {
+  return JSON.stringify({
+    tool: patch.toolName,
+    tool_name: patch.toolName,
+    tool_input: {
+      file_path: patch.filePath,
+      content: raw
+    }
+  });
+}
+
 async function main() {
   const [, , hookId, relScriptPath, profilesCsv] = process.argv;
   const { raw, truncated } = await readStdinRaw();
+  const applyPatch = parseApplyPatchPayload(raw);
+  const hookInput = applyPatch ? buildApplyPatchHookInput(raw, applyPatch) : raw;
 
   // Oversized payloads: never echo the truncated string — a JSON document
   // cut mid-stream is treated by the harness as a hook failure, blocking the
@@ -160,25 +193,30 @@ async function main() {
   // pass-through paths fail open. The hook itself still runs and receives
   // the truncated flag (run() context / ECC_HOOK_INPUT_TRUNCATED), so
   // security hooks like config-protection can still choose to block.
-  const sanitizeEcho = text => (truncated && text === raw ? '' : text);
+  //
+  // Cursor's ApplyPatch tool provides its patch envelope as free-form stdin.
+  // Policy hooks still need the target path, so valid single-file envelopes
+  // are presented as the existing Write/Edit JSON shape. Suppress only the
+  // synthetic no-op response; denials and additional context pass through.
+  const sanitizeEcho = text => ((truncated && text === hookInput) || (applyPatch !== null && (text === hookInput || text === raw)) ? '' : text);
   if (truncated) {
     process.stderr.write(`[Hook] stdin exceeded ${MAX_STDIN} bytes for ${hookId || 'unknown'}; suppressing pass-through (fail-open unless the hook blocks)\n`);
   }
 
   if (!hookId || !relScriptPath) {
-    exitWithStdout(sanitizeEcho(raw), 0);
+    exitWithStdout(sanitizeEcho(hookInput), 0);
     return;
   }
 
   if (!isHookEnabled(hookId, { profiles: profilesCsv })) {
-    exitWithStdout(sanitizeEcho(raw), 0);
+    exitWithStdout(sanitizeEcho(hookInput), 0);
     return;
   }
 
   if (isDryRun()) {
-    const preview = buildDryRunPreview(hookId, relScriptPath, profilesCsv, raw);
+    const preview = buildDryRunPreview(hookId, relScriptPath, profilesCsv, hookInput);
     process.stderr.write(preview);
-    exitWithStdout(sanitizeEcho(raw), 0);
+    exitWithStdout(sanitizeEcho(hookInput), 0);
     return;
   }
 
@@ -189,13 +227,13 @@ async function main() {
   // Prevent path traversal outside the plugin root
   if (!scriptPath.startsWith(resolvedRoot + path.sep)) {
     process.stderr.write(`[Hook] Path traversal rejected for ${hookId}: ${scriptPath}\n`);
-    exitWithStdout(sanitizeEcho(raw), 0);
+    exitWithStdout(sanitizeEcho(hookInput), 0);
     return;
   }
 
   if (!fs.existsSync(scriptPath)) {
     process.stderr.write(`[Hook] Script not found for ${hookId}: ${scriptPath}\n`);
-    exitWithStdout(sanitizeEcho(raw), 0);
+    exitWithStdout(sanitizeEcho(hookInput), 0);
     return;
   }
 
@@ -224,25 +262,25 @@ async function main() {
       // hands back a pending Promise, which resolveHookResult reads as "no
       // opinion" and silently degrades to pass-through. Synchronous hooks are
       // unaffected: awaiting a plain value just costs a microtask.
-      const output = await hookModule.run(raw, {
+      const output = await hookModule.run(hookInput, {
         hookId,
         pluginRoot,
         scriptPath,
         truncated,
         maxStdin: MAX_STDIN
       });
-      const result = resolveHookResult(raw, output);
+      const result = resolveHookResult(hookInput, output);
       exitWithStdout(sanitizeEcho(result.stdout), result.exitCode);
     } catch (runErr) {
       process.stderr.write(`[Hook] run() error for ${hookId}: ${runErr.message}\n`);
-      exitWithStdout(sanitizeEcho(raw), 0);
+      exitWithStdout(sanitizeEcho(hookInput), 0);
     }
     return;
   }
 
   // Legacy path: spawn a child Node process for hooks without run() export
   const result = spawnSync(process.execPath, [scriptPath], {
-    input: raw,
+    input: hookInput,
     encoding: 'utf8',
     env: {
       ...process.env,
@@ -256,7 +294,7 @@ async function main() {
     timeout: 30000
   });
 
-  const legacyStdout = sanitizeEcho(resolveLegacySpawnStdout(raw, result));
+  const legacyStdout = sanitizeEcho(resolveLegacySpawnStdout(hookInput, result));
   if (result.stderr) process.stderr.write(result.stderr);
 
   if (result.error || result.signal || result.status === null) {

--- a/tests/hooks/run-with-flags.test.js
+++ b/tests/hooks/run-with-flags.test.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const wrapper = path.join(repoRoot, 'scripts', 'hooks', 'run-with-flags.js');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+function runWrapper(input, overrides = {}) {
+  const result = spawnSync(process.execPath, [wrapper, overrides.hookId || 'pre:write:doc-file-warning', overrides.script || 'scripts/hooks/doc-file-warning.js', 'standard,strict'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    input,
+    env: {
+      ...process.env,
+      CLAUDE_PLUGIN_ROOT: repoRoot,
+      ECC_HOOK_PROFILE: 'standard',
+      ECC_ENABLE_INSAITS: '',
+      ECC_DRY_RUN: '0',
+      ECC_HOOKS_ENABLED: '1',
+      ECC_DISABLED_HOOKS: overrides.disabled ? overrides.hookId : ''
+    },
+    timeout: 10000
+  });
+
+  return {
+    code: result.status,
+    stdout: result.stdout || '',
+    stderr: result.stderr || ''
+  };
+}
+
+function runTests() {
+  console.log('\n=== Testing run-with-flags.js ===\n');
+  let passed = 0;
+  let failed = 0;
+
+  test('suppresses ApplyPatch pass-through from an enabled no-op hook', () => {
+    const patch = '*** Begin Patch\n*** Update File: /tmp/example.md\n*** End Patch\n';
+    const result = runWrapper(patch);
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout, '');
+  })
+    ? passed++
+    : failed++;
+
+  test('suppresses ApplyPatch pass-through when the hook is disabled', () => {
+    const patch = '*** Begin Patch\n*** Update File: /tmp/example.md\n*** End Patch\n';
+    const hookId = 'pre:write:doc-file-warning';
+    const result = runWrapper(patch, { hookId, disabled: true });
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout, '');
+  })
+    ? passed++
+    : failed++;
+
+  test('passes a structured ApplyPatch target to blocking hooks', () => {
+    const protectedPath = path.join(repoRoot, 'eslint.config.js');
+    const patch = ['*** Begin Patch', `*** Update File: ${protectedPath}`, '@@', '-old', '+new', '*** End Patch', ''].join('\n');
+    const result = runWrapper(patch, {
+      hookId: 'pre:config-protection',
+      script: 'scripts/hooks/config-protection.js'
+    });
+    assert.strictEqual(result.code, 2);
+    assert.strictEqual(result.stdout, '');
+    assert.match(result.stderr, /BLOCKED: Modifying eslint\.config\.js/);
+  })
+    ? passed++
+    : failed++;
+
+  test('preserves marker-shaped text without one valid file operation', () => {
+    const input = '*** Begin Patch\nnot a file operation\n*** End Patch\n';
+    const result = runWrapper(input);
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout, input);
+  })
+    ? passed++
+    : failed++;
+
+  test('preserves malformed envelopes with nested patch markers', () => {
+    const input = ['*** Begin Patch', '*** Update File: /tmp/example.md', '*** Begin Patch', '@@', '-old', '+new', '*** End Patch', ''].join('\n');
+    const result = runWrapper(input);
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout, input);
+  })
+    ? passed++
+    : failed++;
+
+  test('recognizes a complete CRLF ApplyPatch envelope', () => {
+    const input = ['*** Begin Patch', '*** Update File: C:\\tmp\\example.md', '@@', '-old', '+new', '*** End Patch', ''].join('\r\n');
+    const result = runWrapper(input);
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout, '');
+  })
+    ? passed++
+    : failed++;
+
+  test('preserves JSON hook input for existing Claude Code integrations', () => {
+    const input = JSON.stringify({
+      tool_name: 'Write',
+      tool_input: { file_path: 'README.md' }
+    });
+    const result = runWrapper(input);
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout, input);
+  })
+    ? passed++
+    : failed++;
+
+  test('preserves unrelated malformed input for existing hooks', () => {
+    const input = '{"tool_name":"Write"';
+    const result = runWrapper(input);
+    assert.strictEqual(result.code, 0);
+    assert.strictEqual(result.stdout, input);
+  })
+    ? passed++
+    : failed++;
+
+  test('preserves genuine JSON hook decisions', () => {
+    const input = JSON.stringify({
+      tool_name: 'Write',
+      tool_input: { file_path: 'TODO.md' }
+    });
+    const result = runWrapper(input);
+    const output = JSON.parse(result.stdout);
+    assert.strictEqual(result.code, 0);
+    assert.match(output.hookSpecificOutput.additionalContext, /Ad-hoc documentation filename detected/);
+  })
+    ? passed++
+    : failed++;
+
+  console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+runTests();


### PR DESCRIPTION
## Summary

- recognize Cursor's single-file `ApplyPatch` envelope at the hook wrapper boundary
- translate it to the existing Write/Edit JSON shape so warning and blocking policies receive the target path and patch content
- suppress only the synthetic no-op echo that Cursor otherwise rejects as invalid hook JSON
- preserve Claude Code JSON pass-through, malformed-input compatibility, hook denials, and additional context

## Type

- [x] Hook

## Testing

- `node tests/hooks/run-with-flags.test.js` — 9 passed
- `node tests/hooks/config-protection.test.js` — 9 passed
- `node tests/hooks/gateguard-fact-force.test.js` — 174 passed
- `npm test` — 4,168 passed, 0 failed
- manually reproduced the original two-hook Cursor failure against the active 1.8.0 cache, then verified empty no-op stdout and target-path visibility after the fix

## Checklist

- [x] Follows existing hook wrapper patterns
- [x] Tested with Claude Code-compatible JSON and Cursor ApplyPatch input
- [x] Blocking policies remain effective for protected targets
- [x] No sensitive information included
