### PR TITLE
fix(commands): clarify overlapping command triggers

### DIFF
--- a/commands/code-review.md
+++ b/commands/code-review.md
@@ -1,5 +1,5 @@
 ---
-description: Code review — local uncommitted changes or GitHub PR (pass PR number/URL for PR mode)
+description: Code review — local uncommitted changes or GitHub PR (pass PR number/URL for PR mode). Use for a step-by-step PRP-style checklist review; for a multi-agent pass use /review-pr, and for the adversarially-verified Workflow pass use /orch-review.
 argument-hint: [pr-number | pr-url | blank for local review]
 ---
 

--- a/commands/cost-report.md
+++ b/commands/cost-report.md
@@ -1,5 +1,5 @@
 ---
-description: Generate a local Claude Code cost report from the ECC cost-tracker metrics log.
+description: Generate a local Claude Code cost report from the ECC cost-tracker metrics log. Use for a terminal summary or CSV export of tracked spend; the cost-tracking skill covers the same metrics log for on-demand cost/budget questions asked in conversation.
 argument-hint: [csv]
 ---
 

--- a/commands/ecc-guide.md
+++ b/commands/ecc-guide.md
@@ -1,5 +1,5 @@
 ---
-description: Navigate ECC's current agents, skills, commands, hooks, install profiles, and docs from the live repository surface.
+description: Navigate ECC's current agents, skills, commands, hooks, install profiles, and docs from the live repository surface. This is the slash-command entrypoint for that navigation; the ecc-guide skill covers the same map for on-demand use in conversation.
 ---
 
 # /ecc-guide

--- a/commands/harness-audit.md
+++ b/commands/harness-audit.md
@@ -1,5 +1,5 @@
 ---
-description: Run a deterministic repository harness audit and return a prioritized scorecard.
+description: Run a deterministic repository harness audit and return a prioritized scorecard. Use for a deterministic overall repo-readiness scorecard; for a security-specific audit use /security-scan.
 ---
 
 # Harness Audit Command

--- a/commands/harness-audit.md
+++ b/commands/harness-audit.md
@@ -1,5 +1,5 @@
 ---
-description: Run a deterministic repository harness audit and return a prioritized scorecard. Use for a deterministic overall repo-readiness scorecard; for a security-specific audit use /security-scan.
+description: Run a deterministic repository harness audit and return a prioritized scorecard. Use for a deterministic overall repo-readiness scorecard; for a security-specific audit use the security-scan command.
 ---
 
 # Harness Audit Command

--- a/commands/hookify.md
+++ b/commands/hookify.md
@@ -1,5 +1,5 @@
 ---
-description: Create hooks to prevent unwanted behaviors from conversation analysis or explicit instructions
+description: Create hooks to prevent unwanted behaviors from conversation analysis or explicit instructions. Use to generate a new hook rule file from conversation analysis or a described behavior; the hookify-rules skill covers hookify rule syntax and patterns for authoring or editing rules directly.
 ---
 
 Create hook rules to prevent unwanted Claude Code behaviors by analyzing conversation patterns or explicit user instructions.

--- a/commands/learn.md
+++ b/commands/learn.md
@@ -1,5 +1,5 @@
 ---
-description: Extract reusable patterns from the current session and save them as candidate skills or guidance.
+description: Extract reusable patterns from the current session and save them as candidate skills or guidance. Use to review a session on demand and persist an approved skill file; continuous-learning-v2 is a separate, configurable Stop/PreToolUse/PostToolUse hook-observation and instinct-evolution system (background observer disabled by default) and is not an automatic equivalent of this command.
 ---
 
 # /learn - Extract Reusable Patterns

--- a/commands/loop-start.md
+++ b/commands/loop-start.md
@@ -1,5 +1,5 @@
 ---
-description: Start a managed autonomous loop pattern with safety defaults and explicit stop conditions.
+description: Prepare a managed autonomous loop pattern with safety defaults and explicit stop conditions, then print the commands to launch and monitor it. Use to set up sequential, continuous-pr, rfc-dag, or infinite loop patterns with safety gates before starting one; the continuous-agent-loop skill covers the same pattern selection and quality-gate guidance for in-conversation use (supersedes the deprecated autonomous-loops skill).
 ---
 
 # Loop Start Command

