### PR TITLE
fix(commands): mark /prp-pr as an alias of /pr in its description

### DIFF
--- a/commands/prp-pr.md
+++ b/commands/prp-pr.md
@@ -1,5 +1,5 @@
 ---
-description: "Create a GitHub PR from current branch with unpushed commits — discovers templates, analyzes changes, pushes"
+description: "Alias of /pr for the PRP workflow series — same PR creation flow, differing only in suggesting /prp-commit for uncommitted changes. Use /pr unless already mid-PRP-series."
 argument-hint: "[base-branch] (default: main)"
 ---
 

--- a/docs/COMMAND-REGISTRY.json
+++ b/docs/COMMAND-REGISTRY.json
@@ -741,7 +741,7 @@
     },
     {
       "command": "prp-pr",
-      "description": "Create a GitHub PR from current branch with unpushed commits — discovers templates, analyzes changes, pushes",
+      "description": "Alias of /pr for the PRP workflow series — same PR creation flow, differing only in suggesting /prp-commit for uncommitted changes. Use /pr unless already mid-PRP-series.",
       "type": "testing",
       "primaryAgents": [],
       "allAgents": [],


### PR DESCRIPTION
## Summary

`commands/pr.md` and `commands/prp-pr.md` had byte-identical `description:` frontmatter, so from the 401-entry listing text the two entries were indistinguishable at selection time.

This gives `/prp-pr` its own alias-style description following the pattern the `orch-*` commands already use successfully (e.g. "Wrapper that kicks off the orch-add-feature skill"):

- names the sibling entry (`/pr`)
- states the only real difference (suggests `/prp-commit` for uncommitted changes)
- points readers to `/pr` unless they are already mid-PRP-series

## Verification

- `grep -m1 '^description:' commands/pr.md commands/prp-pr.md` now yields distinct lines
- `node tests/commands/command-frontmatter.test.js` — 95 passed
- `node scripts/ci/generate-command-registry.js --check` — up to date

Closes #2905