### PR TITLE
fix(hooks): anchor GATEGUARD_EXEMPT_GLOBS patterns and lowercase them

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -106,6 +106,13 @@ function getExtraDestructiveRegex() {
 // this / what schema" carries no signal. Memoized on the env value; fail-open (a
 // malformed pattern is dropped, never throws). `*` matches within a path segment,
 // `**` across segments, `?` a single char.
+//
+// Compiled patterns are anchored with `(^|/)` ... `$` (#2921): an unanchored pattern
+// such as `services/**` or `*.md` would otherwise match those names as a suffix of
+// ANY absolute path (e.g. `/other/repo/services/x` or `C:/docs/notes.md`), exempting
+// far more than the operator intended. Patterns are also lowercased because
+// `normalizeForMatch` lowercases the candidate path — a pattern written as
+// `README.md` would otherwise never match anything.
 let exemptCacheKey = null;
 let exemptCacheRegexes = null;
 function getExemptMatchers() {
@@ -120,12 +127,15 @@ function getExemptMatchers() {
     .filter(Boolean)
     .map(glob => {
       const source = glob
+        .toLowerCase()                          // candidate paths are lowercased too (#2921)
         .replace(/[.+^${}()|[\]\\]/g, '\\$&') // escape regex metachars, keep * and ?
         .split('**')                           // ** boundaries (cross-segment)
         .map(part => part.replace(/\*/g, '[^/]*').replace(/\?/g, '.'))
         .join('.*');                           // ** -> across segments
       try {
-        return new RegExp(source);
+        // Anchor to path boundaries so globs are repo-relative, not
+        // "match this name anywhere on the machine" (#2921).
+        return new RegExp('(^|/)' + source + '$');
       } catch (_) {
         return null;
       }

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -2860,6 +2860,75 @@ function runTests() {
     passed++;
   else failed++;
 
+  // --- Exempt glob anchoring (#2921): patterns must not match arbitrary suffixes ---
+  clearState();
+  if (
+    test('does NOT exempt a partial-segment match: services/** must not match my-services/ (#2921)', () => {
+      const input = {
+        tool_name: 'Edit',
+        tool_input: { file_path: '/proj/my-services/x.js', old_string: 'a', new_string: 'b' }
+      };
+      const result = runHook(input, { GATEGUARD_EXEMPT_GLOBS: 'services/**' });
+      const output = parseOutput(result.stdout);
+      assert.ok(output, 'should produce JSON output');
+      assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny', 'unanchored suffix match is fixed by boundary anchoring');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('exempts a segment-boundary match for the same glob: services/** in any repo', () => {
+      const input = {
+        tool_name: 'Edit',
+        tool_input: { file_path: '/proj/services/x.js', old_string: 'a', new_string: 'b' }
+      };
+      const result = runHook(input, { GATEGUARD_EXEMPT_GLOBS: 'services/**' });
+      const output = parseOutput(result.stdout);
+      assert.ok(output, 'should produce JSON output');
+      if (output.hookSpecificOutput) {
+        assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny', 'segment-boundary path stays exempt');
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('does NOT exempt a path where the glob name is only a directory component: *.md (#2921)', () => {
+      const input = {
+        tool_name: 'Write',
+        tool_input: { file_path: '/proj/notes.md/outline.txt', content: 'x' }
+      };
+      const result = runHook(input, { GATEGUARD_EXEMPT_GLOBS: '*.md' });
+      const output = parseOutput(result.stdout);
+      assert.ok(output, 'should produce JSON output');
+      assert.strictEqual(output.hookSpecificOutput.permissionDecision, 'deny', 'end-anchored glob must not match a mid-path .md directory');
+    })
+  )
+    passed++;
+  else failed++;
+
+  clearState();
+  if (
+    test('lowercases patterns so uppercase globs are not silently dead: README.md (#2921)', () => {
+      const input = {
+        tool_name: 'Write',
+        tool_input: { file_path: '/proj/readme.md', content: 'x' }
+      };
+      const result = runHook(input, { GATEGUARD_EXEMPT_GLOBS: 'README.md' });
+      const output = parseOutput(result.stdout);
+      assert.ok(output, 'should produce JSON output');
+      if (output.hookSpecificOutput) {
+        assert.notStrictEqual(output.hookSpecificOutput.permissionDecision, 'deny', 'pattern case must not break matching');
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
   // Cleanup only the temp directory created by this test file.
   try {
     if (fs.existsSync(stateDir)) {


### PR DESCRIPTION
## Summary

Exempt globs compiled to unanchored regexes tested against the whole absolute path, so a repo-relative pattern silently exempted matching paths anywhere on the machine — this fails open:

- `services/**` matched `/any/other/repo/services/x` and a nested `vendor/foo/services/x`
- `*.md` matched every markdown file at any depth, outside any repository
- `api/` also matched `my-api/` (partial-segment match)
- the `$`-anchor stops a glob name from matching as a mid-path directory component (`/proj/notes.md/outline.txt` under `*.md`)

The fix anchors compiled patterns with `(^|/)` … `$` so they behave as segment-boundary-anchored path matches, and lowercases the glob alongside the already-lowercased candidate path so uppercase patterns (`README.md`) are not silently dead.

`GATEGUARD_BASH_EXTRA_DESTRUCTIVE` stays unanchored on purpose: it is a raw operator regex where unanchored fails closed. Scope remains limited to the first-touch Edit/Write/MultiEdit gate — destructive-Bash checks never consult `isExemptPath`.

## Verification

Four regression tests mirroring the issue probe in `tests/hooks/gateguard-fact-force.test.js`: 178/178 pass with the fix; the 3 new anchor/case tests fail on `main` (plus one positive boundary test).