### PR TITLE
fix(install): skip user-owned destinations instead of overwriting them

### DIFF
--- a/scripts/lib/install-targets/antigravity-project.js
+++ b/scripts/lib/install-targets/antigravity-project.js
@@ -23,6 +23,10 @@ module.exports = createInstallTargetAdapter({
   kind: 'project',
   rootSegments: ['.agents'],
   installStatePathSegments: ['ecc-install-state.json'],
+  // #2964: first adapter to adopt the user-owned-file ownership guard. Existing
+  // .agents files that ECC did not install are skipped with a warning instead
+  // of being overwritten and recorded as managed.
+  preserveUserOwnedFiles: true,
   supportsModule(module) {
     const paths = Array.isArray(module && module.paths) ? module.paths : [];
     return paths.length > 0;

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -260,6 +260,10 @@ function createInstallTargetAdapter(config) {
     target: config.target,
     kind: config.kind,
     nativeRootRelativePath: config.nativeRootRelativePath || null,
+    // #2964: opt-in ownership guard. When true, the installer skips copy-file
+    // operations whose destination already exists but is not recorded in ECC
+    // install-state, instead of overwriting the file and claiming ownership.
+    preserveUserOwnedFiles: Boolean(config.preserveUserOwnedFiles),
     supports(target) {
       return target === config.target || target === config.id;
     },

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -17,6 +17,7 @@ const {
   prepareClaudeSkillMigration,
   removeLegacyClaudeSkillFiles,
 } = require('./claude-skill-migration');
+const { prepareUserOwnedFileGuard } = require('./ownership-guard');
 const { cleanupLegacyAntigravityInstall } = require('./antigravity-legacy-migration');
 const { cleanupLegacyOpencodeInstall } = require('./opencode-legacy-migration');
 const { buildInstallIndex, rewriteRelativeLinks } = require('./link-rewrite');
@@ -335,7 +336,7 @@ function buildResolvedClaudeHooks(plan) {
 }
 
 function previewInstallPlan(plan) {
-  const migration = prepareClaudeSkillMigration(plan);
+  const migration = prepareUserOwnedFileGuard(plan, prepareClaudeSkillMigration(plan));
   const hookConsentWarnings = planMaterializesHookRuntime(plan) && plan.hookConsent !== 'enabled'
     ? ['Applying this plan requires an explicit hook decision: --enable-hooks or --no-hooks.']
     : [];
@@ -363,7 +364,7 @@ function applyInstallPlan(plan, dependencies = {}) {
   if (typeof beforeInstallStateRead === 'function') {
     beforeInstallStateRead({ plan });
   }
-  const migration = prepareClaudeSkillMigration(plan);
+  const migration = prepareUserOwnedFileGuard(plan, prepareClaudeSkillMigration(plan));
   const appliedPlan = {
     ...plan,
     operations: migration.appliedOperations,

--- a/scripts/lib/install/ownership-guard.js
+++ b/scripts/lib/install/ownership-guard.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const { readInstallState } = require('../install-state');
+
+function pathExists(filePath) {
+  try {
+    fs.lstatSync(filePath);
+    return true;
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function comparablePath(filePath) {
+  const resolvedPath = path.resolve(filePath);
+  return process.platform === 'win32' ? resolvedPath.toLowerCase() : resolvedPath;
+}
+
+/**
+ * #2964: the shared copy path used to write every copy-file operation
+ * unconditionally and record the destination as `ownership: 'managed'` even
+ * when the file already existed and was authored by the user. The visible
+ * symptom is a lost edit; the dangerous one is the install-state record,
+ * which makes a later uninstall delete the user's file.
+ *
+ * This guard generalises the Claude flat-skill migration conflict pattern to
+ * every adapter copy operation: when a destination exists and is NOT recorded
+ * as an ECC-managed operation in the previous install-state, the operation is
+ * skipped with a warning instead of overwriting and claiming ownership.
+ *
+ * It is opt-in per adapter via `preserveUserOwnedFiles` (default off) so the
+ * eleven shipping targets can adopt it individually (#2964).
+ */
+function prepareUserOwnedFileGuard(plan, migration) {
+  const adapter = plan && plan.adapter;
+  if (!adapter || !adapter.preserveUserOwnedFiles) {
+    return migration;
+  }
+
+  const previousState = pathExists(plan.installStatePath)
+    ? readInstallState(plan.installStatePath)
+    : null;
+  const managedDestinations = new Set(
+    ((previousState && previousState.operations) || [])
+      .filter(operation => (
+        operation
+        && operation.ownership === 'managed'
+        && operation.destinationPath
+      ))
+      .map(operation => comparablePath(operation.destinationPath))
+  );
+
+  const appliedOperations = [];
+  const skippedOperations = [];
+  const warnings = [];
+  for (const operation of (migration && migration.appliedOperations) || []) {
+    if (
+      operation
+      && operation.kind === 'copy-file'
+      && operation.destinationPath
+      && pathExists(operation.destinationPath)
+      && !managedDestinations.has(comparablePath(operation.destinationPath))
+    ) {
+      skippedOperations.push(operation);
+      warnings.push(
+        `Skipped user-owned file ${operation.destinationPath}: the existing file is not recorded in ECC install-state.`
+      );
+      continue;
+    }
+    appliedOperations.push(operation);
+  }
+
+  if (skippedOperations.length === 0) {
+    return migration;
+  }
+
+  const skippedDestinations = new Set(
+    skippedOperations.map(operation => comparablePath(operation.destinationPath))
+  );
+  const filterStateOperations = operations => (operations || [])
+    .filter(operation => !skippedDestinations.has(comparablePath(operation.destinationPath)));
+
+  // Never leave a skipped destination inside the install-state: recording it
+  // would claim ownership of a file ECC did not create and make uninstall
+  // delete it (#2964).
+  const bridgeState = migration.bridgeState
+    ? {
+      ...migration.bridgeState,
+      operations: filterStateOperations(migration.bridgeState.operations),
+    }
+    : migration.bridgeState;
+  const finalState = migration.finalState
+    ? {
+      ...migration.finalState,
+      operations: filterStateOperations(migration.finalState.operations),
+    }
+    : migration.finalState;
+
+  return {
+    ...migration,
+    appliedOperations,
+    skippedOperations: [
+      ...((migration && migration.skippedOperations) || []),
+      ...skippedOperations,
+    ],
+    warnings: [...((migration && migration.warnings) || []), ...warnings],
+    bridgeState,
+    finalState,
+    // Only keep bridge persistence when operations actually remain; a fully
+    // skipped plan installs nothing and must not claim anything.
+    requiresBridgeState: Boolean(migration.requiresBridgeState)
+      && appliedOperations.length > 0,
+  };
+}
+
+module.exports = {
+  prepareUserOwnedFileGuard,
+};

--- a/scripts/lib/install/plan.js
+++ b/scripts/lib/install/plan.js
@@ -292,7 +292,10 @@ function createManifestInstallPlan(options = {}) {
     adapter: {
       id: adapter.id,
       target: adapter.target,
-      kind: adapter.kind
+      kind: adapter.kind,
+      // #2964: propagate the opt-in ownership-guard flag so apply/preview can
+      // skip user-owned destinations instead of overwriting them.
+      preserveUserOwnedFiles: Boolean(adapter.preserveUserOwnedFiles)
     },
     homeDir: plan.homeDir,
     targetRoot: plan.targetRoot,

--- a/tests/scripts/ownership-guard.test.js
+++ b/tests/scripts/ownership-guard.test.js
@@ -1,0 +1,150 @@
+/**
+ * Regression tests for #2964: the installer must not overwrite project-authored
+ * files at managed destinations, and must not record overwritten paths as
+ * `ownership: "managed"`.
+ *
+ * The ownership guard is adapter opt-in (`preserveUserOwnedFiles`); the
+ * antigravity adapter is the first adopter, so these tests drive
+ * scripts/install-apply.js with `--target antigravity` and a narrow module set
+ * that produces `.agents/agents/architect.md`.
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const repoRoot = path.join(__dirname, '..', '..');
+const installScript = path.join(repoRoot, 'scripts', 'install-apply.js');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  \u2713 ${name}`);
+    passed++;
+  } catch (error) {
+    console.log(`  \u2717 ${name}`);
+    console.log(`    Error: ${error.message}`);
+    failed++;
+  }
+}
+
+function createTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function cleanup(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+}
+
+function runInstall(projectRoot, extraArgs = []) {
+  return execFileSync('node', [installScript, '--target', 'antigravity', '--modules', 'agents-core', ...extraArgs], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 120000,
+  });
+}
+
+function readState(projectRoot) {
+  return JSON.parse(fs.readFileSync(
+    path.join(projectRoot, '.agents', 'ecc-install-state.json'),
+    'utf8'
+  ));
+}
+
+function stateRecordsDestination(state, destinationPath) {
+  const resolved = path.resolve(destinationPath).toLowerCase();
+  return (state.operations || []).some(operation => (
+    operation.destinationPath
+    && path.resolve(operation.destinationPath).toLowerCase() === resolved
+  ));
+}
+
+function test1() {
+  const projectRoot = createTempDir('ownership-guard-user-file-');
+  try {
+    const userFilePath = path.join(projectRoot, '.agents', 'agents', 'architect.md');
+    fs.mkdirSync(path.dirname(userFilePath), { recursive: true });
+    fs.writeFileSync(userFilePath, 'MY OWN USER FILE - DO NOT OVERWRITE\n');
+
+    const stdout = runInstall(projectRoot);
+
+    assert.strictEqual(
+      fs.readFileSync(userFilePath, 'utf8'),
+      'MY OWN USER FILE - DO NOT OVERWRITE\n',
+      'user-authored file must survive the install untouched'
+    );
+    assert.ok(
+      stdout.includes('Skipped user-owned file'),
+      'install output must explain the skipped user-owned file'
+    );
+    assert.strictEqual(
+      stateRecordsDestination(readState(projectRoot), userFilePath),
+      false,
+      'install-state must not claim ownership of the user-authored file'
+    );
+  } finally {
+    cleanup(projectRoot);
+  }
+}
+
+function test2() {
+  const projectRoot = createTempDir('ownership-guard-fresh-');
+  try {
+    runInstall(projectRoot);
+
+    const installedPath = path.join(projectRoot, '.agents', 'agents', 'architect.md');
+    assert.ok(fs.existsSync(installedPath), 'fresh install must still install the agent file');
+
+    const state = readState(projectRoot);
+    assert.ok(
+      stateRecordsDestination(state, installedPath),
+      'freshly installed file must be recorded in install-state'
+    );
+    assert.strictEqual(
+      (state.operations || []).find(operation => (
+        operation.destinationPath
+        && path.resolve(operation.destinationPath) === path.resolve(installedPath)
+      )).ownership,
+      'managed',
+      'freshly installed file must be owned by ECC'
+    );
+  } finally {
+    cleanup(projectRoot);
+  }
+}
+
+function test3() {
+  const projectRoot = createTempDir('ownership-guard-reinstall-');
+  try {
+    runInstall(projectRoot);
+    const installedPath = path.join(projectRoot, '.agents', 'agents', 'architect.md');
+    fs.unlinkSync(installedPath);
+
+    // Second install over an ECC-managed path (recorded in install-state) is
+    // an upgrade, not an ownership conflict: it must reinstall the file.
+    runInstall(projectRoot);
+
+    assert.ok(fs.existsSync(installedPath), 'managed reinstall must restore the removed file');
+    assert.ok(
+      stateRecordsDestination(readState(projectRoot), installedPath),
+      'managed reinstall keeps ownership recorded'
+    );
+  } finally {
+    cleanup(projectRoot);
+  }
+}
+
+console.log('\n=== Testing install ownership guard (#2964) ===\n');
+
+test('skips user-authored destinations without recording ownership (#2964)', test1);
+test('installs normally when the destination does not exist (#2964)', test2);
+test('still reinstalls over an ECC-managed destination (#2964)', test3);
+
+console.log(`\n  ${passed} passed, ${failed} failed\n`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

The shared copy path wrote every `copy-file` operation unconditionally and recorded the destination as `ownership: "managed"` even when the file already existed and was authored by the user. The lost edit is the visible symptom; the dangerous one is the install-state record, which makes a later uninstall delete the user's file.

This generalises the existing Claude flat-skill conflict pattern (`assertSafeClaudeSkillOperation` / `prepareClaudeSkillMigration`) into a new opt-in ownership guard:

- new `scripts/lib/install/ownership-guard.js`: when a `copy-file` destination exists and is **not** recorded as a managed operation in the previous install-state, skip it with a warning instead of overwriting and claiming ownership; skipped destinations are removed from `appliedOperations` **and** from bridge/final install-state, so uninstall never sees them
- new adapter opt-in flag `preserveUserOwnedFiles` (default off, propagated through `createInstallTargetAdapter` → plan) so the eleven shipping targets can adopt individually — `antigravity-project` is the first adopter
- wired into both `previewInstallPlan` and `applyInstallPlan`

## Verification

New `tests/scripts/ownership-guard.test.js` drives the real installer CLI on antigravity:

- user-authored `.agents/agents/architect.md` survives install untouched, no state record, warning emitted (fails on `main`)
- fresh installs still install and record the file as `managed`
- managed reinstalls (destination recorded in install-state) still update files

Also green: `install-apply` 40, `install-lifecycle` 57, `dry-run` 12, `install-plan` 11, `install-plan-boundary` 3, `install-claude-skill-migration` 17, `install-targets` 51.