### PR TITLE
fix(uninstall): honor global dry-run

### DIFF
--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -23,11 +23,15 @@ explicitly, including marker-only AGENTS.md cleanup.
   process.exit(exitCode);
 }
 
-function parseArgs(argv) {
+function parseArgs(argv, env = process.env) {
   const args = argv.slice(2);
+  const dryRunEnv = env.ECC_DRY_RUN;
+  if (dryRunEnv !== undefined && dryRunEnv !== '0' && dryRunEnv !== '1') {
+    throw new Error('ECC_DRY_RUN must be "1" or "0" when set');
+  }
   const parsed = {
     targets: [],
-    dryRun: false,
+    dryRun: dryRunEnv === '1',
     json: false,
     legacyCodexSync: false,
     help: false,

--- a/tests/scripts/ecc.test.js
+++ b/tests/scripts/ecc.test.js
@@ -3,10 +3,12 @@
  */
 
 const assert = require('assert');
+const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
+const { createInstallState, writeInstallState } = require('../../scripts/lib/install-state');
 
 const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'ecc.js');
 
@@ -14,23 +16,21 @@ function runCli(args, options = {}) {
   const envOverrides = {
     ...(options.env || {}),
   };
-
-  if (typeof envOverrides.HOME === 'string' && !('USERPROFILE' in envOverrides)) {
-    envOverrides.USERPROFILE = envOverrides.HOME;
-  }
-
-  if (typeof envOverrides.USERPROFILE === 'string' && !('HOME' in envOverrides)) {
-    envOverrides.HOME = envOverrides.USERPROFILE;
-  }
+  const inheritedEnv = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => key !== 'ECC_DRY_RUN')
+  );
+  const homeAlias = typeof envOverrides.HOME === 'string' && !('USERPROFILE' in envOverrides)
+    ? { USERPROFILE: envOverrides.HOME }
+    : typeof envOverrides.USERPROFILE === 'string' && !('HOME' in envOverrides)
+      ? { HOME: envOverrides.USERPROFILE }
+      : {};
+  const env = { ...inheritedEnv, ...envOverrides, ...homeAlias };
 
   return spawnSync('node', [SCRIPT, ...args], {
     encoding: 'utf8',
     cwd: options.cwd || process.cwd(),
     maxBuffer: 10 * 1024 * 1024,
-    env: {
-      ...process.env,
-      ...envOverrides,
-    },
+    env,
   });
 }
 
