### PR TITLE
fix(uninstall): honor global --dry-run and phrase previews conditionally

### DIFF
--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -61,10 +61,15 @@ function printHuman(result) {
     return;
   }
 
-  console.log('Uninstall summary:\n');
+  // Dry-run output must be phrased as a preview so it can never be mistaken
+  // for a completed uninstall (#2952).
+  console.log(`Uninstall summary${result.dryRun ? ' (dry run — nothing was removed)' : ''}:\n`);
   for (const entry of result.results) {
     console.log(`- ${entry.adapter.id}`);
-    console.log(`  Status: ${entry.status.toUpperCase()}`);
+    const statusLabel = result.dryRun && entry.status === 'planned'
+      ? 'WOULD UNINSTALL (dry run)'
+      : entry.status.toUpperCase();
+    console.log(`  Status: ${statusLabel}`);
     console.log(`  Install-state: ${entry.installStatePath}`);
 
     if (entry.error) {
@@ -84,10 +89,10 @@ function printHuman(result) {
 
     const candidatePaths = result.dryRun ? entry.plannedRemovals : entry.removedPaths;
     const paths = Array.isArray(candidatePaths) ? candidatePaths : [];
-    console.log(`  ${result.dryRun ? 'Planned removals' : 'Removed paths'}: ${paths.length}`);
+    console.log(`  ${result.dryRun ? 'Would remove' : 'Removed paths'}: ${paths.length}`);
   }
 
-  console.log(`\nSummary: checked=${result.summary.checkedCount}, ${result.dryRun ? 'planned' : 'uninstalled'}=${result.dryRun ? result.summary.plannedRemovalCount : result.summary.uninstalledCount}, partial=${result.summary.partialCount}, errors=${result.summary.errorCount}`);
+  console.log(`\nSummary${result.dryRun ? ' (dry run)' : ''}: checked=${result.summary.checkedCount}, ${result.dryRun ? 'planned' : 'uninstalled'}=${result.dryRun ? result.summary.plannedRemovalCount : result.summary.uninstalledCount}, partial=${result.summary.partialCount}, errors=${result.summary.errorCount}`);
 
   if (!result.dryRun) {
     console.log(`\n${exitFeedbackLines().join('\n')}`);
@@ -114,6 +119,16 @@ function codexHomePath() {
   return process.env.CODEX_HOME || path.join(process.env.HOME || os.homedir(), '.codex');
 }
 
+/**
+ * Dry-run is enabled either by the subcommand-level `--dry-run` flag or by the
+ * global `ecc --dry-run <command>` prefix, which sets ECC_DRY_RUN=1 (#2952).
+ * Destructive subcommands must honor both forms rather than silently ignoring
+ * the global flag.
+ */
+function isDryRun(options) {
+  return options.dryRun || process.env.ECC_DRY_RUN === '1';
+}
+
 function includesCodexTarget(targets) {
   return targets.length === 0 || targets.includes('codex');
 }
@@ -125,6 +140,8 @@ async function main() {
       showHelp(0);
     }
 
+    const dryRun = isDryRun(options);
+
     if (options.legacyCodexSync && options.targets.length > 0) {
       throw new Error('--legacy-codex-sync cannot be combined with --target');
     }
@@ -135,7 +152,7 @@ async function main() {
     if (options.legacyCodexSync) {
       result = uninstallLegacyCodexSync({
         codexHome: codexHomePath(),
-        dryRun: options.dryRun,
+        dryRun,
       });
       mode = 'legacy-codex-sync';
     } else {
@@ -144,7 +161,7 @@ async function main() {
         env: process.env,
         projectRoot: process.cwd(),
         targets: options.targets,
-        dryRun: options.dryRun,
+        dryRun,
       });
 
       if (
@@ -154,12 +171,12 @@ async function main() {
       ) {
         result = uninstallLegacyCodexSync({
           codexHome: codexHomePath(),
-          dryRun: options.dryRun,
+          dryRun,
         });
         mode = 'legacy-codex-sync';
       }
 
-      if (mode === 'install-state' && !options.dryRun) {
+      if (mode === 'install-state' && !dryRun) {
         const { reconcileCanonicalInstallStates } = require('./lib/install-state-store-sync');
         result.installStateProjection = await reconcileCanonicalInstallStates({
           homeDir: process.env.HOME || os.homedir(),
@@ -177,7 +194,7 @@ async function main() {
     if (options.json) {
       console.log(JSON.stringify(result, null, 2));
     } else if (mode === 'legacy-codex-sync') {
-      printLegacy(result, options.dryRun);
+      printLegacy(result, dryRun);
     } else {
       printHuman(result);
     }

--- a/tests/scripts/uninstall.test.js
+++ b/tests/scripts/uninstall.test.js
@@ -47,9 +47,10 @@ function writeState(filePath, options) {
 }
 
 function run(args = [], options = {}) {
-  const env = options.homeDir
+  const baseEnv = options.homeDir
     ? { ...process.env, HOME: options.homeDir, CODEX_HOME: path.join(options.homeDir, '.codex') }
-    : Object.fromEntries(Object.entries(process.env).filter(([key]) => key !== 'CODEX_HOME'))
+    : Object.fromEntries(Object.entries(process.env).filter(([key]) => key !== 'CODEX_HOME'));
+  const env = { ...baseEnv, ...(options.env || {}) };
 
   try {
     const stdout = execFileSync('node', [SCRIPT, ...args], {
@@ -285,6 +286,138 @@ function runTests() {
       assert.ok(parsed.results[0].plannedRemovals.includes(renderedPath));
       assert.ok(fs.existsSync(renderedPath));
       assert.ok(fs.existsSync(statePath));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  // #2952: the global `ecc --dry-run uninstall` prefix sets ECC_DRY_RUN=1.
+  // The uninstaller must honor it exactly like the subcommand-level flag.
+  if (test('honors global ECC_DRY_RUN=1 without mutating managed files (#2952)', () => {
+    const homeDir = createTempDir('uninstall-home-');
+    const projectRoot = createTempDir('uninstall-project-');
+
+    try {
+      const targetRoot = path.join(projectRoot, '.cursor');
+      fs.mkdirSync(targetRoot, { recursive: true });
+      const normalizedTargetRoot = fs.realpathSync(targetRoot);
+      const statePath = path.join(normalizedTargetRoot, 'ecc-install-state.json');
+      const renderedPath = path.join(normalizedTargetRoot, 'generated.md');
+      fs.writeFileSync(renderedPath, '# generated\n');
+
+      writeState(statePath, {
+        adapter: { id: 'cursor-project', target: 'cursor', kind: 'project' },
+        targetRoot: normalizedTargetRoot,
+        installStatePath: statePath,
+        request: {
+          profile: null,
+          modules: ['platform-configs'],
+          includeComponents: [],
+          excludeComponents: [],
+          legacyLanguages: [],
+          legacyMode: false,
+        },
+        resolution: {
+          selectedModules: ['platform-configs'],
+          skippedModules: [],
+        },
+        operations: [
+          {
+            kind: 'render-template',
+            moduleId: 'platform-configs',
+            sourceRelativePath: '.cursor/generated.md.template',
+            destinationPath: renderedPath,
+            strategy: 'render-template',
+            ownership: 'managed',
+            scaffoldOnly: false,
+            renderedContent: '# generated\n',
+          },
+        ],
+        source: {
+          repoVersion: CURRENT_PACKAGE_VERSION,
+          repoCommit: 'abc123',
+          manifestVersion: CURRENT_MANIFEST_VERSION,
+        },
+      });
+
+      // No --dry-run flag: the global flag form must still be a no-op.
+      const uninstallResult = run(['--target', 'cursor', '--json'], {
+        cwd: projectRoot,
+        homeDir,
+        env: { ECC_DRY_RUN: '1' },
+      });
+      assert.strictEqual(uninstallResult.code, 0, uninstallResult.stderr);
+
+      const parsed = JSON.parse(uninstallResult.stdout);
+      assert.strictEqual(parsed.dryRun, true, 'ECC_DRY_RUN=1 must enable dry-run mode');
+      assert.ok(parsed.results[0].plannedRemovals.includes(renderedPath));
+      assert.ok(fs.existsSync(renderedPath), 'managed file must survive the dry run');
+      assert.ok(fs.existsSync(statePath), 'install-state must survive the dry run');
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectRoot);
+    }
+  })) passed++; else failed++;
+
+  if (test('phrases dry-run human output as an unmistakable preview (#2952)', () => {
+    const homeDir = createTempDir('uninstall-home-');
+    const projectRoot = createTempDir('uninstall-project-');
+
+    try {
+      const targetRoot = path.join(projectRoot, '.cursor');
+      fs.mkdirSync(targetRoot, { recursive: true });
+      const normalizedTargetRoot = fs.realpathSync(targetRoot);
+      const statePath = path.join(normalizedTargetRoot, 'ecc-install-state.json');
+      const renderedPath = path.join(normalizedTargetRoot, 'generated.md');
+      fs.writeFileSync(renderedPath, '# generated\n');
+
+      writeState(statePath, {
+        adapter: { id: 'cursor-project', target: 'cursor', kind: 'project' },
+        targetRoot: normalizedTargetRoot,
+        installStatePath: statePath,
+        request: {
+          profile: null,
+          modules: ['platform-configs'],
+          includeComponents: [],
+          excludeComponents: [],
+          legacyLanguages: [],
+          legacyMode: false,
+        },
+        resolution: {
+          selectedModules: ['platform-configs'],
+          skippedModules: [],
+        },
+        operations: [
+          {
+            kind: 'render-template',
+            moduleId: 'platform-configs',
+            sourceRelativePath: '.cursor/generated.md.template',
+            destinationPath: renderedPath,
+            strategy: 'render-template',
+            ownership: 'managed',
+            scaffoldOnly: false,
+            renderedContent: '# generated\n',
+          },
+        ],
+        source: {
+          repoVersion: CURRENT_PACKAGE_VERSION,
+          repoCommit: 'abc123',
+          manifestVersion: CURRENT_MANIFEST_VERSION,
+        },
+      });
+
+      const uninstallResult = run(['--target', 'cursor', '--dry-run'], {
+        cwd: projectRoot,
+        homeDir,
+      });
+      assert.strictEqual(uninstallResult.code, 0, uninstallResult.stderr);
+
+      assert.ok(uninstallResult.stdout.includes('dry run'), 'summary header must carry the dry-run marker');
+      assert.ok(uninstallResult.stdout.includes('WOULD UNINSTALL (dry run)'), 'status must use conditional wording');
+      assert.ok(uninstallResult.stdout.includes('Would remove:'), 'path count must use conditional wording');
+      assert.ok(!uninstallResult.stdout.includes('Status: UNINSTALLED'), 'dry run must not claim UNINSTALLED');
+      assert.ok(!uninstallResult.stdout.includes('Removed paths:'), 'dry run must not claim removal');
     } finally {
       cleanup(homeDir);
       cleanup(projectRoot);


### PR DESCRIPTION
## Summary

`ecc --dry-run uninstall` ignored the global `--dry-run` flag (`ECC_DRY_RUN=1`) and permanently deleted all managed files while reporting `Status: UNINSTALLED / Removed paths: N` — a data-loss trap where a dry run was textually indistinguishable from a real one.

- `uninstall.js` now honors `ECC_DRY_RUN=1` in addition to the subcommand-level `--dry-run` flag, matching the existing `ito.js` / `memory.js` convention
- human output uses conditional wording for previews: `Uninstall summary (dry run — nothing was removed)`, `Status: WOULD UNINSTALL (dry run)`, `Would remove: N`
- JSON output is unchanged (machine contract): status stays `planned`

## Verification

Regression tests in `tests/scripts/uninstall.test.js`:

- `ECC_DRY_RUN=1` without the flag performs no filesystem changes and reports `dryRun: true`
- dry-run human output never claims removal (`Status: UNINSTALLED` / `Removed paths:` absent)
- full suite: 11/11 pass with the fix; the 2 new tests fail on `main`

Severity note: this was reported as data loss (807 files deleted by a preview); recovery required a full reinstall.