### PR TITLE
feat: map FastAPI projects to fastapi-patterns and api-design

### DIFF
--- a/config/project-stack-mappings.json
+++ b/config/project-stack-mappings.json
@@ -486,6 +486,34 @@
       }
     },
     {
+      "id": "fastapi",
+      "name": "FastAPI (Python)",
+      "indicators": [
+        { "file": "requirements.txt", "contains": "fastapi" },
+        { "file": "pyproject.toml", "contains": "fastapi" }
+      ],
+      "rules": ["common", "python"],
+      "skills": [
+        "fastapi-patterns",
+        "api-design",
+        "python-patterns",
+        "python-testing",
+        "tdd-workflow",
+        "verification-loop"
+      ],
+      "commands": {
+        "build": ["pip install -e ."],
+        "test": ["pytest", "python -m pytest"],
+        "lint": ["ruff check .", "mypy ."],
+        "format": ["ruff format .", "black ."],
+        "dev": ["uvicorn main:app --reload", "fastapi dev"]
+      },
+      "permissions": {
+        "allow": ["python *", "pip install *", "pytest *", "ruff *", "black *", "mypy *", "uvicorn *"],
+        "deny": []
+      }
+    },
+    {
       "id": "android",
       "name": "Android (Kotlin/Java)",
       "indicators": [


### PR DESCRIPTION
## What Changed

Adds a `fastapi` stack entry to `config/project-stack-mappings.json`, placed beside the existing `django` entry.

It resolves to skills that already ship in this repo:

- `fastapi-patterns`
- `api-design`
- `python-patterns`, `python-testing`, `tdd-workflow`, `verification-loop`

Indicators follow the `django` pattern — `fastapi` appearing in `requirements.txt` or `pyproject.toml`. Commands cover `uvicorn main:app --reload` and `fastapi dev`, with `uvicorn *` added to the allow list.

## Why This Change

`skills/fastapi-patterns/` and the `fastapi-reviewer` agent both ship today, but nothing routed to them. With no `fastapi` entry, `/project-init` matched FastAPI projects on the generic `python` indicators (`pyproject.toml`, `requirements.txt`) and stopped there — so a FastAPI project got `python-patterns` and never the FastAPI skill written for it.

There is a second effect on install size. Because `coding-standards`/`frontend-patterns`/`backend-patterns` resolve through the coarse `framework-language` module, a generic-Python plan pulls that whole bundle (android, angular, cpp, csharp, dart, dotnet, laravel, perl, quarkus, springboot…). Requesting `fastapi-patterns` and `api-design` instead resolves to their own narrow modules — on the repo I tested this against, 13 modules dropped to 7.

## Testing Done

- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`) — **4159 passed, 0 failed**
- [x] Edge cases considered and tested

Verified on a real FastAPI + Next.js codebase:

- JSON parses; `stacks` goes 20 → 21
- All 6 referenced skill directories and both rule directories resolve on disk
- Both indicators match (`fastapi` present in `requirements.txt` and `pyproject.toml`)
- `install-plan.js --skills fastapi-patterns,api-design,…` resolves cleanly

## Type of Change

- [x] `feat:` New feature

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (n/a — no shell changed)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Notes for reviewers

Data-only. No code reads `project-stack-mappings.json` — `grep -rln project-stack-mappings` returns only `commands/project-init.md` and its ja-JP translation, so this changes what `/project-init` detects, not installer behaviour. No new skill, command, agent or hook is added, so the registration/catalog checklist does not apply.

Placement next to `django` is by convention only; entries are not evaluated in order.