--- a/commands/marketing-campaign.md
+++ b/commands/marketing-campaign.md
@@ -1,5 +1,5 @@
 ---
-description: Plan and execute a full marketing campaign. Accepts a product brief and returns positioning, landing page copy, email sequence, social posts, ad variants, video scripts, and a content calendar. Can also review existing copy for conversion quality.
+description: Plan and execute a full marketing campaign. Accepts a product brief and returns positioning, landing page copy, email sequence, social posts, ad variants, video scripts, and a content calendar. Can also review existing copy for conversion quality. This is the slash-command entrypoint that delegates to the marketing-agent; prefer the marketing-campaign skill for the same end-to-end workflow in conversation.
 allowed-tools: ["Read", "Grep", "Glob", "WebSearch", "WebFetch", "Write"]
 ---
 

--- a/commands/multi-plan.md
+++ b/commands/multi-plan.md
@@ -1,5 +1,5 @@
 ---
-description: Create a multi-model implementation plan without modifying production code.
+description: Create a multi-model (Codex + Antigravity) implementation plan without modifying production code. Requires the external ccg-workflow runtime, not part of the base ECC install (see Prerequisite below). Use when the user explicitly wants dual-model plan drafts; for a single-model plan with no extra runtime use /plan.
 ---
 
 # Plan - Multi-Model Collaborative Planning

--- a/commands/orch-review.md
+++ b/commands/orch-review.md
@@ -1,5 +1,5 @@
 ---
-description: Run the orch-review native Workflow over a diff (local changes or a GitHub PR) and report blocking vs advisory findings. Surface for the orch-review workflow.
+description: Run the orch-review native Workflow over a diff (local changes or a GitHub PR) and report blocking vs advisory findings. Surface for the orch-review workflow. Use for a native-Workflow, adversarially-verified multi-dimension review with fan-out and dedup; for the step-by-step checklist pass use /code-review, and for the multi-agent pass use /review-pr.
 argument-hint: [pr-number | pr-url | blank for local uncommitted changes]
 ---
 

--- a/commands/plan-canvas.md
+++ b/commands/plan-canvas.md
@@ -1,5 +1,5 @@
 ---
-description: Open a plan or HTML artifact in the browser Plan Canvas for annotate-and-approve review
+description: Open a plan or HTML artifact in the browser Plan Canvas for annotate-and-approve review. This is a thin slash-command entrypoint over the plan-canvas skill, which covers the full workflow and rules.
 argument-hint: "[path/to/artifact.plan.md | path/to/artifact.html]"
 ---
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -1,5 +1,5 @@
 ---
-description: Restate requirements, assess risks, and create step-by-step implementation plan. WAIT for user CONFIRM before touching any code.
+description: Restate requirements, assess risks, and create step-by-step implementation plan. WAIT for user CONFIRM before touching any code. Use for a single-model inline or PRD-driven implementation plan; for a dual-model (Codex/Antigravity) plan use /multi-plan, and for visual annotate-and-approve review of the resulting plan use /plan-canvas.
 argument-hint: "[feature description | path/to/*.prd.md]"
 ---
 

--- a/commands/project-init.md
+++ b/commands/project-init.md
@@ -1,5 +1,5 @@
 ---
-description: Detect a project's stack and produce a dry-run ECC onboarding plan using the repository's install manifests and stack mappings.
+description: Detect a project's stack and produce a dry-run ECC onboarding plan using the repository's install manifests and stack mappings. Use to onboard ECC into a target project via a reviewable dry-run plan; for general feature discovery and navigation use the ecc-guide skill or /ecc-guide command instead.
 ---
 
 # /project-init

--- a/commands/prune.md
+++ b/commands/prune.md
@@ -1,6 +1,6 @@
 ---
 name: prune