@@ -152,6 +152,79 @@ function main() {
       assert.strictEqual(result.status, 0, result.stderr);
       const payload = parseJson(result.stdout);
       assert.deepStrictEqual(payload.records, []);
+    }],
+    ['keeps uninstall read-only when global --dry-run precedes the command', () => {
+      const homeDir = createTempDir('ecc-cli-uninstall-home-');
+      const projectRoot = createTempDir('ecc-cli-uninstall-project-');
+
+      try {
+        const targetRoot = path.join(projectRoot, '.cursor');
+        const statePath = path.join(targetRoot, 'ecc-install-state.json');
+        const managedPath = path.join(targetRoot, 'managed-rule.md');
+        const managedContent = 'managed\n';
+        fs.mkdirSync(targetRoot, { recursive: true });
+        fs.writeFileSync(managedPath, managedContent);
+        writeInstallState(statePath, createInstallState({
+          adapter: { id: 'cursor-project', target: 'cursor', kind: 'project' },
+          targetRoot,
+          installStatePath: statePath,
+          request: {
+            profile: null,
+            modules: [],
+            includeComponents: [],
+            excludeComponents: [],
+            legacyLanguages: ['typescript'],
+            legacyMode: true,
+          },
+          resolution: {
+            selectedModules: ['legacy-cursor-install'],
+            skippedModules: [],
+          },
+          source: {
+            repoVersion: null,
+            repoCommit: null,
+            manifestVersion: 1,
+          },
+          operations: [{
+            kind: 'copy-file',
+            moduleId: 'rules-core',
+            sourceRelativePath: 'rules/common/coding-style.md',
+            destinationPath: managedPath,
+            strategy: 'preserve-relative-path',
+            ownership: 'managed',
+            scaffoldOnly: false,
+            contentSha256: crypto.createHash('sha256').update(managedContent).digest('hex'),
+          }],
+        }));
+
+        const jsonResult = runCli(['--dry-run', 'uninstall', '--target', 'cursor', '--json'], {
+          cwd: projectRoot,
+          env: { HOME: homeDir },
+        });
+
+        assert.strictEqual(jsonResult.status, 0, jsonResult.stderr);
+        const preview = parseJson(jsonResult.stdout);
+        assert.strictEqual(preview.dryRun, true);
+        assert.strictEqual(preview.results[0].status, 'planned');
+        assert.deepStrictEqual(
+          preview.results[0].plannedRemovals.map(candidate => fs.realpathSync(candidate)).sort(),
+          [managedPath, statePath].map(candidate => fs.realpathSync(candidate)).sort()
+        );
+
+        const humanResult = runCli(['--dry-run', 'uninstall', '--target', 'cursor'], {
+          cwd: projectRoot,
+          env: { HOME: homeDir },
+        });
+        assert.strictEqual(humanResult.status, 0, humanResult.stderr);
+        assert.match(humanResult.stdout, /Status: PLANNED/);
+        assert.match(humanResult.stdout, /Planned removals: 2/);
+        assert.doesNotMatch(humanResult.stdout, /Status: UNINSTALLED|Removed paths:/);
+        assert.ok(fs.existsSync(managedPath), 'global dry-run must preserve managed files');
+        assert.ok(fs.existsSync(statePath), 'global dry-run must preserve install-state');
+      } finally {
+        fs.rmSync(homeDir, { force: true, recursive: true });
+        fs.rmSync(projectRoot, { force: true, recursive: true });
+      }
     }],
     ['delegates auto-update command', () => {
       const homeDir = createTempDir('ecc-cli-home-');

--- a/tests/scripts/uninstall.test.js
+++ b/tests/scripts/uninstall.test.js
@@ -47,9 +47,16 @@ function writeState(filePath, options) {
 }
 
 function run(args = [], options = {}) {
-  const env = options.homeDir
-    ? { ...process.env, HOME: options.homeDir, CODEX_HOME: path.join(options.homeDir, '.codex') }
-    : Object.fromEntries(Object.entries(process.env).filter(([key]) => key !== 'CODEX_HOME'))
+  const inheritedEnv = Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => key !== 'ECC_DRY_RUN' && key !== 'CODEX_HOME')
+  );
+  const optionEnv = Object.fromEntries(
+    Object.entries(options.env || {}).filter(([key]) => options.homeDir || key !== 'CODEX_HOME')
+  );
+  const homeEnv = options.homeDir
+    ? { HOME: options.homeDir, CODEX_HOME: path.join(options.homeDir, '.codex') }
+    : {};
+  const env = { ...inheritedEnv, ...optionEnv, ...homeEnv };
 
   try {
     const stdout = execFileSync('node', [SCRIPT, ...args], {
@@ -409,6 +416,74 @@ function runTests() {
       assert.strictEqual(fs.readFileSync(conversationPath, 'utf8'), 'conversation history');
       assert.strictEqual(fs.readFileSync(userFilePath, 'utf8'), 'unrelated');
       assert.ok(!fs.existsSync(statePath));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('global dry-run environment previews legacy Codex cleanup without removing artifacts', () => {
+    const homeDir = createTempDir('uninstall-legacy-codex-dry-run-home-');
+    const projectRoot = createTempDir('uninstall-legacy-codex-dry-run-project-');
+
+    try {
+      const codexHome = path.join(homeDir, '.codex');
+      const promptPath = path.join(codexHome, 'prompts', 'ecc-plan.md');
+      fs.mkdirSync(path.dirname(promptPath), { recursive: true });
+
+      const statePath = beginLegacySyncState({
+        codexHome,
+        backupDir: path.join(codexHome, 'backups', 'ecc-test'),
+      });
+      recordLegacySyncPath({ statePath, filePath: promptPath });
+      fs.writeFileSync(promptPath, '# ECC generated prompt\n');
+      finalizeLegacySyncState({ statePath });
+
+      const uninstallResult = run(['--legacy-codex-sync'], {
+        cwd: projectRoot,
+        homeDir,
+        env: { ECC_DRY_RUN: '1' },
+      });
+
+      assert.strictEqual(uninstallResult.code, 0, uninstallResult.stderr);
+      assert.match(uninstallResult.stdout, /Status: PLANNED/);
+      assert.match(uninstallResult.stdout, /Planned changes:/);
+      assert.doesNotMatch(uninstallResult.stdout, /Status: UNINSTALLED|Removed paths:/);
+      assert.ok(fs.existsSync(promptPath), 'global dry-run must preserve legacy artifacts');
+      assert.ok(fs.existsSync(statePath), 'global dry-run must preserve legacy state');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('rejects an invalid global dry-run value before legacy cleanup', () => {
+    const homeDir = createTempDir('uninstall-legacy-codex-invalid-dry-run-home-');
+    const projectRoot = createTempDir('uninstall-legacy-codex-invalid-dry-run-project-');
+
+    try {
+      const codexHome = path.join(homeDir, '.codex');
+      const promptPath = path.join(codexHome, 'prompts', 'ecc-plan.md');
+      fs.mkdirSync(path.dirname(promptPath), { recursive: true });
+
+      const statePath = beginLegacySyncState({
+        codexHome,
+        backupDir: path.join(codexHome, 'backups', 'ecc-test'),
+      });
+      recordLegacySyncPath({ statePath, filePath: promptPath });
+      fs.writeFileSync(promptPath, '# ECC generated prompt\n');
+      finalizeLegacySyncState({ statePath });
+
+      const uninstallResult = run(['--legacy-codex-sync'], {
+        cwd: projectRoot,
+        homeDir,
+        env: { ECC_DRY_RUN: 'true' },
+      });
+
+      assert.strictEqual(uninstallResult.code, 1);
+      assert.match(uninstallResult.stderr, /ECC_DRY_RUN must be "1" or "0" when set/);
+      assert.ok(fs.existsSync(promptPath), 'invalid dry-run input must preserve legacy artifacts');
+      assert.ok(fs.existsSync(statePath), 'invalid dry-run input must preserve legacy state');
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);


### PR DESCRIPTION
## What Changed

- Honor the global `ECC_DRY_RUN=1` contract in the uninstall command.
- Reject invalid `ECC_DRY_RUN` values before any uninstall discovery or mutation.
- Add an end-to-end regression for `ecc --dry-run uninstall` covering both JSON and human-readable output.
- Verify that managed files and install-state remain untouched, including the legacy Codex cleanup path.
- Isolate CLI tests from inherited dry-run and Codex-home environment values.

## Why This Change

The top-level CLI converts a leading `--dry-run` into `ECC_DRY_RUN=1` before dispatching the subcommand. The uninstall parser only inspected its own argv, so `ecc --dry-run uninstall` silently performed a real uninstall. This fixes the destructive behavior reported in #2952.

Fixes #2952

## Testing Done

- [x] End-to-end dry-run behavior tested with isolated temporary HOME and project directories
- [x] Focused regression suites pass: 128/128
- [x] Node syntax checks, focused ESLint, and `git diff --check` pass
- [x] `scripts/uninstall.js` focused coverage: 86.73% lines, 75.38% branches
- [x] Edge cases cover install-state and legacy Codex cleanup paths, JSON and human output, invalid environment values, and environment isolation
- [ ] Full `npm test` is completely green locally: 4144/4161 passed; the remaining existing failures are 15 validator-fixture failures, one sandboxed HOME write, and one Plan Canvas SSE timeout, all outside this diff. The package-manager test passes 116/116 with an isolated HOME, and the same Plan Canvas timeout reproduces on `origin/main`.

## Type of Change

- [x] `fix:` Bug fix

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation

- [x] No documentation change required; this restores the already documented global `--dry-run` contract