### PR TITLE
fix(hooks): prevent large passthrough output truncation

### DIFF
--- a/scripts/hooks/post-edit-format.js
+++ b/scripts/hooks/post-edit-format.js
@@ -102,7 +102,6 @@ if (require.main === module) {
   process.stdin.on('end', () => {
     data = run(data);
     process.stdout.write(data);
-    process.exit(0);
   });
 }
 

--- a/scripts/hooks/post-edit-typecheck.js
+++ b/scripts/hooks/post-edit-typecheck.js
@@ -33,7 +33,7 @@ process.stdin.on("end", () => {
       const resolvedPath = path.resolve(filePath);
       if (!fs.existsSync(resolvedPath)) {
         process.stdout.write(data);
-        process.exit(0);
+        return;
       }
       // Find nearest tsconfig.json by walking up (max 20 levels to prevent infinite loop)
       let dir = path.dirname(resolvedPath);
@@ -92,5 +92,4 @@ process.stdin.on("end", () => {
   }
 
   process.stdout.write(data);
-  process.exit(0);
 });

--- a/tests/hooks/passthrough-large-stdout.test.js
+++ b/tests/hooks/passthrough-large-stdout.test.js
@@ -1,0 +1,39 @@
+/**
+ * Regression coverage for #2924: passthrough hooks must not truncate
+ * stdout when forwarding payloads larger than the OS pipe buffer.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const payload = JSON.stringify({
+  session_id: 'large-passthrough-test',
+  hook_event_name: 'PostToolUse',
+  tool_input: { file_path: 'notes.txt' },
+  pad: 'x'.repeat(200 * 1024),
+});
+
+const hooks = [
+  'scripts/hooks/post-edit-typecheck.js',
+  'scripts/hooks/post-edit-format.js',
+];
+
+for (const hook of hooks) {
+  const result = spawnSync('node', [path.join(repoRoot, hook)], {
+    input: payload,
+    encoding: 'utf8',
+    cwd: repoRoot,
+    timeout: 30_000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+
+  assert.strictEqual(result.status, 0, `${hook}: expected exit 0, got ${result.status}: ${result.stderr}`);
+  assert.strictEqual(result.stdout, payload, `${hook}: passthrough payload was truncated`);
+  assert.doesNotThrow(() => JSON.parse(result.stdout), `${hook}: stdout must remain valid JSON`);
+}
+
+console.log(`✓ ${hooks.length} passthrough hooks preserve a 200KB payload`);


### PR DESCRIPTION
## Summary

Fixes the remaining `process.exit(0)` passthrough truncation paths in the PostToolUse hooks called out by #2924.

### Changes
- `post-edit-typecheck.js`: replace early/final `process.exit(0)` calls after stdout writes with natural process completion so Node can flush the pipe.
- `post-edit-format.js`: remove the immediate `process.exit(0)` after the passthrough write for the same reason.
- Add a regression test that sends a 200KB JSON payload through both hooks and asserts byte-for-byte stdout preservation and valid JSON.

The existing 1MB stdin safety cap is intentionally preserved because the repository's current Stop-hook regression contract suppresses oversized passthrough payloads rather than echoing truncated JSON.

Closes #2924