-description: Delete pending instincts older than 30 days that were never promoted
+description: Delete pending instincts older than 30 days that were never promoted. Thin CLI wrapper for continuous-learning-v2's instinct-cli.py prune command; use to clean up stale pending instincts that were never reviewed or promoted.
 command: true
 ---
 

--- a/commands/review-pr.md
+++ b/commands/review-pr.md
@@ -1,5 +1,5 @@
 ---
-description: Comprehensive PR review using specialized agents
+description: Comprehensive PR review using specialized agents (code-reviewer, comment-analyzer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, code-simplifier). Use for a multi-agent PR review pass; for the adversarially-verified Workflow pass use /orch-review, and for the standalone step-by-step checklist review use /code-review.
 ---
 
 Run a comprehensive multi-perspective review of a pull request.

--- a/commands/santa-loop.md
+++ b/commands/santa-loop.md
@@ -1,5 +1,5 @@
 ---
-description: Adversarial dual-review convergence loop — two independent model reviewers must both approve before code ships.
+description: Adversarial dual-review convergence loop — two independent model reviewers must both approve before code ships. Use for the CLI-driven version of this loop; wraps the santa-method skill.
 ---
 
 # Santa Loop

--- a/commands/security-scan.md
+++ b/commands/security-scan.md
@@ -1,5 +1,5 @@
 ---
-description: Run AgentShield against agent, hook, MCP, permission, and secret surfaces.
+description: Run AgentShield against agent, hook, MCP, permission, and secret surfaces. This is the slash-command entrypoint for that audit; prefer the security-scan skill for the same AgentShield audit in conversation.
 agent: ecc:security-reviewer
 subtask: true
 ---

--- a/commands/skill-create.md
+++ b/commands/skill-create.md
@@ -1,6 +1,6 @@
 ---
 name: skill-create
-description: Analyze local git history to extract coding patterns and generate SKILL.md files. Local version of the Skill Creator GitHub App.
+description: Analyze local git history to extract coding patterns and generate SKILL.md files. Local version of the Skill Creator GitHub App. Use to generate new skills from local git history on demand; check the skill-scout skill first to avoid duplicating an existing local, marketplace, or GitHub skill.
 allowed-tools: ["Bash", "Read", "Write", "Grep", "Glob"]
 ---
 

--- a/commands/skill-health.md
+++ b/commands/skill-health.md
@@ -1,6 +1,6 @@
 ---
 name: skill-health
-description: Show skill portfolio health dashboard with charts and analytics
+description: Show skill portfolio health dashboard with charts and analytics. Use for the quantitative usage/success-rate dashboard; for a qualitative compliance or quality audit use the skill-stocktake skill.
 command: true
 ---
 

--- a/docs/COMMAND-REGISTRY.json
+++ b/docs/COMMAND-REGISTRY.json
@@ -325,13 +325,11 @@
     },
     {
       "command": "harness-audit",
-      "description": "Run a deterministic repository harness audit and return a prioritized scorecard. Use for a deterministic overall repo-readiness scorecard; for a security-specific audit use /security-scan.",
+      "description": "Run a deterministic repository harness audit and return a prioritized scorecard. Use for a deterministic overall repo-readiness scorecard; for a security-specific audit use the security-scan command.",
       "type": "testing",
       "primaryAgents": [],
       "allAgents": [],
-      "skills": [
-        "security-scan"
-      ],
+      "skills": [],
       "path": "commands/harness-audit.md"
     },
     {
@@ -1114,11 +1112,11 @@
         "count": 3
       },
       {
-        "skill": "security-scan",
-        "count": 3
+        "skill": "cpp-coding-standards",
+        "count": 2
       },
       {
-        "skill": "cpp-coding-standards",
+        "skill": "cpp-testing",
         "count": 2
       }
     ]

