### PR TITLE
fix(hooks): stop passthrough hooks from emitting truncated JSON

### DIFF
--- a/scripts/hooks/doc-file-warning.js
+++ b/scripts/hooks/doc-file-warning.js
@@ -77,15 +77,26 @@ function run(inputOrRaw, _options = {}) {
  */
 function main() {
   let data = '';
+  let truncated = false;
   process.stdin.setEncoding('utf8');
   process.stdin.on('data', c => {
     if (data.length < MAX_STDIN) {
       const remaining = MAX_STDIN - data.length;
       data += c.substring(0, remaining);
+      if (c.length > remaining) truncated = true;
+    } else {
+      truncated = true;
     }
   });
 
   process.stdin.on('end', () => {
+    if (truncated) {
+      // Truncated stdin is never echoed: a JSON document cut mid-stream is
+      // reported by the harness as invalid hook output (#2924).
+      process.stderr.write('[Hook] doc-file-warning: stdin exceeded 1MB; suppressing pass-through (fail-open)\n');
+      return;
+    }
+
     const result = run(data);
 
     if (result.stderr) {

--- a/scripts/hooks/post-edit-console-warn.js
+++ b/scripts/hooks/post-edit-console-warn.js
@@ -47,14 +47,25 @@ function run(data) {
 
 if (require.main === module) {
   let data = '';
+  let truncated = false;
   process.stdin.setEncoding('utf8');
   process.stdin.on('data', chunk => {
     if (data.length < MAX_STDIN) {
       const remaining = MAX_STDIN - data.length;
       data += chunk.substring(0, remaining);
+      if (chunk.length > remaining) truncated = true;
+    } else {
+      truncated = true;
     }
   });
   process.stdin.on('end', () => {
+    if (truncated) {
+      // Truncated stdin is never echoed: a JSON document cut mid-stream is
+      // reported by the harness as invalid hook output (#2924).
+      process.stderr.write('[Hook] post-edit-console-warn: stdin exceeded 1MB; suppressing pass-through (fail-open)\n');
+      process.exitCode = 0;
+      return;
+    }
     const result = run(data);
     if (result.stderr) process.stderr.write(`${result.stderr}\n`);
     process.stdout.write(result.stdout);

--- a/scripts/hooks/post-edit-format.js
+++ b/scripts/hooks/post-edit-format.js
@@ -90,19 +90,30 @@ function run(rawInput) {
 // ── stdin entry point (backwards-compatible) ────────────────────
 if (require.main === module) {
   let data = '';
+  let truncated = false;
   process.stdin.setEncoding('utf8');
 
   process.stdin.on('data', chunk => {
     if (data.length < MAX_STDIN) {
       const remaining = MAX_STDIN - data.length;
       data += chunk.substring(0, remaining);
+      if (chunk.length > remaining) truncated = true;
+    } else {
+      truncated = true;
     }
   });
 
   process.stdin.on('end', () => {
+    if (truncated) {
+      // Truncated stdin is never echoed: a JSON document cut mid-stream is
+      // reported by the harness as invalid hook output (#2924).
+      process.stderr.write('[Hook] post-edit-format: stdin exceeded 1MB; suppressing pass-through (fail-open)\n');
+      process.exit(0);
+    }
     data = run(data);
-    process.stdout.write(data);
-    process.exit(0);
+    // Flush before exiting: process.exit() with stdout on a pipe can drop
+    // buffered output, truncating the pass-through payload (#2924).
+    process.stdout.write(data, () => process.exit(0));
   });
 }
 

--- a/scripts/hooks/post-edit-typecheck.js
+++ b/scripts/hooks/post-edit-typecheck.js
@@ -15,14 +15,33 @@ const path = require("path");
 
 const MAX_STDIN = 1024 * 1024; // 1MB limit
 let data = "";
+let truncated = false;
 process.stdin.setEncoding("utf8");
 
 process.stdin.on("data", (chunk) => {
   if (data.length < MAX_STDIN) {
     const remaining = MAX_STDIN - data.length;
     data += chunk.substring(0, remaining);
+    if (chunk.length > remaining) truncated = true;
+  } else {
+    truncated = true;
   }
 });
+
+/**
+ * Echo stdin back (ECC pass-through convention), then exit once the pipe has
+ * flushed. Truncated stdin is never echoed: a JSON document cut mid-stream is
+ * reported by the harness as invalid hook output (#2924). `process.exit()`
+ * alone can drop buffered stdout when it is a pipe, so the write callback
+ * drives the exit.
+ */
+function passThroughAndExit() {
+  if (truncated) {
+    process.stderr.write("[Hook] post-edit-typecheck: stdin exceeded 1MB; suppressing pass-through (fail-open)\n");
+    process.exit(0);
+  }
+  process.stdout.write(data, () => process.exit(0));
+}
 
 process.stdin.on("end", () => {
   try {
@@ -32,8 +51,8 @@ process.stdin.on("end", () => {
     if (filePath && /\.(ts|tsx)$/.test(filePath)) {
       const resolvedPath = path.resolve(filePath);
       if (!fs.existsSync(resolvedPath)) {
-        process.stdout.write(data);
-        process.exit(0);
+        passThroughAndExit();
+        return;
       }
       // Find nearest tsconfig.json by walking up (max 20 levels to prevent infinite loop)
       let dir = path.dirname(resolvedPath);
@@ -91,6 +110,5 @@ process.stdin.on("end", () => {
     // Invalid input — pass through
   }
 
-  process.stdout.write(data);
-  process.exit(0);
+  passThroughAndExit();
 });

--- a/tests/hooks/passthrough-truncation.test.js
+++ b/tests/hooks/passthrough-truncation.test.js
@@ -1,0 +1,128 @@
+/**
+ * Regression tests for #2924: passthrough hooks must not emit truncated JSON.
+ *
+ * Two failure modes were fixed:
+ *   Bug 1 - process.exit() without flushing stdout can drop buffered output
+ *           when stdout is a pipe, truncating the pass-through payload.
+ *   Bug 2 - MAX_STDIN cap cut `data` mid-string and the cut payload was echoed.
+ *
+ * The scripts under test are spawned exactly like Claude Code spawns them,
+ * with stdout piped, so pipe-buffer truncation is observable via size mismatch
+ * and via JSON.parse of the echoed output.
+ */
+
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'e2924-payload-'));
+
+/**
+ * Run a hook with the given stdin payload. Stdin is fed from a file fd so an
+ * early-exiting child cannot EPIPE the parent (which happens with spawnSync
+ * `input` strings larger than the child consumes).
+ */
+function runHook(hook, payload) {
+  const payloadFile = path.join(tmpDir, `payload-${process.pid}-${Math.random().toString(36).slice(2)}.json`);
+  fs.writeFileSync(payloadFile, payload, 'utf8');
+  const fd = fs.openSync(payloadFile, 'r');
+  try {
+    return spawnSync('node', [path.join(__dirname, '..', '..', hook)], {
+      encoding: 'utf8',
+      timeout: 20000,
+      stdio: [fd, 'pipe', 'pipe'],
+    });
+  } finally {
+    fs.closeSync(fd);
+    try { fs.unlinkSync(payloadFile); } catch (_) { /* best effort */ }
+  }
+}
+
+const hooks = [
+  'scripts/hooks/post-edit-typecheck.js',
+  'scripts/hooks/post-edit-format.js',
+  'scripts/hooks/post-edit-console-warn.js',
+  'scripts/hooks/pre-write-doc-warn.js',
+];
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    failed++;
+  }
+}
+
+/**
+ * Feed payload of the given size to the hook and assert the echoed stdout
+ * round-trips: same bytes, valid JSON. Returns nothing; asserts internally.
+ */
+function assertPassthroughIntact(hook, size, label) {
+  const payload = JSON.stringify({
+    session_id: 'e2924-test',
+    hook_event_name: 'Stop',
+    tool_input: { file_path: '/tmp/does-not-exist-2924.ts' },
+    pad: 'x'.repeat(size),
+  });
+  const result = spawnSync('node', [path.join(__dirname, '..', '..', hook)], {
+    input: payload,
+    encoding: 'utf8',
+    timeout: 20000,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  assert.strictEqual(result.status, 0, `${hook} ${label}: exit 0`);
+  assert.strictEqual(result.stdout.length, payload.length,
+    `${hook} ${label}: echoed length must match input length`);
+  let parsed;
+  assert.doesNotThrow(() => { parsed = JSON.parse(result.stdout); },
+    `${hook} ${label}: echoed output must be valid JSON`);
+  assert.strictEqual(parsed.pad, 'x'.repeat(size),
+    `${hook} ${label}: echoed payload must be intact`);
+}
+
+// Sizes chosen to cross both truncation points:
+//  - 200 KB sits past the 64 KB pipe buffer (Bug 1)
+//  - 2 MB exceeds the 1 MB MAX_STDIN cap (Bug 2) -> hook suppresses pass-through
+const PROBE_SIZES = [
+  [1000, '1KB'],
+  [200000, '200KB'],
+];
+
+for (const hook of hooks) {
+  for (const [size, label] of PROBE_SIZES) {
+    test(`${path.basename(hook)} round-trips ${label} payload (no truncation)`, () => {
+      assertPassthroughIntact(hook, size, `(${label})`);
+    });
+  }
+}
+
+// Over-MAX_STDIN payloads must NOT be echoed (invalid JSON would be emitted);
+// the hook must exit cleanly and stay silent on stdout (fail-open suppression).
+for (const hook of hooks) {
+  test(`${path.basename(hook)} suppresses pass-through for 2MB payload (over MAX_STDIN)`, () => {
+    const payload = JSON.stringify({
+      session_id: 'e2924-test',
+      hook_event_name: 'Stop',
+      tool_input: { file_path: '/tmp/does-not-exist-2924.ts' },
+      pad: 'x'.repeat(2000000),
+    });
+    const result = runHook(hook, payload);
+    assert.strictEqual(result.status, 0, 'exit 0');
+    assert.strictEqual(result.stdout, '', 'truncated payload must not be echoed');
+    assert.ok(/exceeded 1MB/.test(result.stderr || ''), 'suppression must be logged to stderr');
+  });
+}
+
+try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) { /* best effort */ }
+
+console.log(`\n  ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Five passthrough hooks truncated the payload echoed back to the harness, producing `Hook output looks like a JSON object but is not valid JSON`:

1. `process.exit(0)` without flushing stdout drops buffered output past the pipe buffer
2. the `MAX_STDIN` cap cut the passthrough payload mid-string

`check-console-log.js` already carries the fixed pattern on `main`; this applies the same pattern to the remaining scripts:

- `post-edit-typecheck.js` — both bugs, including the early-exit path
- `post-edit-format.js` — both bugs
- `post-edit-console-warn.js` — stdin cap
- `doc-file-warning.js` via the `pre-write-doc-warn` entrypoint — stdin cap

Over-`MAX_STDIN` payloads are suppressed (fail-open) and reported on stderr instead of being echoed; exits flush stdout via the write callback.

## Verification

New `tests/hooks/passthrough-truncation.test.js` feeds 1KB / 200KB / 2MB payloads through all four entrypoints exactly like the issue repro: 12/12 pass with the fix, 6 fail on `main`.