--- a/docs/COMMAND-REGISTRY.json
+++ b/docs/COMMAND-REGISTRY.json
@@ -40,7 +40,7 @@
     },
     {
       "command": "code-review",
-      "description": "Code review — local uncommitted changes or GitHub PR (pass PR number/URL for PR mode)",
+      "description": "Code review — local uncommitted changes or GitHub PR (pass PR number/URL for PR mode). Use for a step-by-step PRP-style checklist review; for a multi-agent pass use /review-pr, and for the adversarially-verified Workflow pass use /orch-review.",
       "type": "testing",
       "primaryAgents": [],
       "allAgents": [],
@@ -49,7 +49,7 @@
     },
     {
       "command": "cost-report",
-      "description": "Generate a local Claude Code cost report from the ECC cost-tracker metrics log.",
+      "description": "Generate a local Claude Code cost report from the ECC cost-tracker metrics log. Use for a terminal summary or CSV export of tracked spend; the cost-tracking skill covers the same metrics log for on-demand cost/budget questions asked in conversation.",
       "type": "testing",
       "primaryAgents": [],
       "allAgents": [],
@@ -101,7 +101,7 @@
     },
     {
       "command": "ecc-guide",
-      "description": "Navigate ECC's current agents, skills, commands, hooks, install profiles, and docs from the live repository surface.",
+      "description": "Navigate ECC's current agents, skills, commands, hooks, install profiles, and docs from the live repository surface. This is the slash-command entrypoint for that navigation; the ecc-guide skill covers the same map for on-demand use in conversation.",
       "type": "review",
       "primaryAgents": [],
       "allAgents": [],
@@ -325,11 +325,13 @@
     },
     {
       "command": "harness-audit",
-      "description": "Run a deterministic repository harness audit and return a prioritized scorecard.",
+      "description": "Run a deterministic repository harness audit and return a prioritized scorecard. Use for a deterministic overall repo-readiness scorecard; for a security-specific audit use /security-scan.",
       "type": "testing",
       "primaryAgents": [],
       "allAgents": [],
-      "skills": [],
+      "skills": [
+        "security-scan"
+      ],
       "path": "commands/harness-audit.md"
     },
     {
@@ -361,7 +363,7 @@
     },
     {
       "command": "hookify",
-      "description": "Create hooks to prevent unwanted behaviors from conversation analysis or explicit instructions",
+      "description": "Create hooks to prevent unwanted behaviors from conversation analysis or explicit instructions. Use to generate a new hook rule file from conversation analysis or a described behavior; the hookify-rules skill covers hookify rule syntax and patterns for authoring or editing rules directly.",
       "type": "general",
       "primaryAgents": [],
       "allAgents": [],
@@ -464,7 +466,7 @@
     },
     {
       "command": "learn",
-      "description": "Extract reusable patterns from the current session and save them as candidate skills or guidance.",
+      "description": "Extract reusable patterns from the current session and save them as candidate skills or guidance. Use to review a session on demand and persist an approved skill file; continuous-learning-v2 is a separate, configurable Stop/PreToolUse/PostToolUse hook-observation and instinct-evolution system (background observer disabled by default) and is not an automatic equivalent of this command.",
       "type": "review",
       "primaryAgents": [],
       "allAgents": [],
@@ -473,7 +475,7 @@
     },
     {
       "command": "loop-start",
-      "description": "Start a managed autonomous loop pattern with safety defaults and explicit stop conditions.",
+      "description": "Prepare a managed autonomous loop pattern with safety defaults and explicit stop conditions, then print the commands to launch and monitor it. Use to set up sequential, continuous-pr, rfc-dag, or infinite loop patterns with safety gates before starting one; the continuous-agent-loop skill covers the same pattern selection and quality-gate guidance for in-conversation use (supersedes the deprecated autonomous-loops skill).",
       "type": "testing",
       "primaryAgents": [],
       "allAgents": [],
@@ -491,7 +493,7 @@
     },
     {
       "command": "marketing-campaign",
-      "description": "Plan and execute a full marketing campaign. Accepts a product brief and returns positioning, landing page copy, email sequence, social posts, ad variants, video scripts, and a content calendar. Can also review existing copy for conversion quality.",
+      "description": "Plan and execute a full marketing campaign. Accepts a product brief and returns positioning, landing page copy, email sequence, social posts, ad variants, video scripts, and a content calendar. Can also review existing copy for conversion quality. This is the slash-command entrypoint that delegates to the marketing-agent; prefer the marketing-campaign skill for the same end-to-end workflow in conversation.",
       "type": "testing",
       "primaryAgents": [],
       "allAgents": [],
@@ -538,7 +540,7 @@
     },
     {
       "command": "multi-plan",
-      "description": "Create a multi-model implementation plan without modifying production code.",
+      "description": "Create a multi-model (Codex + Antigravity) implementation plan without modifying production code. Requires the external ccg-workflow runtime, not part of the base ECC install (see Prerequisite below). Use when the user explicitly wants dual-model plan drafts; for a single-model plan with no extra runtime use /plan.",
       "type": "orchestration",
       "primaryAgents": [],
       "allAgents": [],
@@ -619,7 +621,7 @@
     },
     {
       "command": "orch-review",
-      "description": "Run the orch-review native Workflow over a diff (local changes or a GitHub PR) and report blocking vs advisory findings. Surface for the orch-review workflow.",
+      "description": "Run the orch-review native Workflow over a diff (local changes or a GitHub PR) and report blocking vs advisory findings. Surface for the orch-review workflow. Use for a native-Workflow, adversarially-verified multi-dimension review with fan-out and dedup; for the step-by-step checklist pass use /code-review, and for the multi-agent pass use /review-pr.",
       "type": "review",
       "primaryAgents": [],
       "allAgents": [],
@@ -628,7 +630,7 @@
     },
     {
       "command": "plan-canvas",
-      "description": "Open a plan or HTML artifact in the browser Plan Canvas for annotate-and-approve review",
+      "description": "Open a plan or HTML artifact in the browser Plan Canvas for annotate-and-approve review. This is a thin slash-command entrypoint over the plan-canvas skill, which covers the full workflow and rules.",
       "type": "review",
       "primaryAgents": [],
       "allAgents": [],
@@ -648,7 +650,7 @@
     },
     {
       "command": "plan",
-      "description": "Restate requirements, assess risks, and create step-by-step implementation plan. WAIT for user CONFIRM before touching any code.",
+      "description": "Restate requirements, assess risks, and create step-by-step implementation plan. WAIT for user CONFIRM before touching any code. Use for a single-model inline or PRD-driven implementation plan; for a dual-model (Codex/Antigravity) plan use /multi-plan, and for visual annotate-and-approve review of the resulting plan use /plan-canvas.",
       "type": "testing",
       "primaryAgents": [
         "planner"
@@ -681,7 +683,7 @@
     },
     {
       "command": "project-init",
-      "description": "Detect a project's stack and produce a dry-run ECC onboarding plan using the repository's install manifests and stack mappings.",
+      "description": "Detect a project's stack and produce a dry-run ECC onboarding plan using the repository's install manifests and stack mappings. Use to onboard ECC into a target project via a reviewable dry-run plan; for general feature discovery and navigation use the ecc-guide skill or /ecc-guide command instead.",
       "type": "testing",
       "primaryAgents": [],
       "allAgents": [],
@@ -759,7 +761,7 @@
     },
     {
       "command": "prune",
-      "description": "Delete pending instincts older than 30 days that were never promoted",
+      "description": "Delete pending instincts older than 30 days that were never promoted. Thin CLI wrapper for continuous-learning-v2's instinct-cli.py prune command; use to clean up stale pending instincts that were never reviewed or promoted.",
       "type": "review",
       "primaryAgents": [],
       "allAgents": [],
@@ -862,7 +864,7 @@
     },
     {
       "command": "review-pr",
-      "description": "Comprehensive PR review using specialized agents",
+      "description": "Comprehensive PR review using specialized agents (code-reviewer, comment-analyzer, pr-test-analyzer, silent-failure-hunter, type-design-analyzer, code-simplifier). Use for a multi-agent PR review pass; for the adversarially-verified Workflow pass use /orch-review, and for the standalone step-by-step checklist review use /code-review.",
       "type": "testing",
       "primaryAgents": [],
       "allAgents": [],
@@ -914,7 +916,7 @@
     },
     {
       "command": "santa-loop",
-      "description": "Adversarial dual-review convergence loop — two independent model reviewers must both approve before code ships.",
+      "description": "Adversarial dual-review convergence loop — two independent model reviewers must both approve before code ships. Use for the CLI-driven version of this loop; wraps the santa-method skill.",
       "type": "review",
       "primaryAgents": [],
       "allAgents": [],
@@ -932,7 +934,7 @@
     },
     {
       "command": "security-scan",
-      "description": "Run AgentShield against agent, hook, MCP, permission, and secret surfaces.",
+      "description": "Run AgentShield against agent, hook, MCP, permission, and secret surfaces. This is the slash-command entrypoint for that audit; prefer the security-scan skill for the same AgentShield audit in conversation.",
       "type": "review",
       "primaryAgents": [
         "security-reviewer"
@@ -965,7 +967,7 @@
     },
     {
       "command": "skill-create",
-      "description": "Analyze local git history to extract coding patterns and generate SKILL.md files. Local version of the Skill Creator GitHub App.",
+      "description": "Analyze local git history to extract coding patterns and generate SKILL.md files. Local version of the Skill Creator GitHub App. Use to generate new skills from local git history on demand; check the skill-scout skill first to avoid duplicating an existing local, marketplace, or GitHub skill.",
       "type": "testing",
       "primaryAgents": [],
       "allAgents": [],
@@ -974,7 +976,7 @@
     },
     {
       "command": "skill-health",
-      "description": "Show skill portfolio health dashboard with charts and analytics",
+      "description": "Show skill portfolio health dashboard with charts and analytics. Use for the quantitative usage/success-rate dashboard; for a qualitative compliance or quality audit use the skill-stocktake skill.",
       "type": "review",
       "primaryAgents": [],
       "allAgents": [],
@@ -1112,11 +1114,11 @@
         "count": 3
       },
       {
-        "skill": "cpp-coding-standards",
-        "count": 2
+        "skill": "security-scan",
+        "count": 3
       },
       {
-        "skill": "cpp-testing",
+        "skill": "cpp-coding-standards",
         "count": 2
       }
     ]


### PR DESCRIPTION
## What Changed
Add intent triggers and sibling boundaries to 19 existing command descriptions, covering the prioritized review/planning/onboarding/audit/cost commands, overlapping learning/hook/skill workflows, and four same-name compatibility entrypoints. Regenerate `docs/COMMAND-REGISTRY.json` with the existing generator. Command bodies and other metadata remain unchanged.

## Why This Change
Overlapping entries did not explain when to choose a command, its sibling workflow, or the equivalent skill. The descriptions now distinguish checklist versus multi-agent/adversarial review, single versus dual-model planning, setup prerequisites, and compatibility entrypoints.

Addresses #2906. This is a focused first pass over the implicated overlaps, not a rewrite of all 94 commands or all skill descriptions. A fixed 15-prompt before/after listing-only exercise preserved 14 selections; the baseline already selected commands for many natural prompts. No measured routing improvement or universal routing fix is claimed.

## Testing Done
- PASS: command and skill validators; command registry freshness check; 95 command-frontmatter tests; 4 registry tests; Markdown lint and `git diff --check`.
- Independent review of the actual diff completed with no remaining actionable findings.
- Full `npm test` was run before and after the combined documentation changes under the same sandbox: **4,125 total, 4,069 passed, 56 failed** in both runs, with identical failure names and order. Failures include restricted localhost binding and user-configuration writes; not all baseline failures were individually root-caused. Full-suite success is **not** claimed.
- [ ] Automated tests pass locally (`node tests/run-all.js`) — baseline failures above remain.

## Type of Change
- [x] `docs:` Documentation

## Security & Quality Checklist
- [x] Diff inspected for secrets and unrelated local data.
- [x] JSON and Markdown metadata validation passed.
- [x] Conventional commit format.
- Shell checks and dependency updates: not applicable; no shell, package, lockfile or runtime changes.

## Documentation
- [x] Relevant existing documentation updated.
