### PR TITLE
chore(skills): declare license and agent compatibility in skill frontmatter

### DIFF
--- a/skills/accessibility/SKILL.md
+++ b/skills/accessibility/SKILL.md
@@ -4,6 +4,8 @@ description: Design, implement, and audit inclusive digital products using WCAG 
   standards. Use this skill to generate semantic ARIA for Web and accessibility traits for Web and Native platforms (iOS/Android).
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Accessibility (WCAG 2.2)

--- a/skills/agent-architecture-audit/SKILL.md
+++ b/skills/agent-architecture-audit/SKILL.md
@@ -4,6 +4,8 @@ description: Full-stack diagnostic for agent and LLM applications. Audits the 12
 metadata:
   origin: oh-my-agent-check
 tools: Read, Write, Edit, Bash, Grep, Glob
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Agent Architecture Audit

--- a/skills/agent-eval/SKILL.md
+++ b/skills/agent-eval/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 metadata:
   origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
+compatibility: [claude-code, codex]
 ---
 
 # Agent Eval Skill

--- a/skills/agent-harness-construction/SKILL.md
+++ b/skills/agent-harness-construction/SKILL.md
@@ -3,6 +3,8 @@ name: agent-harness-construction
 description: Design and optimize AI agent action spaces, tool definitions, and observation formatting for higher completion rates. Use when defining or revising an agent's tool set, action space, or observation format.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Agent Harness Construction

--- a/skills/agent-introspection-debugging/SKILL.md
+++ b/skills/agent-introspection-debugging/SKILL.md
@@ -3,6 +3,8 @@ name: agent-introspection-debugging
 description: Structured self-debugging workflow for AI agent failures using capture, diagnosis, contained recovery, and introspection reports. Use when an agent run fails and you need a reproducible diagnosis instead of a retry.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Agent Introspection Debugging

--- a/skills/agent-payment-x402/SKILL.md
+++ b/skills/agent-payment-x402/SKILL.md
@@ -3,6 +3,8 @@ name: agent-payment-x402
 description: Add x402 payment execution to AI agents with per-task budgets, spending controls, and non-custodial wallets. Supports Base through agentwallet-sdk and X Layer through OKX Payments / OKX Agent Payments Protocol. Use when an agent must pay for something itself and needs per-task budgets, spending controls, and a non-custodial wallet.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Agent Payment Execution (x402)

--- a/skills/agent-self-evaluation/SKILL.md
+++ b/skills/agent-self-evaluation/SKILL.md
@@ -2,6 +2,8 @@
 name: agent-self-evaluation
 description: Use after completing any non-trivial task. The agent self-rates its output on 5 axes — accuracy, completeness, clarity, actionability, conciseness — with concrete evidence per criterion. Produces a structured 1-5 scorecard with specific improvement suggestions.
 origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Agent Self-Evaluation

--- a/skills/agent-sort/SKILL.md
+++ b/skills/agent-sort/SKILL.md
@@ -3,6 +3,8 @@ name: agent-sort
 description: Build an evidence-backed ECC install plan for a specific repo by sorting skills, commands, rules, hooks, and extras into DAILY vs LIBRARY buckets using parallel repo-aware review passes. Use when ECC should be trimmed to what a project actually needs instead of loading the full bundle.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Agent Sort

--- a/skills/agentic-engineering/SKILL.md
+++ b/skills/agentic-engineering/SKILL.md
@@ -3,6 +3,8 @@ name: agentic-engineering
 description: Operate as an agentic engineer using eval-first execution, decomposition, and cost-aware model routing. Use when planning or executing engineering work that agents will carry out end to end.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Agentic Engineering

--- a/skills/agentic-os/SKILL.md
+++ b/skills/agentic-os/SKILL.md
@@ -3,6 +3,8 @@ name: agentic-os
 description: Build persistent multi-agent operating systems on Claude Code. Covers kernel architecture, specialist agents, slash commands, file-based memory, scheduled automation, and state management without external databases. Use when building a persistent multi-agent system on Claude Code with its own memory, commands, and scheduling.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Agentic OS

--- a/skills/ai-first-engineering/SKILL.md
+++ b/skills/ai-first-engineering/SKILL.md
@@ -3,6 +3,8 @@ name: ai-first-engineering
 description: Engineering operating model for teams where AI agents generate a large share of implementation output. Use when setting team process, review gates, or ownership rules for a codebase largely written by agents.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # AI-First Engineering

--- a/skills/ai-regression-testing/SKILL.md
+++ b/skills/ai-regression-testing/SKILL.md
@@ -3,6 +3,8 @@ name: ai-regression-testing
 description: Regression testing strategies for AI-assisted development. Sandbox-mode API testing without database dependencies, automated bug-check workflows, and patterns to catch AI blind spots where the same model writes and reviews code. Use when adding regression coverage to AI-assisted code, or when the same model both wrote and reviewed a change.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # AI Regression Testing

--- a/skills/android-clean-architecture/SKILL.md
+++ b/skills/android-clean-architecture/SKILL.md
@@ -3,6 +3,8 @@ name: android-clean-architecture
 description: Clean Architecture patterns for Android and Kotlin Multiplatform projects — module structure, dependency rules, UseCases, Repositories, and data layer patterns. Use when structuring modules, layers, or data flow in an Android or KMP project.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Android Clean Architecture

--- a/skills/angular-developer/SKILL.md
+++ b/skills/angular-developer/SKILL.md
@@ -3,6 +3,8 @@ name: angular-developer
 description: Generates Angular code and provides architectural guidance. Trigger when creating projects, components, or services, or for best practices on reactivity (signals, linkedSignal, resource), forms, dependency injection, routing, SSR, accessibility (ARIA), animations, styling (component styles, Tailwind CSS), testing, or CLI tooling.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Angular Developer Guidelines

--- a/skills/api-connector-builder/SKILL.md
+++ b/skills/api-connector-builder/SKILL.md
@@ -4,6 +4,8 @@ description: Build a new API connector or provider by matching the target repo's
 metadata:
   version: "1.0.0"
   origin: ECC direct-port adaptation
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # API Connector Builder

--- a/skills/api-design/SKILL.md
+++ b/skills/api-design/SKILL.md
@@ -3,6 +3,8 @@ name: api-design
 description: REST API design patterns including resource naming, status codes, pagination, filtering, error responses, versioning, and rate limiting for production APIs. Use when designing or reviewing REST endpoints, resource names, status codes, pagination, or versioning.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # API Design Patterns

--- a/skills/architecture-decision-records/SKILL.md
+++ b/skills/architecture-decision-records/SKILL.md
@@ -3,6 +3,8 @@ name: architecture-decision-records
 description: Capture architectural decisions made during Claude Code sessions as structured ADRs. Auto-detects decision moments, records context, alternatives considered, and rationale. Maintains an ADR log so future developers understand why the codebase is shaped the way it is.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Architecture Decision Records

--- a/skills/article-writing/SKILL.md
+++ b/skills/article-writing/SKILL.md
@@ -3,6 +3,8 @@ name: article-writing
 description: Write articles, guides, blog posts, tutorials, newsletter issues, and other long-form content in a distinctive voice derived from supplied examples or brand guidance. Use when the user wants polished written content longer than a paragraph, especially when voice consistency, structure, and credibility matter.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Article Writing

--- a/skills/automation-audit-ops/SKILL.md
+++ b/skills/automation-audit-ops/SKILL.md
@@ -3,6 +3,8 @@ name: automation-audit-ops
 description: Evidence-first automation inventory and overlap audit workflow for ECC. Use when the user wants to know which jobs, hooks, connectors, MCP servers, or wrappers are live, broken, redundant, or missing before fixing anything.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Automation Audit Ops

--- a/skills/autonomous-agent-harness/SKILL.md
+++ b/skills/autonomous-agent-harness/SKILL.md
@@ -3,6 +3,8 @@ name: autonomous-agent-harness
 description: Transform Claude Code into a fully autonomous agent system with persistent memory, scheduled operations, computer use, and task queuing. Replaces standalone agent frameworks (Hermes, AutoGPT) by leveraging Claude Code's native crons, dispatch, MCP tools, and memory. Use when the user wants continuous autonomous operation, scheduled tasks, or a self-directing agent loop.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Autonomous Agent Harness

--- a/skills/autonomous-loops/SKILL.md
+++ b/skills/autonomous-loops/SKILL.md
@@ -3,6 +3,8 @@ name: autonomous-loops
 description: "Patterns and architectures for autonomous Claude Code loops — from simple sequential pipelines to RFC-driven multi-agent DAG systems. Retained for compatibility only: when new autonomous loop guidance is needed, use continuous-agent-loop instead."
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Autonomous Loops Skill

--- a/skills/backend-patterns/SKILL.md
+++ b/skills/backend-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: backend-patterns
 description: Backend architecture patterns, API design, database optimization, and server-side best practices for Node.js, Express, and Next.js API routes. Use when building or reviewing Node.js, Express, or Next.js API routes and their data access.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Backend Development Patterns

--- a/skills/benchmark-methodology/SKILL.md
+++ b/skills/benchmark-methodology/SKILL.md
@@ -7,6 +7,7 @@ description: >-
   leadership, pricing, client's strategic tension) with explicit 1–5 rubrics
   and a tension-plot. Precedes competitive-report-structure.
 license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Benchmark Methodology

--- a/skills/benchmark-optimization-loop/SKILL.md
+++ b/skills/benchmark-optimization-loop/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 metadata:
   origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
+compatibility: [claude-code, codex]
 ---
 
 # Benchmark Optimization Loop

--- a/skills/benchmark/SKILL.md
+++ b/skills/benchmark/SKILL.md
@@ -4,6 +4,7 @@ description: Use this skill to measure performance baselines, detect regressions
 license: MIT
 metadata:
   origin: ECC
+compatibility: [claude-code, codex]
 ---
 
 # Benchmark — Performance Baseline & Regression Detection

--- a/skills/blender-motion-state-inspection/SKILL.md
+++ b/skills/blender-motion-state-inspection/SKILL.md
@@ -4,6 +4,8 @@ description: Use this skill when inspecting Blender characters, rigs, poses, ani
 metadata:
   origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Blender Motion State Inspection

--- a/skills/blueprint/SKILL.md
+++ b/skills/blueprint/SKILL.md
@@ -12,6 +12,8 @@ description: >-
   than 3 tool calls, or user says "just do it".
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Blueprint — Construction Plan Generator

--- a/skills/brand-discovery/SKILL.md
+++ b/skills/brand-discovery/SKILL.md
@@ -6,6 +6,8 @@ description: >-
   personality, voice, narrative, and founder-brand tension across 8 modules
   using laddering, 5 Whys, and projective techniques. Produces a resumable
   session with disk-persisted state and a master brandbook (90_SYNTHESIS.md).
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Brand Discovery

--- a/skills/brand-voice/SKILL.md
+++ b/skills/brand-voice/SKILL.md
@@ -3,6 +3,8 @@ name: brand-voice
 description: Build a source-derived writing style profile from real posts, essays, launch notes, docs, or site copy, then reuse that profile across content, outreach, and social workflows. Use when the user wants voice consistency without generic AI writing tropes.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Brand Voice

--- a/skills/browser-qa/SKILL.md
+++ b/skills/browser-qa/SKILL.md
@@ -3,6 +3,8 @@ name: browser-qa
 description: Use this skill to automate visual testing and UI interaction verification using browser automation after deploying features.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Browser QA — Automated Visual Testing & Interaction

--- a/skills/bun-runtime/SKILL.md
+++ b/skills/bun-runtime/SKILL.md
@@ -3,6 +3,8 @@ name: bun-runtime
 description: Bun as runtime, package manager, bundler, and test runner. When to choose Bun vs Node, migration notes, and Vercel support.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Bun Runtime

--- a/skills/canary-watch/SKILL.md
+++ b/skills/canary-watch/SKILL.md
@@ -3,6 +3,8 @@ name: canary-watch
 description: Use this skill to monitor and verify a deployed URL after releases — checks HTTP endpoints, SSE streams, static assets, console errors, and performance regressions after deploys, merges, or dependency upgrades. Smoke / canary / post-deploy verification.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Canary Watch — Post-Deploy Monitoring

--- a/skills/carrier-relationship-management/SKILL.md
+++ b/skills/carrier-relationship-management/SKILL.md
@@ -15,6 +15,7 @@ metadata:
   author: evos
   clawdbot:
     emoji: ""
+compatibility: [claude-code, codex]
 ---
 
 # Carrier Relationship Management

--- a/skills/cisco-ios-patterns/SKILL.md
+++ b/skills/cisco-ios-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: cisco-ios-patterns
 description: Cisco IOS and IOS-XE review patterns for show commands, config hierarchy, wildcard masks, ACL placement, interface hygiene, and safe change-window verification. Use when reading, writing, or reviewing Cisco IOS / IOS-XE configuration or planning a change window.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Cisco IOS Patterns

--- a/skills/ck/SKILL.md
+++ b/skills/ck/SKILL.md
@@ -6,6 +6,8 @@ metadata:
   origin: community
 author: sreedhargs89
 repo: https://github.com/sreedhargs89/context-keeper
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # ck — Context Keeper

--- a/skills/claude-devfleet/SKILL.md
+++ b/skills/claude-devfleet/SKILL.md
@@ -3,6 +3,8 @@ name: claude-devfleet
 description: Orchestrate multi-agent coding tasks via Claude DevFleet — plan projects, dispatch parallel agents in isolated worktrees, monitor progress, and read structured reports. Use when dispatching parallel coding agents across isolated worktrees and tracking their reports.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Claude DevFleet Multi-Agent Orchestration

--- a/skills/click-path-audit/SKILL.md
+++ b/skills/click-path-audit/SKILL.md
@@ -3,6 +3,8 @@ name: click-path-audit
 description: "Trace every user-facing button/touchpoint through its full state change sequence to find bugs where functions individually work but cancel each other out, produce wrong final state, or leave the UI in an inconsistent state. Use when: systematic debugging found no bugs but users report broken buttons, or after any major refactor touching shared state stores."
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # /click-path-audit — Behavioural Flow Audit

--- a/skills/clickhouse-io/SKILL.md
+++ b/skills/clickhouse-io/SKILL.md
@@ -3,6 +3,8 @@ name: clickhouse-io
 description: ClickHouse database patterns, query optimization, analytics, and data engineering best practices for high-performance analytical workloads. Use when writing ClickHouse schemas or queries, or when an analytical query is too slow.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # ClickHouse Analytics Patterns

--- a/skills/code-tour/SKILL.md
+++ b/skills/code-tour/SKILL.md
@@ -3,6 +3,8 @@ name: code-tour
 description: Create CodeTour `.tour` files — persona-targeted, step-by-step walkthroughs with real file and line anchors. Use for onboarding tours, architecture walkthroughs, PR tours, RCA tours, and structured "explain how this works" requests. Use when the user asks for a code tour, onboarding walkthrough, PR tour, or an explanation of how a subsystem works.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Code Tour

--- a/skills/codebase-onboarding/SKILL.md
+++ b/skills/codebase-onboarding/SKILL.md
@@ -3,6 +3,8 @@ name: codebase-onboarding
 description: Analyze an unfamiliar codebase and generate a structured onboarding guide with architecture map, key entry points, conventions, and a starter CLAUDE.md. Use when joining a new project or setting up Claude Code for the first time in a repo.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Codebase Onboarding

--- a/skills/codehealth-mcp/SKILL.md
+++ b/skills/codehealth-mcp/SKILL.md
@@ -3,6 +3,8 @@ name: codehealth-mcp
 description: Real-time structural Code Health via CodeScene MCP — review before edits, verify score deltas after changes, gate commits and PRs. Use when reviewing code quality, refactoring, checking if AI changes degraded a file, or before commit/PR.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Code Health MCP (CodeScene)

--- a/skills/coding-standards/SKILL.md
+++ b/skills/coding-standards/SKILL.md
@@ -3,6 +3,8 @@ name: coding-standards
 description: Baseline cross-project coding conventions for naming, readability, immutability, and code-quality review. Use detailed frontend or backend skills for framework-specific patterns. Use when reviewing code quality or naming with no framework-specific skill that applies.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Coding Standards & Best Practices

--- a/skills/competitive-platform-analysis/SKILL.md
+++ b/skills/competitive-platform-analysis/SKILL.md
@@ -6,6 +6,8 @@ description: >-
   counts as a competitor, which tier they belong to, and which sources to mine.
   First step in the three-skill competitive pipeline; precedes
   benchmark-methodology.
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Competitive Platform Analysis

--- a/skills/competitive-report-structure/SKILL.md
+++ b/skills/competitive-report-structure/SKILL.md
@@ -6,6 +6,8 @@ description: >-
   profiles, benchmarking matrix, white-space analysis, strategic recommendations,
   and team alignment trigger questions. Final step in the three-skill competitive
   pipeline.
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Competitive Report Structure

--- a/skills/compose-multiplatform-patterns/SKILL.md
+++ b/skills/compose-multiplatform-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: compose-multiplatform-patterns
 description: Compose Multiplatform and Jetpack Compose patterns for KMP projects — state management, navigation, theming, performance, and platform-specific UI. Use when building Compose or Jetpack Compose UI, state, navigation, or theming in a KMP project.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Compose Multiplatform Patterns

--- a/skills/config-gc/SKILL.md
+++ b/skills/config-gc/SKILL.md
@@ -3,6 +3,8 @@ name: config-gc
 description: Garbage collection for your Claude Code configuration. Periodically scans ~/.claude (skills, memory, hooks, permissions, MCP servers, caches) for redundant, stale, orphaned, or low-value items, then walks the user through a confirm-each-deletion cleanup. Use when the user says "clean up my config", "config GC", "too many skills", "audit my setup", "my .claude is bloated", or asks for a periodic config review.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Config GC — Garbage Collection for Claude Code Setups

--- a/skills/configure-ecc/SKILL.md
+++ b/skills/configure-ecc/SKILL.md
@@ -3,6 +3,8 @@ name: configure-ecc
 description: Guide ECC installation, update, or reconfiguration from inside Claude Code, Codex, or Kimi while respecting each harness's real plugin, scope, and hook capabilities.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Configure Everything Claude Code

--- a/skills/connections-optimizer/SKILL.md
+++ b/skills/connections-optimizer/SKILL.md
@@ -3,6 +3,8 @@ name: connections-optimizer
 description: Reorganize the user's X and LinkedIn network with review-first pruning, add/follow recommendations, and channel-specific warm outreach drafted in the user's real voice. Use when the user wants to clean up following lists, grow toward current priorities, or rebalance a social graph around higher-signal relationships.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Connections Optimizer

--- a/skills/content-engine/SKILL.md
+++ b/skills/content-engine/SKILL.md
@@ -3,6 +3,8 @@ name: content-engine
 description: Create platform-native content systems for X, LinkedIn, TikTok, YouTube, newsletters, and repurposed multi-platform campaigns. Use when the user wants social posts, threads, scripts, content calendars, or one source asset adapted cleanly across platforms.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Content Engine

--- a/skills/content-hash-cache-pattern/SKILL.md
+++ b/skills/content-hash-cache-pattern/SKILL.md
@@ -3,6 +3,8 @@ name: content-hash-cache-pattern
 description: Cache expensive file processing results using SHA-256 content hashes — path-independent, auto-invalidating, with service layer separation. Use when repeated file processing is slow and results should be cached and invalidated by content rather than path.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Content-Hash File Cache Pattern

--- a/skills/context-budget/SKILL.md
+++ b/skills/context-budget/SKILL.md
@@ -3,6 +3,8 @@ name: context-budget
 description: Audits Claude Code context window consumption across agents, skills, MCP servers, and rules. Identifies bloat, redundant components, and produces prioritized token-savings recommendations. Use when the context window is filling up too fast and the agents, skills, MCP servers, or rules consuming it need to be identified.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Context Budget

--- a/skills/continuous-agent-loop/SKILL.md
+++ b/skills/continuous-agent-loop/SKILL.md
@@ -3,6 +3,8 @@ name: continuous-agent-loop
 description: Patterns for continuous autonomous agent loops with quality gates, evals, and recovery controls. Use when running an agent loop that must self-check, gate on evals, and recover from failures.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Continuous Agent Loop

--- a/skills/continuous-learning-v2/SKILL.md
+++ b/skills/continuous-learning-v2/SKILL.md
@@ -4,6 +4,8 @@ description: Instinct-based learning system that observes sessions via hooks, cr
 metadata:
   version: 2.1.0
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Continuous Learning v2.1 - Instinct

--- a/skills/continuous-learning/SKILL.md
+++ b/skills/continuous-learning/SKILL.md
@@ -3,6 +3,8 @@ name: continuous-learning
 description: "[DEPRECATED - use continuous-learning-v2] Legacy v1 stop-hook skill extractor. v2 is a strict superset with instinct-based, project-scoped, hook-reliable learning. Do not invoke v1: when continuous learning, session learning, or pattern extraction is requested, route to continuous-learning-v2 instead."
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Continuous Learning Skill - DEPRECATED

--- a/skills/contract-first/SKILL.md
+++ b/skills/contract-first/SKILL.md
@@ -3,6 +3,8 @@ name: contract-first
 description: Use when multiple consumers and providers must evolve an API or event schema without field drift, integration surprises, or one side silently redefining the interface.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Contract-First Collaboration

--- a/skills/cost-aware-llm-pipeline/SKILL.md
+++ b/skills/cost-aware-llm-pipeline/SKILL.md
@@ -3,6 +3,8 @@ name: cost-aware-llm-pipeline
 description: Cost optimization patterns for LLM API usage — model routing by task complexity, budget tracking, retry logic, and prompt caching. Use when LLM spend needs to come down, or when routing tasks across model tiers and budgets.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Cost-Aware LLM Pipeline

--- a/skills/cost-tracking/SKILL.md
+++ b/skills/cost-tracking/SKILL.md
@@ -3,6 +3,8 @@ name: cost-tracking
 description: Track and report Claude Code token usage, spending, and budgets from the local ECC cost-tracker metrics log. Use when the user asks about costs, spending, usage, tokens, budgets, or cost breakdowns by model, session, or date.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Cost Tracking

--- a/skills/council-multi-model/SKILL.md
+++ b/skills/council-multi-model/SKILL.md
@@ -3,6 +3,8 @@ name: council-multi-model
 description: Add one optional external Codex critique after the existing council has produced a decision draft. Use when an ambiguous, high-consequence decision would benefit from a separate model invocation's attempt to break the synthesis. Requires explicit consent before sending the compact draft and disagreement to OpenAI, labels same-provider reviews honestly, and marks the review absent when the adapter is unavailable.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Council - External Review

--- a/skills/council/SKILL.md
+++ b/skills/council/SKILL.md
@@ -3,6 +3,8 @@ name: council
 description: Convene a four-voice council for ambiguous decisions, tradeoffs, and go/no-go calls. Use when multiple valid paths exist and you need structured disagreement before choosing.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Council

--- a/skills/cpp-coding-standards/SKILL.md
+++ b/skills/cpp-coding-standards/SKILL.md
@@ -3,6 +3,8 @@ name: cpp-coding-standards
 description: C++ coding standards based on the C++ Core Guidelines (isocpp.github.io). Use when writing, reviewing, or refactoring C++ code to enforce modern, safe, and idiomatic practices.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # C++ Coding Standards (C++ Core Guidelines)

--- a/skills/cpp-testing/SKILL.md
+++ b/skills/cpp-testing/SKILL.md
@@ -3,6 +3,8 @@ name: cpp-testing
 description: Use only when writing/updating/fixing C++ tests, configuring GoogleTest/CTest, diagnosing failing or flaky tests, or adding coverage/sanitizers.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # C++ Testing (Agent Skill)

--- a/skills/crosspost/SKILL.md
+++ b/skills/crosspost/SKILL.md
@@ -3,6 +3,8 @@ name: crosspost
 description: Multi-platform content distribution across X, LinkedIn, Threads, and Bluesky. Adapts content per platform using content-engine patterns. Never posts identical content cross-platform. Use when the user wants to distribute content across social platforms.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Crosspost

--- a/skills/csharp-testing/SKILL.md
+++ b/skills/csharp-testing/SKILL.md
@@ -3,6 +3,8 @@ name: csharp-testing
 description: C# and .NET testing patterns with xUnit, FluentAssertions, mocking, integration tests, and test organization best practices. Use when writing or reviewing xUnit tests, mocks, or integration tests in a C# / .NET project.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # C# Testing Patterns

--- a/skills/customer-billing-ops/SKILL.md
+++ b/skills/customer-billing-ops/SKILL.md
@@ -3,6 +3,8 @@ name: customer-billing-ops
 description: Operate customer billing workflows such as subscriptions, refunds, churn triage, billing-portal recovery, and plan analysis using connected billing tools like Stripe. Use when the user needs to help a customer, inspect subscription state, or manage revenue-impacting billing operations.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Customer Billing Ops

--- a/skills/customs-trade-compliance/SKILL.md
+++ b/skills/customs-trade-compliance/SKILL.md
@@ -16,6 +16,7 @@ metadata:
   author: evos
   clawdbot:
     emoji: ""
+compatibility: [claude-code, codex]
 ---
 
 # Customs & Trade Compliance

--- a/skills/dart-flutter-patterns/SKILL.md
+++ b/skills/dart-flutter-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: dart-flutter-patterns
 description: Production-ready Dart and Flutter patterns covering null safety, immutable state, async composition, widget architecture, popular state management frameworks (BLoC, Riverpod, Provider), GoRouter navigation, Dio networking, Freezed code generation, and clean architecture. Use when writing or reviewing Dart and Flutter code — state, widgets, navigation, networking, or architecture.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Dart/Flutter Patterns

--- a/skills/dashboard-builder/SKILL.md
+++ b/skills/dashboard-builder/SKILL.md
@@ -4,6 +4,8 @@ description: Build monitoring dashboards that answer real operator questions for
 metadata:
   version: "1.0.0"
   origin: ECC direct-port adaptation
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Dashboard Builder

--- a/skills/data-scraper-agent/SKILL.md
+++ b/skills/data-scraper-agent/SKILL.md
@@ -3,6 +3,8 @@ name: data-scraper-agent
 description: Build a fully automated AI-powered data collection agent for any public source — job boards, prices, news, GitHub, sports, anything. Runs on a schedule, enriches data with a free LLM (Gemini Flash), stores results in Notion/Sheets/Supabase, and learns from user feedback. Runs 100% free on GitHub Actions. Use when the user wants to monitor, collect, or track any public data automatically.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Data Scraper Agent

--- a/skills/data-throughput-accelerator/SKILL.md
+++ b/skills/data-throughput-accelerator/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 metadata:
   origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
+compatibility: [claude-code, codex]
 ---
 
 # Data Throughput Accelerator

--- a/skills/database-migrations/SKILL.md
+++ b/skills/database-migrations/SKILL.md
@@ -3,6 +3,8 @@ name: database-migrations
 description: Database migration best practices for schema changes, data migrations, rollbacks, and zero-downtime deployments across PostgreSQL, MySQL, and common ORMs (Prisma, Drizzle, Kysely, Django, TypeORM, golang-migrate). Use when writing a schema or data migration, planning a rollback, or aiming for zero-downtime deployment.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Database Migration Patterns

--- a/skills/deep-research/SKILL.md
+++ b/skills/deep-research/SKILL.md
@@ -3,6 +3,8 @@ name: deep-research
 description: Multi-source deep research using firecrawl and exa MCPs. Searches the web, synthesizes findings, and delivers cited reports with source attribution. Use when the user wants thorough research on any topic with evidence and citations.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Deep Research

--- a/skills/defi-amm-security/SKILL.md
+++ b/skills/defi-amm-security/SKILL.md
@@ -4,6 +4,8 @@ description: Security checklist for Solidity AMM contracts, liquidity pools, and
 metadata:
   version: "1.0.0"
   origin: ECC direct-port adaptation
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # DeFi AMM Security

--- a/skills/delivery-gate/SKILL.md
+++ b/skills/delivery-gate/SKILL.md
@@ -4,6 +4,8 @@ description: Stop hook that blocks Claude from finishing until quality checks pa
 metadata:
   version: 1.1.1
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Delivery Gate — Mechanical Quality Gate for Claude Code

--- a/skills/deployment-patterns/SKILL.md
+++ b/skills/deployment-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: deployment-patterns
 description: Deployment workflows, CI/CD pipeline patterns, Docker containerization, health checks, rollback strategies, and production readiness checklists for web applications. Use when setting up CI/CD, containerizing an app, or checking production readiness before a release.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Deployment Patterns

--- a/skills/design-system/SKILL.md
+++ b/skills/design-system/SKILL.md
@@ -3,6 +3,8 @@ name: design-system
 description: Use this skill to generate or audit design systems, check visual consistency, and review PRs that touch styling. Use when generating or auditing a design system, checking visual consistency, or reviewing a PR that touches styling.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Design System — Generate & Audit Visual Systems

--- a/skills/dev-team/SKILL.md
+++ b/skills/dev-team/SKILL.md
@@ -4,6 +4,8 @@ description: Simulate a collaborative dev team session where multiple role-based
 metadata:
   origin: community
   inspired-by: bmad-method (party mode)
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Dev Team

--- a/skills/django-celery/SKILL.md
+++ b/skills/django-celery/SKILL.md
@@ -3,6 +3,8 @@ name: django-celery
 description: Django + Celery async task patterns — configuration, task design, beat scheduling, retries, canvas workflows, monitoring, and testing. Use when adding background jobs, scheduled tasks, or async processing to a Django app.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Django + Celery Async Task Patterns

--- a/skills/django-patterns/SKILL.md
+++ b/skills/django-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: django-patterns
 description: Django architecture patterns, REST API design with DRF, ORM best practices, caching, signals, middleware, and production-grade Django apps. Use when building or reviewing Django apps, DRF APIs, ORM queries, or caching.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Django Development Patterns

--- a/skills/django-security/SKILL.md
+++ b/skills/django-security/SKILL.md
@@ -3,6 +3,8 @@ name: django-security
 description: Django security best practices, authentication, authorization, CSRF protection, SQL injection prevention, XSS prevention, and secure deployment configurations. Use when reviewing Django authentication, authorization, input handling, or deployment settings.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Django Security Best Practices

--- a/skills/django-tdd/SKILL.md
+++ b/skills/django-tdd/SKILL.md
@@ -3,6 +3,8 @@ name: django-tdd
 description: Django testing strategies with pytest-django, TDD methodology, factory_boy, mocking, coverage, and testing Django REST Framework APIs. Use when writing Django or DRF tests with pytest-django, or driving a Django feature test-first.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Django Testing with TDD

--- a/skills/django-verification/SKILL.md
+++ b/skills/django-verification/SKILL.md
@@ -3,6 +3,8 @@ name: django-verification
 description: "Verification loop for Django projects: migrations, linting, tests with coverage, security scans, and deployment readiness checks before release or PR."
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Django Verification Loop

--- a/skills/dmux-workflows/SKILL.md
+++ b/skills/dmux-workflows/SKILL.md
@@ -3,6 +3,8 @@ name: dmux-workflows
 description: Multi-agent orchestration using dmux (tmux pane manager for AI agents). Patterns for parallel agent workflows across Claude Code, Codex, OpenCode, and other harnesses. Use when running multiple agent sessions in parallel or coordinating multi-agent development workflows.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # dmux Workflows

--- a/skills/docker-patterns/SKILL.md
+++ b/skills/docker-patterns/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: docker-patterns
 description: Docker and Docker Compose patterns for local development, hardened CLI installer harnesses, container security, networking, volumes, and multi-service orchestration. Use when creating or reviewing Dockerfiles and Compose services, testing installers across Linux distributions, or planning accurate native macOS and Windows validation.
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Docker Patterns

--- a/skills/documentation-lookup/SKILL.md
+++ b/skills/documentation-lookup/SKILL.md
@@ -3,6 +3,8 @@ name: documentation-lookup
 description: Use up-to-date library and framework docs via Context7 MCP instead of training data. Activates for setup questions, API references, code examples, or when the user names a framework (e.g. React, Next.js, Prisma).
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Documentation Lookup (Context7)

--- a/skills/dotnet-patterns/SKILL.md
+++ b/skills/dotnet-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: dotnet-patterns
 description: Idiomatic C# and .NET patterns, conventions, dependency injection, async/await, and best practices for building robust, maintainable .NET applications. Use when writing or reviewing C# / .NET code — DI, async, or general conventions.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # .NET Development Patterns

--- a/skills/dynamic-workflow-mode/SKILL.md
+++ b/skills/dynamic-workflow-mode/SKILL.md
@@ -3,6 +3,8 @@ name: dynamic-workflow-mode
 description: "Design task-local harnesses, eval gates, and reusable skill extraction for Claude dynamic workflow mode and other adaptive agent harnesses. Use when building a task-local harness, adding eval gates, or extracting a reusable skill from ad-hoc work."
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Dynamic Workflow Mode

--- a/skills/e2e-testing/SKILL.md
+++ b/skills/e2e-testing/SKILL.md
@@ -3,6 +3,8 @@ name: e2e-testing
 description: Playwright E2E testing patterns, Page Object Model, configuration, CI/CD integration, artifact management, and flaky test strategies. Use when writing Playwright tests, structuring page objects, or fixing flaky E2E runs in CI.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # E2E Testing Patterns

--- a/skills/ecc-guide/SKILL.md
+++ b/skills/ecc-guide/SKILL.md
@@ -3,6 +3,8 @@ name: ecc-guide
 description: Guide users through ECC's current agents, skills, commands, hooks, rules, install profiles, and project onboarding by reading the live repository surface before answering.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # ECC Guide

--- a/skills/ecc-recipes/SKILL.md
+++ b/skills/ecc-recipes/SKILL.md
@@ -6,6 +6,8 @@ origin: community
 author: KyawZinLatt
 metadata:
   version: "1.0.0"
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # ECC Recipes

--- a/skills/ecc-tools-cost-audit/SKILL.md
+++ b/skills/ecc-tools-cost-audit/SKILL.md
@@ -3,6 +3,8 @@ name: ecc-tools-cost-audit
 description: Evidence-first ECC Tools burn and billing audit workflow. Use when investigating runaway PR creation, quota bypass, premium-model leakage, duplicate jobs, or GitHub App cost spikes in the ECC Tools repo.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # ECC Tools Cost Audit

--- a/skills/email-ops/SKILL.md
+++ b/skills/email-ops/SKILL.md
@@ -3,6 +3,8 @@ name: email-ops
 description: Evidence-first mailbox triage, drafting, send verification, and sent-mail-safe follow-up workflow for ECC. Use when the user wants to organize email, draft or send through the real mail surface, or prove what landed in Sent.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Email Ops

--- a/skills/energy-procurement/SKILL.md
+++ b/skills/energy-procurement/SKILL.md
@@ -16,6 +16,7 @@ metadata:
   author: evos
   clawdbot:
     emoji: ""
+compatibility: [claude-code, codex]
 ---
 
 # Energy Procurement

--- a/skills/enterprise-agent-ops/SKILL.md
+++ b/skills/enterprise-agent-ops/SKILL.md
@@ -3,6 +3,8 @@ name: enterprise-agent-ops
 description: Operate long-lived agent workloads with observability, security boundaries, and lifecycle management. Use when running long-lived agent workloads that need observability, security boundaries, or lifecycle control.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Enterprise Agent Ops

--- a/skills/error-handling/SKILL.md
+++ b/skills/error-handling/SKILL.md
@@ -3,6 +3,8 @@ name: error-handling
 description: Patterns for robust error handling across TypeScript, Python, and Go. Covers typed errors, error boundaries, retries, circuit breakers, and user-facing error messages. Use when designing error types, retries, circuit breakers, or user-facing failure messages in TypeScript, Python, or Go.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Error Handling Patterns

--- a/skills/eval-harness/SKILL.md
+++ b/skills/eval-harness/SKILL.md
@@ -4,6 +4,8 @@ description: Formal evaluation framework for Claude Code sessions implementing e
 metadata:
   origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Eval Harness Skill

--- a/skills/evm-token-decimals/SKILL.md
+++ b/skills/evm-token-decimals/SKILL.md
@@ -4,6 +4,8 @@ description: Prevent silent decimal mismatch bugs across EVM chains. Covers runt
 metadata:
   version: "1.0.0"
   origin: ECC direct-port adaptation
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # EVM Token Decimals

--- a/skills/exa-search/SKILL.md
+++ b/skills/exa-search/SKILL.md
@@ -3,6 +3,8 @@ name: exa-search
 description: Neural search via Exa MCP for web, code, and company research. Use when the user needs web search, code examples, company intel, people lookup, or AI-powered deep research with Exa's neural search engine.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Exa Search

--- a/skills/fal-ai-media/SKILL.md
+++ b/skills/fal-ai-media/SKILL.md
@@ -3,6 +3,8 @@ name: fal-ai-media
 description: Unified media generation via fal.ai MCP — image, video, and audio. Covers text-to-image (Nano Banana), text/image-to-video (Seedance, Kling, Veo 3), text-to-speech (CSM-1B), and video-to-audio (ThinkSound). Use when the user wants to generate images, videos, or audio with AI.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # fal.ai Media Generation

--- a/skills/fastapi-patterns/SKILL.md
+++ b/skills/fastapi-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: fastapi-patterns
 description: FastAPI best practices covering project structure, Pydantic v2 schemas, dependency injection, async handlers, authentication, authorization, transactional service layers, and testing with httpx and pytest. Use when building or reviewing FastAPI apps — Pydantic schemas, dependencies, async handlers, auth, or tests.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # FastAPI Patterns

--- a/skills/finance-billing-ops/SKILL.md
+++ b/skills/finance-billing-ops/SKILL.md
@@ -3,6 +3,8 @@ name: finance-billing-ops
 description: Evidence-first revenue, pricing, refunds, team-billing, and billing-model truth workflow for ECC. Use when the user wants a sales snapshot, pricing comparison, duplicate-charge diagnosis, or code-backed billing reality instead of generic payments advice.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Finance Billing Ops

--- a/skills/flox-environments/SKILL.md
+++ b/skills/flox-environments/SKILL.md
@@ -3,6 +3,8 @@ name: flox-environments
 description: "Create reproducible, cross-platform (macOS/Linux) development environments with Flox, a declarative Nix-based environment manager. Use when setting up project toolchains for any language, installing system-level dependencies (compilers, databases, native libs like openssl/BLAS), pinning exact package versions for a team, running local services (PostgreSQL, Redis, Kafka), onboarding developers with one command, or solving 'works on my machine' problems — including agent/vibe-coding setups that need project-scoped tools without sudo. Also use when the user mentions .flox/, manifest.toml, flox activate, or FloxHub."
 metadata:
   origin: Flox
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Flox Environments

--- a/skills/flutter-dart-code-review/SKILL.md
+++ b/skills/flutter-dart-code-review/SKILL.md
@@ -3,6 +3,8 @@ name: flutter-dart-code-review
 description: Library-agnostic Flutter/Dart code review checklist covering widget best practices, state management patterns (BLoC, Riverpod, Provider, GetX, MobX, Signals), Dart idioms, performance, accessibility, security, and clean architecture. Use when reviewing Flutter or Dart code, whatever state management library the project uses.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Flutter/Dart Code Review Best Practices

--- a/skills/foundation-models-on-device/SKILL.md
+++ b/skills/foundation-models-on-device/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: foundation-models-on-device
 description: Apple FoundationModels framework for on-device LLM — text generation, guided generation with @Generable, tool calling, and snapshot streaming in iOS 26+. Use when adding on-device LLM features with Apple FoundationModels on iOS 26+.
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # FoundationModels: On-Device LLM (iOS 26)

--- a/skills/frontend-a11y/SKILL.md
+++ b/skills/frontend-a11y/SKILL.md
@@ -6,6 +6,8 @@ description: >
   Use when building any interactive UI component or form.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Frontend Accessibility Patterns

--- a/skills/frontend-design-direction/SKILL.md
+++ b/skills/frontend-design-direction/SKILL.md
@@ -3,6 +3,8 @@ name: frontend-design-direction
 description: Set an ECC-specific frontend design direction for production UI work. Use when building or improving websites, dashboards, applications, components, landing pages, visual tools, or any web UI that needs stronger product-specific design judgment.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Frontend Design Direction

--- a/skills/frontend-patterns/SKILL.md
+++ b/skills/frontend-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: frontend-patterns
 description: Frontend development patterns for React, Next.js, state management, performance optimization, and UI best practices. Use when building or reviewing React or Next.js components, state, or render performance.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Frontend Development Patterns

--- a/skills/frontend-slides/SKILL.md
+++ b/skills/frontend-slides/SKILL.md
@@ -3,6 +3,8 @@ name: frontend-slides
 description: Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or create slides for a talk/pitch. Helps non-designers discover their aesthetic through visual exploration rather than abstract choices.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Frontend Slides

--- a/skills/fsharp-testing/SKILL.md
+++ b/skills/fsharp-testing/SKILL.md
@@ -3,6 +3,8 @@ name: fsharp-testing
 description: F# testing patterns with xUnit, FsUnit, Unquote, FsCheck property-based testing, integration tests, and test organization best practices. Use when writing F# tests with xUnit, FsUnit, Unquote, or FsCheck.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # F# Testing Patterns

--- a/skills/gan-style-harness/SKILL.md
+++ b/skills/gan-style-harness/SKILL.md
@@ -4,6 +4,8 @@ description: "GAN-inspired Generator-Evaluator agent harness for building high-q
 metadata:
   origin: ECC-community
 tools: Read, Write, Edit, Bash, Grep, Glob, Task
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # GAN-Style Harness Skill

--- a/skills/gateguard/SKILL.md
+++ b/skills/gateguard/SKILL.md
@@ -3,6 +3,8 @@ name: gateguard
 description: Fact-forcing gate that blocks Edit/Write/Bash (including MultiEdit) and demands concrete investigation (importers, data schemas, user instruction) before allowing the action. Measurably improves output quality by +2.25 points vs ungated agents.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # GateGuard — Fact-Forcing Pre-Action Gate

--- a/skills/generating-python-installer/SKILL.md
+++ b/skills/generating-python-installer/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: generating-python-installer
 description: "Commercial-grade Python installer expert for Windows: Nuitka extreme compilation, dist slimming, DLL footprint analysis, and Inno Setup packaging to ship the smallest, fastest installers. Use when a Python app must ship as a minimal, fast-starting Windows installer; not for basic script-to-exe conversion. 中文触发：Nuitka 极限优化、Python 商业打包、极限编译 Python、dist 瘦身、DLL 分析、最小安装包、最快启动、商业级打包风格"
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Generating Python Installer (Commercial-Grade)

--- a/skills/git-workflow/SKILL.md
+++ b/skills/git-workflow/SKILL.md
@@ -3,6 +3,8 @@ name: git-workflow
 description: Git workflow patterns including branching strategies, commit conventions, merge vs rebase, conflict resolution, and collaborative development best practices for teams of all sizes. Use when choosing a branching strategy, writing commit conventions, deciding merge versus rebase, or resolving conflicts.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Git Workflow Patterns

--- a/skills/github-ops/SKILL.md
+++ b/skills/github-ops/SKILL.md
@@ -3,6 +3,8 @@ name: github-ops
 description: GitHub repository operations, automation, and management. Issue triage, PR management, CI/CD operations, release management, and security monitoring using the gh CLI. Use when the user wants to manage GitHub issues, PRs, CI status, releases, contributors, stale items, or any GitHub operational task beyond simple git commands.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # GitHub Operations

--- a/skills/golang-patterns/SKILL.md
+++ b/skills/golang-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: golang-patterns
 description: Idiomatic Go patterns, best practices, and conventions for building robust, efficient, and maintainable Go applications. Use when writing or reviewing Go code and idiomatic structure or conventions are in question.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Go Development Patterns

--- a/skills/golang-testing/SKILL.md
+++ b/skills/golang-testing/SKILL.md
@@ -3,6 +3,8 @@ name: golang-testing
 description: Go testing patterns including table-driven tests, subtests, benchmarks, fuzzing, and test coverage. Follows TDD methodology with idiomatic Go practices. Use when writing Go tests — table-driven cases, subtests, benchmarks, fuzzing, or coverage.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Go Testing Patterns

--- a/skills/google-workspace-ops/SKILL.md
+++ b/skills/google-workspace-ops/SKILL.md
@@ -3,6 +3,8 @@ name: google-workspace-ops
 description: Operate across Google Drive, Docs, Sheets, and Slides as one workflow surface for plans, trackers, decks, and shared documents. Use when the user needs to find, summarize, edit, migrate, or clean up Google Workspace assets without dropping to raw tool calls.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Google Workspace Ops

--- a/skills/growth-log/SKILL.md
+++ b/skills/growth-log/SKILL.md
@@ -4,6 +4,8 @@ description: "Use after a complex task, failure, or when reviewing what was lear
 metadata:
   version: 1.1.0
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Growth Log Skill

--- a/skills/healthcare-cdss-patterns/SKILL.md
+++ b/skills/healthcare-cdss-patterns/SKILL.md
@@ -4,6 +4,8 @@ description: Clinical Decision Support System (CDSS) development patterns. Drug 
 metadata:
   version: "1.0.0"
   origin: Health1 Super Speciality Hospitals — contributed by Dr. Keyur Patel
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Healthcare CDSS Development Patterns

--- a/skills/healthcare-emr-patterns/SKILL.md
+++ b/skills/healthcare-emr-patterns/SKILL.md
@@ -4,6 +4,8 @@ description: EMR/EHR development patterns for healthcare applications. Clinical 
 metadata:
   version: "1.0.0"
   origin: Health1 Super Speciality Hospitals — contributed by Dr. Keyur Patel
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Healthcare EMR Development Patterns

--- a/skills/healthcare-eval-harness/SKILL.md
+++ b/skills/healthcare-eval-harness/SKILL.md
@@ -4,6 +4,8 @@ description: Patient safety evaluation harness for healthcare application deploy
 metadata:
   version: "1.0.0"
   origin: Health1 Super Speciality Hospitals — contributed by Dr. Keyur Patel
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Healthcare Eval Harness — Patient Safety Verification

--- a/skills/healthcare-phi-compliance/SKILL.md
+++ b/skills/healthcare-phi-compliance/SKILL.md
@@ -4,6 +4,8 @@ description: Protected Health Information (PHI) and Personally Identifiable Info
 metadata:
   version: "1.0.0"
   origin: Health1 Super Speciality Hospitals — contributed by Dr. Keyur Patel
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Healthcare PHI/PII Compliance Patterns

--- a/skills/hermes-imports/SKILL.md
+++ b/skills/hermes-imports/SKILL.md
@@ -3,6 +3,8 @@ name: hermes-imports
 description: Convert local Hermes operator workflows into sanitized ECC skills and release-pack artifacts. Use when preparing a Hermes workflow for public ECC reuse without leaking private workspace state, credentials, or local-only paths.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Hermes Imports

--- a/skills/hexagonal-architecture/SKILL.md
+++ b/skills/hexagonal-architecture/SKILL.md
@@ -3,6 +3,8 @@ name: hexagonal-architecture
 description: Design, implement, and refactor Ports & Adapters systems with clear domain boundaries, dependency inversion, and testable use-case orchestration across TypeScript, Java, Kotlin, and Go services. Use when introducing or refactoring toward Ports and Adapters, or when domain logic has become entangled with I/O.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Hexagonal Architecture

--- a/skills/hipaa-compliance/SKILL.md
+++ b/skills/hipaa-compliance/SKILL.md
@@ -4,6 +4,8 @@ description: HIPAA-specific entrypoint for healthcare privacy and security work.
 metadata:
   version: "1.0.0"
   origin: ECC direct-port adaptation
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # HIPAA Compliance

--- a/skills/homelab-network-readiness/SKILL.md
+++ b/skills/homelab-network-readiness/SKILL.md
@@ -3,6 +3,8 @@ name: homelab-network-readiness
 description: Readiness checklist for homelab VLAN segmentation, local DNS filtering, and WireGuard-style remote access before changing router, firewall, DHCP, or VPN configuration.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Homelab Network Readiness

--- a/skills/homelab-network-setup/SKILL.md
+++ b/skills/homelab-network-setup/SKILL.md
@@ -3,6 +3,8 @@ name: homelab-network-setup
 description: Practical home and homelab network planning for gateways, switches, access points, IP ranges, DHCP reservations, DNS, cabling, and common beginner mistakes. Use when planning or fixing a home or homelab network — gateway, switch, AP, IP ranges, DHCP, DNS, or cabling.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Homelab Network Setup

--- a/skills/homelab-pihole-dns/SKILL.md
+++ b/skills/homelab-pihole-dns/SKILL.md
@@ -3,6 +3,8 @@ name: homelab-pihole-dns
 description: Pi-hole installation, blocklist management, DNS-over-HTTPS setup, DHCP integration, local DNS records, and troubleshooting broken DNS resolution on a home network. Use when the task explicitly involves Pi-hole — installing it, managing blocklists, configuring DoH or DHCP, adding local DNS records, or diagnosing DNS resolution with Pi-hole in the path.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Homelab Pi-hole DNS

--- a/skills/homelab-vlan-segmentation/SKILL.md
+++ b/skills/homelab-vlan-segmentation/SKILL.md
@@ -3,6 +3,8 @@ name: homelab-vlan-segmentation
 description: Segmenting home networks into VLANs for IoT, guest, trusted, and server traffic using UniFi, pfSense/OPNsense, and MikroTik — including switch trunk config, firewall rules, and wireless SSID mapping. Use when splitting a home network into IoT, guest, trusted, and server VLANs on UniFi, pfSense/OPNsense, or MikroTik.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Homelab VLAN Segmentation

--- a/skills/homelab-wireguard-vpn/SKILL.md
+++ b/skills/homelab-wireguard-vpn/SKILL.md
@@ -3,6 +3,8 @@ name: homelab-wireguard-vpn
 description: WireGuard VPN server setup, peer configuration, key generation, split tunneling vs full tunnel routing, and remote access to a home network from mobile and laptop clients. Use when setting up WireGuard for remote access to a home network, or deciding between split and full tunnel routing.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Homelab WireGuard VPN

--- a/skills/hookify-rules/SKILL.md
+++ b/skills/hookify-rules/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: hookify-rules
 description: This skill should be used when the user asks to create a hookify rule, write a hook rule, configure hookify, add a hookify rule, or needs guidance on hookify rule syntax and patterns.
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Writing Hookify Rules

--- a/skills/inherit-legacy-style/SKILL.md
+++ b/skills/inherit-legacy-style/SKILL.md
@@ -4,6 +4,8 @@ description: Legacy-project style inheritance skill. Use when the user types /in
 metadata:
   origin: community
 allowed-tools: Read, Glob, Grep, Bash, Edit, Write, AskUserQuestion
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Inherit Legacy Style

--- a/skills/intent-driven-development/SKILL.md
+++ b/skills/intent-driven-development/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: intent-driven-development
 description: Turn ambiguous or high-impact product and engineering changes into scoped, verifiable acceptance criteria before or alongside implementation. Use when a user asks to clarify a feature, define acceptance criteria, de-risk a security/data/migration/integration change, prepare implementation requirements for another agent, or make a complex request testable. Do not trigger for trivial edits, straightforward fixes, active debugging, code review, or implementation requests whose acceptance conditions are already clear unless the user explicitly invokes this skill.
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Intent-Driven Development

--- a/skills/inventory-demand-planning/SKILL.md
+++ b/skills/inventory-demand-planning/SKILL.md
@@ -16,6 +16,7 @@ metadata:
   author: evos
   clawdbot:
     emoji: ""
+compatibility: [claude-code, codex]
 ---
 
 # Inventory Demand Planning

--- a/skills/investor-materials/SKILL.md
+++ b/skills/investor-materials/SKILL.md
@@ -3,6 +3,8 @@ name: investor-materials
 description: Create and update pitch decks, one-pagers, investor memos, accelerator applications, financial models, and fundraising materials. Use when the user needs investor-facing documents, projections, use-of-funds tables, milestone plans, or materials that must stay internally consistent across multiple fundraising assets.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Investor Materials

--- a/skills/investor-outreach/SKILL.md
+++ b/skills/investor-outreach/SKILL.md
@@ -3,6 +3,8 @@ name: investor-outreach
 description: Draft cold emails, warm intro blurbs, follow-ups, update emails, and investor communications for fundraising. Use when the user wants outreach to angels, VCs, strategic investors, or accelerators and needs concise, personalized, investor-facing messaging.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Investor Outreach

--- a/skills/ios-icon-gen/SKILL.md
+++ b/skills/ios-icon-gen/SKILL.md
@@ -3,6 +3,8 @@ name: ios-icon-gen
 description: Generate iOS app icons as PNG imagesets for Xcode asset catalogs from SF Symbols (5000+ Apple-native) or Iconify API (275k+ open source icons from 200+ collections). Use when generating icons, creating icon assets, adding icons to asset catalog, or searching for icons for iOS projects.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # iOS Icon Generator

--- a/skills/iterative-retrieval/SKILL.md
+++ b/skills/iterative-retrieval/SKILL.md
@@ -3,6 +3,8 @@ name: iterative-retrieval
 description: Pattern for progressively refining context retrieval to solve the subagent context problem. Use when a subagent lacks the context it needs and retrieval must be refined across passes.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Iterative Retrieval Pattern

--- a/skills/ito-baskets/SKILL.md
+++ b/skills/ito-baskets/SKILL.md
@@ -4,6 +4,8 @@ description: Read-only Itô basket and prediction-market data skill. Index the l
 metadata:
   origin: ECC
   aliases: ito-basket-compare, ito-market-intelligence, ito-data-atlas-agent, ito-trade-planner
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Itô Baskets

--- a/skills/ito-compute/SKILL.md
+++ b/skills/ito-compute/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: ito-compute
 description: Query live GPU inventory, submit an authenticated Itô fixed-rate RFQ, inspect RFQ or procurement status, revoke device credentials, and run explicitly gated node qualification through the separately installed canonical CLI. Use when a user asks to find H100/H200 capacity, request a fixed compute rate, check Itô compute status, validate GPU nodes, revoke Itô access, or rent or purchase GPU compute and needs the supported boundary explained.
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Itô Compute

--- a/skills/ito-inference/SKILL.md
+++ b/skills/ito-inference/SKILL.md
@@ -5,6 +5,8 @@ metadata:
   origin: ECC
   status: scaffold
   aliases: ito-serve, hosted-open-weights
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Itô Inference

--- a/skills/ito-training/SKILL.md
+++ b/skills/ito-training/SKILL.md
@@ -4,6 +4,8 @@ description: Inspect the availability of ML training on a completed Itô compute
 metadata:
   origin: ECC
   status: scaffold
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Itô Training

--- a/skills/java-coding-standards/SKILL.md
+++ b/skills/java-coding-standards/SKILL.md
@@ -3,6 +3,8 @@ name: java-coding-standards
 description: "Java coding standards for Spring Boot and Quarkus services: naming, immutability, Optional usage, streams, exceptions, generics, CDI, reactive patterns, and project layout. Automatically applies framework-specific conventions. Use when writing or reviewing Java in a Spring Boot or Quarkus service."
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Java Coding Standards

--- a/skills/jira-integration/SKILL.md
+++ b/skills/jira-integration/SKILL.md
@@ -3,6 +3,8 @@ name: jira-integration
 description: Use this skill when retrieving Jira tickets, analyzing requirements, updating ticket status, adding comments, or transitioning issues. Provides Jira API patterns via MCP or direct REST calls.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Jira Integration Skill

--- a/skills/jpa-patterns/SKILL.md
+++ b/skills/jpa-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: jpa-patterns
 description: JPA/Hibernate patterns for entity design, relationships, query optimization, transactions, auditing, indexing, pagination, and pooling in Spring Boot. Use when designing JPA entities or relationships, or when a Hibernate query, transaction, or N+1 problem needs fixing.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # JPA/Hibernate Patterns

--- a/skills/knowledge-ops/SKILL.md
+++ b/skills/knowledge-ops/SKILL.md
@@ -3,6 +3,8 @@ name: knowledge-ops
 description: Knowledge base management, ingestion, sync, and retrieval across multiple storage layers (local files, MCP memory, vector stores, Git repos). Use when the user wants to save, organize, sync, deduplicate, or search across their knowledge systems.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Knowledge Operations

--- a/skills/kotlin-coroutines-flows/SKILL.md
+++ b/skills/kotlin-coroutines-flows/SKILL.md
@@ -3,6 +3,8 @@ name: kotlin-coroutines-flows
 description: Kotlin Coroutines and Flow patterns for Android and KMP — structured concurrency, Flow operators, StateFlow, error handling, and testing. Use when writing coroutines or Flow code on Android or KMP, or debugging cancellation and concurrency.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Kotlin Coroutines & Flows

--- a/skills/kotlin-exposed-patterns/SKILL.md
+++ b/skills/kotlin-exposed-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: kotlin-exposed-patterns
 description: JetBrains Exposed ORM patterns including DSL queries, DAO pattern, transactions, HikariCP connection pooling, Flyway migrations, and repository pattern. Use when working with the Exposed ORM — DSL or DAO queries, transactions, pooling, or migrations.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Kotlin Exposed Patterns

--- a/skills/kotlin-ktor-patterns/SKILL.md
+++ b/skills/kotlin-ktor-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: kotlin-ktor-patterns
 description: Ktor server patterns including routing DSL, plugins, authentication, Koin DI, kotlinx.serialization, WebSockets, and testApplication testing. Use when building a Ktor server — routing, plugins, auth, DI, serialization, or tests.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Ktor Server Patterns

--- a/skills/kotlin-patterns/SKILL.md
+++ b/skills/kotlin-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: kotlin-patterns
 description: Idiomatic Kotlin patterns, best practices, and conventions for building robust, efficient, and maintainable Kotlin applications with coroutines, null safety, and DSL builders. Use when writing or reviewing Kotlin code and idiomatic structure or null safety is in question.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Kotlin Development Patterns

--- a/skills/kotlin-testing/SKILL.md
+++ b/skills/kotlin-testing/SKILL.md
@@ -3,6 +3,8 @@ name: kotlin-testing
 description: Kotlin testing patterns with Kotest, MockK, coroutine testing, property-based testing, and Kover coverage. Follows TDD methodology with idiomatic Kotlin practices. Use when writing Kotlin tests with Kotest or MockK, or testing coroutines and checking coverage.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Kotlin Testing Patterns

--- a/skills/kubernetes-patterns/SKILL.md
+++ b/skills/kubernetes-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: kubernetes-patterns
 description: Kubernetes workload patterns, resource management, RBAC, probes, autoscaling, ConfigMap/Secret handling, and kubectl debugging for production-grade deployments. Use when writing or reviewing Kubernetes manifests, or debugging probes, RBAC, autoscaling, or resource limits.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Kubernetes Patterns

--- a/skills/laravel-patterns/SKILL.md
+++ b/skills/laravel-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: laravel-patterns
 description: Laravel architecture patterns, routing/controllers, Eloquent ORM, service layers, queues, events, caching, and API resources for production apps. Use when building or reviewing Laravel apps — controllers, Eloquent, service layers, queues, or API resources.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Laravel Development Patterns

--- a/skills/laravel-plugin-discovery/SKILL.md
+++ b/skills/laravel-plugin-discovery/SKILL.md
@@ -3,6 +3,8 @@ name: laravel-plugin-discovery
 description: Discover and evaluate Laravel packages via LaraPlugins.io MCP. Use when the user wants to find plugins, check package health, or assess Laravel/PHP compatibility.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Laravel Plugin Discovery

--- a/skills/laravel-security/SKILL.md
+++ b/skills/laravel-security/SKILL.md
@@ -3,6 +3,8 @@ name: laravel-security
 description: Laravel security best practices — authentication, authorization, Eloquent safety, CSRF, XSS prevention, API security, and secure deployment configurations. Use when reviewing Laravel auth, Eloquent safety, CSRF, XSS, API security, or deployment configuration.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Laravel Security Best Practices

--- a/skills/laravel-tdd/SKILL.md
+++ b/skills/laravel-tdd/SKILL.md
@@ -3,6 +3,8 @@ name: laravel-tdd
 description: Laravel testing strategies with PHPUnit, Pest, model factories, HTTP tests, Sanctum authentication testing, mocking, and coverage. Use when writing Laravel tests with PHPUnit or Pest, or driving a Laravel feature test-first.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Laravel Testing with TDD

--- a/skills/laravel-verification/SKILL.md
+++ b/skills/laravel-verification/SKILL.md
@@ -3,6 +3,8 @@ name: laravel-verification
 description: "Verification loop for Laravel projects: env checks, linting, static analysis, tests with coverage, security scans, and deployment readiness. Use when verifying a Laravel project before merge or deploy — lint, static analysis, tests, coverage, security."
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Laravel Verification Loop

--- a/skills/latency-critical-systems/SKILL.md
+++ b/skills/latency-critical-systems/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 metadata:
   origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
+compatibility: [claude-code, codex]
 ---
 
 # Latency Critical Systems

--- a/skills/lead-intelligence/SKILL.md
+++ b/skills/lead-intelligence/SKILL.md
@@ -3,6 +3,8 @@ name: lead-intelligence
 description: AI-native lead intelligence and outreach pipeline. Replaces Apollo, Clay, and ZoomInfo with agent-powered signal scoring, mutual ranking, warm path discovery, source-derived voice modeling, and channel-specific outreach across email, LinkedIn, and X. Use when the user wants to find, qualify, and reach high-value contacts.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Lead Intelligence

--- a/skills/liquid-glass-design/SKILL.md
+++ b/skills/liquid-glass-design/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: liquid-glass-design
 description: iOS 26 Liquid Glass design system — dynamic glass material with blur, reflection, and interactive morphing for SwiftUI, UIKit, and WidgetKit. Use when building iOS 26 Liquid Glass UI in SwiftUI, UIKit, or WidgetKit.
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Liquid Glass Design System (iOS 26)

--- a/skills/living-docs-governance/SKILL.md
+++ b/skills/living-docs-governance/SKILL.md
@@ -3,6 +3,8 @@ name: living-docs-governance
 description: "Keep a long-lived project's documentation from rotting by assigning existing project docs clear constitution, map, status, and history roles, then wiring the active agent harness to those canonical sources. Use in the maintain phase when docs drift from code, agents lose context between sessions, or intentional removals keep being recreated. Prefer adopting the repository's current docs structure over creating new root files. 中文触发：文档治理、活文档、项目状态追踪、防文档漂移、项目地图、健康仪表盘、删除区、长期项目治理"
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Living Docs Governance

--- a/skills/llm-trading-agent-security/SKILL.md
+++ b/skills/llm-trading-agent-security/SKILL.md
@@ -4,6 +4,8 @@ description: Security patterns for autonomous trading agents with wallet or tran
 metadata:
   version: "1.0.0"
   origin: ECC direct-port adaptation
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # LLM Trading Agent Security

--- a/skills/logistics-exception-management/SKILL.md
+++ b/skills/logistics-exception-management/SKILL.md
@@ -15,6 +15,7 @@ metadata:
   author: evos
   clawdbot:
     emoji: ""
+compatibility: [claude-code, codex]
 ---
 
 # Logistics Exception Management

--- a/skills/loop-design-check/SKILL.md
+++ b/skills/loop-design-check/SKILL.md
@@ -3,6 +3,8 @@ name: loop-design-check
 description: "Design a goal-oriented agent loop, and review it for the ways loops go wrong — spinning and burning tokens, Goodhart-gaming the verifier, or running a wrong answer to completion. Two actions: (1) WRITE a loop — gate whether to build it, define a machine-decidable goal, pick the loop type, pick a skeleton; (2) REVIEW a loop — run it past five failure modes plus decidability, boundaries, fallback, judge independence, and keep-judgment-with-the-human red lines. Use when designing an autonomous agent loop, or when you already have one and worry it will spin, cheat, or run a wrong answer to the end. Complements the mechanism-layer loop skills (autonomous-loops, continuous-agent-loop) by covering the judgment layer they don't. 中文触发：写 loop、设计 loop、做一个 loop、检查 loop 对不对、loop 体检、loop 会不会跑飞、可判定目标、五个崩法、plan build judge。English triggers: design an agent loop, write a loop, check a loop, loop review, prevent a runaway loop, goal-oriented loop, decidable goal, plan/build/judge."
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Loop Design + Review

--- a/skills/mailtrap-email-integration/SKILL.md
+++ b/skills/mailtrap-email-integration/SKILL.md
@@ -2,6 +2,8 @@
 name: mailtrap-email-integration
 description: Guides agents through integrating transactional email sending via Mailtrap's Email API, including sandbox testing, domain verification, and API authentication. Use when implementing email-sending features, debugging delivery issues, or setting up safe dev/staging email testing.
 origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Mailtrap Email Integration

--- a/skills/make-interfaces-feel-better/SKILL.md
+++ b/skills/make-interfaces-feel-better/SKILL.md
@@ -3,6 +3,8 @@ name: make-interfaces-feel-better
 description: Apply concrete design-engineering details that make interfaces feel polished. Use when reviewing or improving UI spacing, typography, borders, shadows, motion, hit areas, icons, text wrapping, and interaction states.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Make Interfaces Feel Better

--- a/skills/manim-video/SKILL.md
+++ b/skills/manim-video/SKILL.md
@@ -3,6 +3,8 @@ name: manim-video
 description: Build reusable Manim explainers for technical concepts, graphs, system diagrams, and product walkthroughs, then hand off to the wider ECC video stack if needed. Use when the user wants a clean animated explainer rather than a generic talking-head script.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Manim Video

--- a/skills/market-research/SKILL.md
+++ b/skills/market-research/SKILL.md
@@ -3,6 +3,8 @@ name: market-research
 description: Conduct market research, competitive analysis, investor due diligence, and industry intelligence with source attribution and decision-oriented summaries. Use when the user wants market sizing, competitor comparisons, fund research, technology scans, or research that informs business decisions.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Market Research

--- a/skills/marketing-campaign/SKILL.md
+++ b/skills/marketing-campaign/SKILL.md
@@ -3,6 +3,8 @@ name: marketing-campaign
 description: End-to-end marketing campaign planning and execution. Covers audience research, positioning, campaign angle definition, landing page copy, email sequences, social posts, ad copy, short-form video scripts, and content calendars. Use as the orchestration layer for multi-channel product launches. Use when planning or executing a multi-channel product launch, or producing landing page, email, social, or ad copy.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Marketing Campaign

--- a/skills/mcp-server-patterns/SKILL.md
+++ b/skills/mcp-server-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: mcp-server-patterns
 description: Build MCP servers with Node/TypeScript SDK — tools, resources, prompts, Zod validation, stdio vs Streamable HTTP. Use Context7 or official MCP docs for latest API. Use when building or debugging an MCP server — tools, resources, prompts, validation, or transport choice.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # MCP Server Patterns

--- a/skills/messages-ops/SKILL.md
+++ b/skills/messages-ops/SKILL.md
@@ -3,6 +3,8 @@ name: messages-ops
 description: Evidence-first live messaging workflow for ECC. Use when the user wants to read texts or DMs, recover a recent one-time code, inspect a thread before replying, or prove which message source was actually checked.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Messages Ops

--- a/skills/ml-adoption-playbook/SKILL.md
+++ b/skills/ml-adoption-playbook/SKILL.md
@@ -2,6 +2,8 @@
 name: ml-adoption-playbook
 description: End-to-end methodology for AI agents and software engineers to add machine learning algorithms to existing non-ML codebases. Covers problem framing, data readiness, architectural decoupling, and baseline model integration. Use when adding a machine learning capability to a codebase that has none, from problem framing through a baseline model.
 origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # ML Adoption Playbook

--- a/skills/mle-workflow/SKILL.md
+++ b/skills/mle-workflow/SKILL.md
@@ -4,6 +4,7 @@ description: Production machine-learning engineering workflow for data contracts
 license: MIT
 metadata:
   origin: ECC
+compatibility: [claude-code, codex]
 ---
 
 # Machine Learning Engineering Workflow

--- a/skills/motion-advanced/SKILL.md
+++ b/skills/motion-advanced/SKILL.md
@@ -6,6 +6,8 @@ category: frontend
 author: jeff
 metadata:
   version: 1.0.0
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Motion Advanced

--- a/skills/motion-foundations/SKILL.md
+++ b/skills/motion-foundations/SKILL.md
@@ -6,6 +6,8 @@ category: frontend
 author: jeff
 metadata:
   version: 1.0.0
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Motion Foundations

--- a/skills/motion-patterns/SKILL.md
+++ b/skills/motion-patterns/SKILL.md
@@ -6,6 +6,8 @@ category: frontend
 author: jeff
 metadata:
   version: 1.0.0
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Motion Patterns

--- a/skills/motion-ui/SKILL.md
+++ b/skills/motion-ui/SKILL.md
@@ -3,6 +3,8 @@ name: motion-ui
 description: "Production-ready UI motion system for React/Next.js. Use when implementing animations, transitions, or motion patterns."
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Motion System v4.2

--- a/skills/mysql-patterns/SKILL.md
+++ b/skills/mysql-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: mysql-patterns
 description: MySQL and MariaDB schema, query, indexing, transaction, replication, and connection-pool patterns for production backends. Use when designing MySQL or MariaDB schemas and indexes, or when a query, transaction, or replica lags.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # MySQL Patterns

--- a/skills/nanoclaw-repl/SKILL.md
+++ b/skills/nanoclaw-repl/SKILL.md
@@ -3,6 +3,8 @@ name: nanoclaw-repl
 description: Operate and extend NanoClaw v2, ECC's zero-dependency session-aware REPL built on claude -p. Use when operating or extending the NanoClaw REPL.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # NanoClaw REPL

--- a/skills/nasiko-control-plane/SKILL.md
+++ b/skills/nasiko-control-plane/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: nasiko-control-plane
 description: Use the experimental Nasiko CLI lifecycle bridge for pinned installation, read-only status, and qualified uninstall with explicit consent and telemetry and secrets boundaries.
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Nasiko CLI Lifecycle Bridge

--- a/skills/nestjs-patterns/SKILL.md
+++ b/skills/nestjs-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: nestjs-patterns
 description: NestJS architecture patterns for modules, controllers, providers, DTO validation, guards, interceptors, config, and production-grade TypeScript backends. Use when building or reviewing a NestJS backend — modules, providers, DTO validation, guards, or interceptors.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # NestJS Development Patterns

--- a/skills/netmiko-ssh-automation/SKILL.md
+++ b/skills/netmiko-ssh-automation/SKILL.md
@@ -3,6 +3,8 @@ name: netmiko-ssh-automation
 description: Safe Python Netmiko patterns for read-only collection, bounded batch SSH, TextFSM parsing, guarded config changes, timeouts, and network automation error handling. Use when automating network device access with Python Netmiko, whether collecting state or pushing guarded config changes.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Netmiko SSH Automation

--- a/skills/network-bgp-diagnostics/SKILL.md
+++ b/skills/network-bgp-diagnostics/SKILL.md
@@ -3,6 +3,8 @@ name: network-bgp-diagnostics
 description: Diagnostics-only BGP troubleshooting patterns for neighbor state, route exchange, prefix policy, AS path inspection, and safe evidence collection. Use when a BGP neighbor is down, routes are missing, or prefix policy and AS path need inspection.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Network BGP Diagnostics

--- a/skills/network-config-validation/SKILL.md
+++ b/skills/network-config-validation/SKILL.md
@@ -3,6 +3,8 @@ name: network-config-validation
 description: Pre-deployment checks for router and switch configuration, including dangerous commands, duplicate addresses, subnet overlaps, stale references, management-plane risk, and IOS-style security hygiene. Use when reviewing a router or switch configuration before deployment.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Network Config Validation

--- a/skills/network-interface-health/SKILL.md
+++ b/skills/network-interface-health/SKILL.md
@@ -3,6 +3,8 @@ name: network-interface-health
 description: Diagnose interface errors, drops, CRCs, duplex mismatches, flapping, speed negotiation issues, and counter trends on routers, switches, and Linux hosts. Use when an interface shows errors, drops, CRCs, flapping, or a duplex or speed mismatch.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Network Interface Health

--- a/skills/nextjs-turbopack/SKILL.md
+++ b/skills/nextjs-turbopack/SKILL.md
@@ -3,6 +3,8 @@ name: nextjs-turbopack
 description: Next.js 16+ and Turbopack — incremental bundling, FS caching, dev speed, and when to use Turbopack vs webpack.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Next.js and Turbopack

--- a/skills/nodejs-keccak256/SKILL.md
+++ b/skills/nodejs-keccak256/SKILL.md
@@ -4,6 +4,8 @@ description: Prevent Ethereum hashing bugs in JavaScript and TypeScript. Node's 
 metadata:
   version: "1.0.0"
   origin: ECC direct-port adaptation
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Node.js Keccak-256

--- a/skills/nutrient-document-processing/SKILL.md
+++ b/skills/nutrient-document-processing/SKILL.md
@@ -3,6 +3,8 @@ name: nutrient-document-processing
 description: Process, convert, OCR, extract, redact, sign, and fill documents using the Nutrient DWS API. Works with PDFs, DOCX, XLSX, PPTX, HTML, and images. Use when converting, OCRing, extracting from, redacting, signing, or filling documents via the Nutrient DWS API.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Nutrient Document Processing

--- a/skills/nuxt4-patterns/SKILL.md
+++ b/skills/nuxt4-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: nuxt4-patterns
 description: Nuxt 4 app patterns for hydration safety, performance, route rules, lazy loading, and SSR-safe data fetching with useFetch and useAsyncData. Use when building or reviewing a Nuxt 4 app, or debugging hydration mismatches and SSR-safe data fetching.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Nuxt 4 Patterns

--- a/skills/openclaw-persona-forge/SKILL.md
+++ b/skills/openclaw-persona-forge/SKILL.md
@@ -3,6 +3,8 @@ name: openclaw-persona-forge
 description: "为 OpenClaw AI Agent 锻造完整的龙虾灵魂方案。根据用户偏好或随机抽卡， 输出身份定位、灵魂描述(SOUL.md)、角色化底线规则、名字和头像生图提示词。 如当前环境提供已审核的生图 skill，可自动生成统一风格头像图片。 当用户需要创建、设计或定制 OpenClaw 龙虾灵魂时使用。 不适用于：微调已有 SOUL.md、非 OpenClaw 平台的角色设计、纯工具型无性格 Agent。 触发词：龙虾灵魂、虾魂、OpenClaw 灵魂、养虾灵魂、龙虾角色、龙虾定位、 龙虾剧本杀角色、龙虾游戏角色、龙虾 NPC、龙虾性格、龙虾背景故事、 lobster soul、lobster character、抽卡、随机龙虾、龙虾 SOUL、gacha。 Use when creating, designing, or customizing an OpenClaw lobster persona — identity, SOUL.md, name, or avatar prompt."
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # 龙虾灵魂锻造炉

--- a/skills/opensource-pipeline/SKILL.md
+++ b/skills/opensource-pipeline/SKILL.md
@@ -3,6 +3,8 @@ name: opensource-pipeline
 description: "Open-source pipeline: fork, sanitize, and package private projects for safe public release. Chains 3 agents (forker, sanitizer, packager). Triggers: '/opensource', 'open source this', 'make this public', 'prepare for open source'. Use when a private project must be forked, stripped of secrets, and packaged for public release."
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Open-Source Pipeline Skill

--- a/skills/orch-add-feature/SKILL.md
+++ b/skills/orch-add-feature/SKILL.md
@@ -3,6 +3,8 @@ name: orch-add-feature
 description: Orchestrate building a brand-new feature end to end — research, plan, TDD implementation, review, and gated commit — by delegating each phase to the matching ECC agent. Use when adding a capability that does not exist yet.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # orch-add-feature

--- a/skills/orch-build-mvp/SKILL.md
+++ b/skills/orch-build-mvp/SKILL.md
@@ -3,6 +3,8 @@ name: orch-build-mvp
 description: Orchestrate bootstrapping a working MVP from a design or spec document — ingest the doc, plan thin vertical slices, scaffold the first end-to-end slice, then TDD-implement, review, and gated commit. Use to turn an SDD/PRD into a running starting point. Use when a design or spec document must become a running MVP through planned vertical slices.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # orch-build-mvp

--- a/skills/orch-change-feature/SKILL.md
+++ b/skills/orch-change-feature/SKILL.md
@@ -3,6 +3,8 @@ name: orch-change-feature
 description: Orchestrate altering an existing, working feature to new desired behavior — update its tests to the new spec, change the implementation to match, review, and gated commit. Use when behavior is not broken but should be different.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # orch-change-feature

--- a/skills/orch-fix-defect/SKILL.md
+++ b/skills/orch-fix-defect/SKILL.md
@@ -3,6 +3,8 @@ name: orch-fix-defect
 description: Orchestrate fixing a bug — reproduce it as a failing regression test, fix to green, review, and gated commit — by delegating each phase to the matching ECC agent. Use when existing behavior is broken or wrong.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # orch-fix-defect

--- a/skills/orch-pipeline/SKILL.md
+++ b/skills/orch-pipeline/SKILL.md
@@ -3,6 +3,8 @@ name: orch-pipeline
 description: Shared orchestration engine for the orch-* skill family. Defines the gated Research-Plan-TDD-Review-Commit pipeline, the size classifier, the agent map, and the two human gates that the orch-* operation skills delegate to. Not usually invoked directly. Not usually invoked directly; it applies when an orch-* skill delegates its gated Research-Plan-TDD-Review-Commit pipeline.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Orchestrator Pipeline (shared engine)

--- a/skills/orch-refine-code/SKILL.md
+++ b/skills/orch-refine-code/SKILL.md
@@ -3,6 +3,8 @@ name: orch-refine-code
 description: Orchestrate a behavior-preserving refactor — confirm tests are green, restructure without changing behavior, keep tests green, review, and gated commit. Use when the structure should improve but behavior must not change.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # orch-refine-code

--- a/skills/parallel-execution-optimizer/SKILL.md
+++ b/skills/parallel-execution-optimizer/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 metadata:
   origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
+compatibility: [claude-code, codex]
 ---
 
 # Parallel Execution Optimizer

--- a/skills/perl-patterns/SKILL.md
+++ b/skills/perl-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: perl-patterns
 description: Modern Perl 5.36+ idioms, best practices, and conventions for building robust, maintainable Perl applications. Use when writing or reviewing modern Perl 5.36+ code.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Modern Perl Development Patterns

--- a/skills/perl-security/SKILL.md
+++ b/skills/perl-security/SKILL.md
@@ -3,6 +3,8 @@ name: perl-security
 description: Comprehensive Perl security covering taint mode, input validation, safe process execution, DBI parameterized queries, web security (XSS/SQLi/CSRF), and perlcritic security policies. Use when reviewing Perl input handling, process execution, DBI queries, or web-facing code.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Perl Security Patterns

--- a/skills/perl-testing/SKILL.md
+++ b/skills/perl-testing/SKILL.md
@@ -3,6 +3,8 @@ name: perl-testing
 description: Perl testing patterns using Test2::V0, Test::More, prove runner, mocking, coverage with Devel::Cover, and TDD methodology. Use when writing Perl tests with Test2::V0 or Test::More, or measuring coverage.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Perl Testing Patterns

--- a/skills/plan-canvas/SKILL.md
+++ b/skills/plan-canvas/SKILL.md
@@ -4,6 +4,8 @@ description: Open plans and HTML artifacts in a local browser canvas where the h
 metadata:
   version: "1.0.0"
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Plan Canvas

--- a/skills/plan-orchestrate/SKILL.md
+++ b/skills/plan-orchestrate/SKILL.md
@@ -3,6 +3,8 @@ name: plan-orchestrate
 description: Read a plan document, decompose it into steps, design a per-step agent chain from the ECC catalogue, and emit ready-to-paste /orchestrate custom prompts. Generative only — never invokes /orchestrate itself. Use when the user has a multi-step plan and wants to drive it through orchestrate without composing chains by hand.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Plan Orchestrate

--- a/skills/plankton-code-quality/SKILL.md
+++ b/skills/plankton-code-quality/SKILL.md
@@ -3,6 +3,8 @@ name: plankton-code-quality
 description: "Write-time code quality enforcement using Plankton — auto-formatting, linting, and Claude-powered fixes on every file edit via hooks. Use when setting up write-time formatting, linting, or auto-fix hooks on file edits."
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Plankton Code Quality Skill

--- a/skills/postgres-patterns/SKILL.md
+++ b/skills/postgres-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: postgres-patterns
 description: PostgreSQL database patterns for query optimization, schema design, indexing, and security. Based on Supabase best practices. Use when designing PostgreSQL schemas, indexes, or RLS policies, or when a query is too slow.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # PostgreSQL Patterns

--- a/skills/prediction-market-oracle-research/SKILL.md
+++ b/skills/prediction-market-oracle-research/SKILL.md
@@ -3,6 +3,8 @@ name: prediction-market-oracle-research
 description: Research prediction markets as data sources or oracle signals for products, agents, dashboards, and corporate decision intelligence. Use for source-grounded analysis of market-implied probabilities, caveats, and integration patterns without investment advice. Use when evaluating prediction markets as a data source or oracle signal for a product, agent, or dashboard.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Prediction Market Oracle Research

--- a/skills/prediction-market-risk-review/SKILL.md
+++ b/skills/prediction-market-risk-review/SKILL.md
@@ -3,6 +3,8 @@ name: prediction-market-risk-review
 description: Review prediction-market, basket, oracle, and trading-agent workflows for compliance, safety, data-quality, privacy, and execution risk. Use before any workflow handles venue auth, user portfolio data, API keys, or trade planning.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Prediction Market Risk Review

--- a/skills/prisma-patterns/SKILL.md
+++ b/skills/prisma-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: prisma-patterns
 description: Prisma ORM patterns for TypeScript backends — schema design, query optimization, transactions, pagination, and critical traps like updateMany returning count not records, $transaction timeouts, migrate dev resetting the DB, @updatedAt skipped on bulk writes, and serverless connection exhaustion. Use when writing a Prisma schema or query, or debugging transactions, migrations, or serverless connection limits.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Prisma Patterns

--- a/skills/product-capability/SKILL.md
+++ b/skills/product-capability/SKILL.md
@@ -3,6 +3,8 @@ name: product-capability
 description: Translate PRD intent, roadmap asks, or product discussions into an implementation-ready capability plan that exposes constraints, invariants, interfaces, and unresolved decisions before multi-service work starts. Use when the user needs an ECC-native PRD-to-SRS lane instead of vague planning prose.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Product Capability

--- a/skills/product-lens/SKILL.md
+++ b/skills/product-lens/SKILL.md
@@ -3,6 +3,8 @@ name: product-lens
 description: Use this skill to validate the "why" before building, run product diagnostics, and pressure-test product direction before the request becomes an implementation contract.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Product Lens — Think Before You Build

--- a/skills/production-audit/SKILL.md
+++ b/skills/production-audit/SKILL.md
@@ -3,6 +3,8 @@ name: production-audit
 description: Local-evidence production readiness audit for shipped apps, pre-launch reviews, post-merge checks, and "what breaks in prod?" questions without sending repo data to an external audit service. Use when auditing production readiness before launch, after a merge, or when asked what breaks in prod.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Production Audit

--- a/skills/production-scheduling/SKILL.md
+++ b/skills/production-scheduling/SKILL.md
@@ -16,6 +16,7 @@ metadata:
   author: evos
   clawdbot:
     emoji: ""
+compatibility: [claude-code, codex]
 ---
 
 # Production Scheduling

--- a/skills/project-flow-ops/SKILL.md
+++ b/skills/project-flow-ops/SKILL.md
@@ -3,6 +3,8 @@ name: project-flow-ops
 description: Operate execution flow across GitHub and Linear by triaging issues and pull requests, linking active work, and keeping GitHub public-facing while Linear remains the internal execution layer. Use when the user wants backlog control, PR triage, or GitHub-to-Linear coordination.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Project Flow Ops

--- a/skills/prompt-optimizer/SKILL.md
+++ b/skills/prompt-optimizer/SKILL.md
@@ -16,6 +16,8 @@ metadata:
   origin: community
   author: YannJY02
   version: "1.0.0"
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Prompt Optimizer

--- a/skills/python-patterns/SKILL.md
+++ b/skills/python-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: python-patterns
 description: Pythonic idioms, PEP 8 standards, type hints, and best practices for building robust, efficient, and maintainable Python applications. Use when writing or reviewing Python code and idiomatic structure, typing, or PEP 8 is in question.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Python Development Patterns

--- a/skills/python-testing/SKILL.md
+++ b/skills/python-testing/SKILL.md
@@ -3,6 +3,8 @@ name: python-testing
 description: Python testing strategies using pytest, TDD methodology, fixtures, mocking, parametrization, and coverage requirements. Use when writing pytest tests — fixtures, mocks, parametrization, or coverage.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Python Testing Patterns

--- a/skills/pytorch-patterns/SKILL.md
+++ b/skills/pytorch-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: pytorch-patterns
 description: PyTorch deep learning patterns and best practices for building robust, efficient, and reproducible training pipelines, model architectures, and data loading. Use when writing or reviewing PyTorch training loops, model architectures, or data loading, or when a run will not reproduce.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # PyTorch Development Patterns

--- a/skills/quality-nonconformance/SKILL.md
+++ b/skills/quality-nonconformance/SKILL.md
@@ -16,6 +16,7 @@ metadata:
   author: evos
   clawdbot:
     emoji: ""
+compatibility: [claude-code, codex]
 ---
 
 # Quality & Non-Conformance Management

--- a/skills/quarkus-patterns/SKILL.md
+++ b/skills/quarkus-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: quarkus-patterns
 description: Quarkus 3.x LTS architecture patterns with Camel for messaging, RESTful API design, CDI services, data access with Panache, and async processing. Use for Java Quarkus backend work with event-driven architectures. Use when building or reviewing a Quarkus service, especially with Camel messaging or Panache data access.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Quarkus Development Patterns

--- a/skills/quarkus-security/SKILL.md
+++ b/skills/quarkus-security/SKILL.md
@@ -3,6 +3,8 @@ name: quarkus-security
 description: Quarkus Security best practices for authentication, authorization, JWT/OIDC, RBAC, input validation, CSRF, secrets management, and dependency security. Use when reviewing Quarkus authn/authz, JWT or OIDC, RBAC, validation, or secrets.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Quarkus Security Review

--- a/skills/quarkus-tdd/SKILL.md
+++ b/skills/quarkus-tdd/SKILL.md
@@ -3,6 +3,8 @@ name: quarkus-tdd
 description: Test-driven development for Quarkus 3.x LTS using JUnit 5, Mockito, REST Assured, Camel testing, and JaCoCo. Use when adding features, fixing bugs, or refactoring event-driven services.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Quarkus TDD Workflow

--- a/skills/quarkus-verification/SKILL.md
+++ b/skills/quarkus-verification/SKILL.md
@@ -3,6 +3,8 @@ name: quarkus-verification
 description: "Verification loop for Quarkus projects: build, static analysis, tests with coverage, security scans, native compilation, and diff review before release or PR."
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Quarkus Verification Loop

--- a/skills/ralphinho-rfc-pipeline/SKILL.md
+++ b/skills/ralphinho-rfc-pipeline/SKILL.md
@@ -3,6 +3,8 @@ name: ralphinho-rfc-pipeline
 description: RFC-driven multi-agent DAG execution pattern with quality gates, merge queues, and work unit orchestration. Use when running RFC-driven multi-agent execution with quality gates and a merge queue.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Ralphinho RFC Pipeline

--- a/skills/react-native-patterns/SKILL.md
+++ b/skills/react-native-patterns/SKILL.md
@@ -2,6 +2,8 @@
 name: react-native-patterns
 description: React Native and Expo app patterns — Expo Router navigation, state separation (server/client/route/form), TanStack Query data fetching with Zod, performant lists, NativeWind/StyleSheet styling, native APIs, and secure storage. Use when building or editing React Native / Expo screens, components, navigation, or data layers.
 origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # React Native / Expo Patterns

--- a/skills/react-patterns/SKILL.md
+++ b/skills/react-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: react-patterns
 description: React 18/19 patterns including hooks discipline, server/client component boundaries, Suspense + error boundaries, form actions, data fetching, state management decision trees, and accessibility-first composition. Use when writing or reviewing React components.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # React Patterns

--- a/skills/react-performance/SKILL.md
+++ b/skills/react-performance/SKILL.md
@@ -3,6 +3,8 @@ name: react-performance
 description: React and Next.js performance optimization patterns adapted from Vercel Engineering's React Best Practices (https://github.com/vercel-labs/agent-skills). Organizes 70+ rules across 8 priority categories — waterfalls, bundle size, server-side, client fetching, re-render, rendering, JS micro-perf, advanced. Use when writing, reviewing, or refactoring React/Next.js code for performance.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # React Performance

--- a/skills/react-testing/SKILL.md
+++ b/skills/react-testing/SKILL.md
@@ -3,6 +3,8 @@ name: react-testing
 description: React component testing with React Testing Library, Vitest/Jest, MSW for network mocking, accessibility assertions with axe, and the decision boundary between component tests and Playwright/Cypress end-to-end runs. Use when writing or fixing tests for React components, hooks, or pages.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # React Testing

--- a/skills/recsys-pipeline-architect/SKILL.md
+++ b/skills/recsys-pipeline-architect/SKILL.md
@@ -3,6 +3,8 @@ name: recsys-pipeline-architect
 description: Design composable recommendation, ranking, and feed pipelines using the six-stage Source→Hydrator→Filter→Scorer→Selector→SideEffect framework popularized by xAI's open-sourced For You algorithm. Use this skill whenever the user is building any system that picks "the top K items for a (user, context)" — social feeds, content CMSs, RAG rerankers, task prioritizers, notification triage, search reranking, ad ranking.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # recsys-pipeline-architect

--- a/skills/recursive-decision-ledger/SKILL.md
+++ b/skills/recursive-decision-ledger/SKILL.md
@@ -5,6 +5,7 @@ license: MIT
 metadata:
   origin: ECC
 tools: Read, Write, Edit, Bash, Grep, Glob
+compatibility: [claude-code, codex]
 ---
 
 # Recursive Decision Ledger

--- a/skills/redis-patterns/SKILL.md
+++ b/skills/redis-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: redis-patterns
 description: Redis data structure patterns, caching strategies, distributed locks, rate limiting, pub/sub, and connection management for production applications. Use when adding caching, a distributed lock, rate limiting, or pub/sub with Redis, or when key design needs review.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Redis Patterns

--- a/skills/regex-vs-llm-structured-text/SKILL.md
+++ b/skills/regex-vs-llm-structured-text/SKILL.md
@@ -3,6 +3,8 @@ name: regex-vs-llm-structured-text
 description: Decision framework for choosing between regex and LLM when parsing structured text — start with regex, add LLM only for low-confidence edge cases.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Regex vs LLM for Structured Text Parsing

--- a/skills/remotion-video-creation/SKILL.md
+++ b/skills/remotion-video-creation/SKILL.md
@@ -3,6 +3,8 @@ name: remotion-video-creation
 description: Best practices for Remotion - Video creation in React. 29 domain-specific rules covering 3D, animations, audio, captions, charts, transitions, and more. Use when building video in React with Remotion — animations, audio, captions, charts, or transitions.
 metadata:
   tags: remotion, video, react, animation, composition, three.js, lottie
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 ## When to use

--- a/skills/repo-scan/SKILL.md
+++ b/skills/repo-scan/SKILL.md
@@ -3,6 +3,8 @@ name: repo-scan
 description: Bootstrap pointer that installs the external repo-scan skill from a pinned, reviewable commit. Use when repo-scan must be installed before running its cross-stack source-code asset audit; this ECC pointer does not perform the audit itself.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # repo-scan

--- a/skills/research-ops/SKILL.md
+++ b/skills/research-ops/SKILL.md
@@ -3,6 +3,8 @@ name: research-ops
 description: Evidence-first current-state research workflow for ECC. Use when the user wants fresh facts, comparisons, enrichment, or a recommendation built from current public evidence and any supplied local context.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Research Ops

--- a/skills/returns-reverse-logistics/SKILL.md
+++ b/skills/returns-reverse-logistics/SKILL.md
@@ -16,6 +16,7 @@ metadata:
   author: evos
   clawdbot:
     emoji: ""
+compatibility: [claude-code, codex]
 ---
 
 # Returns & Reverse Logistics

--- a/skills/rules-distill/SKILL.md
+++ b/skills/rules-distill/SKILL.md
@@ -3,6 +3,8 @@ name: rules-distill
 description: "Scan skills to extract cross-cutting principles and distill them into rules — append, revise, or create new rule files. Use when the same principle keeps recurring across skills and belongs in a rule file instead."
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Rules Distill

--- a/skills/rust-patterns/SKILL.md
+++ b/skills/rust-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: rust-patterns
 description: Idiomatic Rust patterns, ownership, error handling, traits, concurrency, and best practices for building safe, performant applications. Use when writing or reviewing Rust code and ownership, error handling, traits, or concurrency is in question.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Rust Development Patterns

--- a/skills/rust-testing/SKILL.md
+++ b/skills/rust-testing/SKILL.md
@@ -3,6 +3,8 @@ name: rust-testing
 description: Rust testing patterns including unit tests, integration tests, async testing, property-based testing, mocking, and coverage. Follows TDD methodology. Use when writing Rust tests — unit, integration, async, property-based, or coverage.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Rust Testing Patterns

--- a/skills/safety-guard/SKILL.md
+++ b/skills/safety-guard/SKILL.md
@@ -3,6 +3,8 @@ name: safety-guard
 description: Use this skill to prevent destructive operations when working on production systems or running agents autonomously.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Safety Guard — Prevent Destructive Operations

--- a/skills/santa-method/SKILL.md
+++ b/skills/santa-method/SKILL.md
@@ -3,6 +3,8 @@ name: santa-method
 description: "Multi-agent adversarial verification with convergence loop. Two independent review agents must both pass before output ships. Use when output must clear two independent adversarial reviewers before it ships."
 metadata:
   origin: "Ronald Skelton - Founder, RapportScore.ai"
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Santa Method

--- a/skills/scientific-db-pubmed-database/SKILL.md
+++ b/skills/scientific-db-pubmed-database/SKILL.md
@@ -3,6 +3,8 @@ name: pubmed-database
 description: Direct PubMed and NCBI E-utilities search workflows for biomedical literature, MeSH queries, PMID lookup, citation retrieval, and API-backed literature monitoring. Use when a task needs biomedical literature from PubMed rather than general web search.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # PubMed Database

--- a/skills/scientific-db-uspto-database/SKILL.md
+++ b/skills/scientific-db-uspto-database/SKILL.md
@@ -3,6 +3,8 @@ name: uspto-database
 description: USPTO patent and trademark data workflow for official record lookup, PatentSearch queries, TSDR checks, assignment data, and reproducible IP research logs. Use when a task needs official United States patent or trademark records from USPTO systems.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # USPTO Database

--- a/skills/scientific-pkg-gget/SKILL.md
+++ b/skills/scientific-pkg-gget/SKILL.md
@@ -3,6 +3,8 @@ name: gget
 description: gget CLI and Python workflow for quick genomic database queries, sequence lookup, BLAST-style searches, enrichment checks, and reproducible bioinformatics evidence logs. Use when a task needs quick bioinformatics lookup across genomic reference databases with the gget CLI or Python package.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # gget

--- a/skills/scientific-thinking-literature-review/SKILL.md
+++ b/skills/scientific-thinking-literature-review/SKILL.md
@@ -3,6 +3,8 @@ name: literature-review
 description: Systematic literature-review workflow for academic, biomedical, technical, and scientific topics, including search planning, source screening, synthesis, citation checks, and evidence logging. Use when the task is to find, screen, synthesize, and cite a body of academic or technical literature.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Literature Review

--- a/skills/scientific-thinking-scholar-evaluation/SKILL.md
+++ b/skills/scientific-thinking-scholar-evaluation/SKILL.md
@@ -3,6 +3,8 @@ name: scholar-evaluation
 description: Structured scholarly-work evaluation for papers, proposals, literature reviews, methods sections, evidence quality, citation support, and research-writing feedback. Use when evaluating academic or scientific work — papers, proposals, methods sections, or evidence quality — against a repeatable rubric.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Scholar Evaluation

--- a/skills/search-first/SKILL.md
+++ b/skills/search-first/SKILL.md
@@ -3,6 +3,8 @@ name: search-first
 description: Research-before-coding workflow. Search for existing tools, libraries, and patterns before writing custom code. Invokes the researcher agent.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # /search-first — Research Before You Code

--- a/skills/security-bounty-hunter/SKILL.md
+++ b/skills/security-bounty-hunter/SKILL.md
@@ -4,6 +4,8 @@ description: Hunt for exploitable, bounty-worthy security issues in repositories
 metadata:
   version: "1.0.0"
   origin: ECC direct-port adaptation
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Security Bounty Hunter

--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -3,6 +3,8 @@ name: security-review
 description: Use this skill when adding authentication, handling user input, working with secrets, creating API endpoints, or implementing payment/sensitive features. Provides comprehensive security checklist and patterns.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Security Review Skill

--- a/skills/security-scan/SKILL.md
+++ b/skills/security-scan/SKILL.md
@@ -3,6 +3,8 @@ name: security-scan
 description: Scan your Claude Code configuration (.claude/ directory) for security vulnerabilities, misconfigurations, and injection risks using AgentShield. Checks CLAUDE.md, settings.json, MCP servers, hooks, and agent definitions. Use when auditing a .claude/ directory — CLAUDE.md, settings.json, MCP servers, hooks, or agent definitions.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Security Scan Skill

--- a/skills/seo/SKILL.md
+++ b/skills/seo/SKILL.md
@@ -3,6 +3,8 @@ name: seo
 description: Audit, plan, and implement SEO improvements across technical SEO, on-page optimization, structured data, Core Web Vitals, and content strategy. Use when the user wants better search visibility, SEO remediation, schema markup, sitemap/robots work, or keyword mapping.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # SEO

--- a/skills/skill-comply/SKILL.md
+++ b/skills/skill-comply/SKILL.md
@@ -4,6 +4,8 @@ description: Visualize whether skills, rules, and agent definitions are actually
 metadata:
   origin: ECC
 tools: Read, Bash
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # skill-comply: Automated Compliance Measurement

--- a/skills/skill-scout/SKILL.md
+++ b/skills/skill-scout/SKILL.md
@@ -3,6 +3,8 @@ name: skill-scout
 description: Search existing local, marketplace, GitHub, and web skill sources before creating a new skill. Use when the user wants to create, build, fork, or find a skill for a workflow.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Skill Scout

--- a/skills/skill-stocktake/SKILL.md
+++ b/skills/skill-stocktake/SKILL.md
@@ -3,6 +3,8 @@ name: skill-stocktake
 description: "Use when auditing Claude skills and commands for quality. Supports Quick Scan (changed skills only) and Full Stocktake modes with sequential subagent batch evaluation."
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # skill-stocktake

--- a/skills/social-graph-ranker/SKILL.md
+++ b/skills/social-graph-ranker/SKILL.md
@@ -3,6 +3,8 @@ name: social-graph-ranker
 description: Weighted social-graph ranking for warm intro discovery, bridge scoring, and network gap analysis across X and LinkedIn. Use when the user wants the reusable graph-ranking engine itself, not the broader outreach or network-maintenance workflow layered on top of it.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Social Graph Ranker

--- a/skills/social-publisher/SKILL.md
+++ b/skills/social-publisher/SKILL.md
@@ -3,6 +3,8 @@ name: social-publisher
 description: Agent-driven scheduling and publishing of social media posts across 13 platforms via SocialClaw. Use when the user wants to publish to X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, or Pinterest — or when managing campaigns, uploading media, or monitoring post delivery status.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Social Publisher (SocialClaw)

--- a/skills/springboot-patterns/SKILL.md
+++ b/skills/springboot-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: springboot-patterns
 description: Spring Boot architecture patterns, REST API design, layered services, data access, caching, async processing, and logging. Use for Java Spring Boot backend work. Use when building or reviewing a Spring Boot backend — REST layer, services, data access, caching, or async work.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Spring Boot Development Patterns

--- a/skills/springboot-security/SKILL.md
+++ b/skills/springboot-security/SKILL.md
@@ -3,6 +3,8 @@ name: springboot-security
 description: Spring Security best practices for authn/authz, validation, CSRF, secrets, headers, rate limiting, and dependency security in Java Spring Boot services. Use when reviewing Spring Security authn/authz, validation, CSRF, secrets, headers, or rate limiting.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Spring Boot Security Review

--- a/skills/springboot-tdd/SKILL.md
+++ b/skills/springboot-tdd/SKILL.md
@@ -3,6 +3,8 @@ name: springboot-tdd
 description: Test-driven development for Spring Boot using JUnit 5, Mockito, MockMvc, Testcontainers, and JaCoCo. Use when adding features, fixing bugs, or refactoring.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Spring Boot TDD Workflow

--- a/skills/springboot-verification/SKILL.md
+++ b/skills/springboot-verification/SKILL.md
@@ -3,6 +3,8 @@ name: springboot-verification
 description: "Verification loop for Spring Boot projects: build, static analysis, tests with coverage, security scans, and diff review before release or PR."
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Spring Boot Verification Loop

--- a/skills/strategic-compact/SKILL.md
+++ b/skills/strategic-compact/SKILL.md
@@ -3,6 +3,8 @@ name: strategic-compact
 description: Suggests manual context compaction at logical intervals to preserve context through task phases rather than arbitrary auto-compaction. Use when a session is approaching a context limit and a task phase is a natural place to compact.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Strategic Compact Skill

--- a/skills/swift-actor-persistence/SKILL.md
+++ b/skills/swift-actor-persistence/SKILL.md
@@ -3,6 +3,8 @@ name: swift-actor-persistence
 description: Thread-safe data persistence in Swift using actors — in-memory cache with file-backed storage, eliminating data races by design. Use when persisting data in Swift and a data race or thread-safety problem needs designing out.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Swift Actors for Thread-Safe Persistence

--- a/skills/swift-concurrency-6-2/SKILL.md
+++ b/skills/swift-concurrency-6-2/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: swift-concurrency-6-2
 description: Swift 6.2 Approachable Concurrency — single-threaded by default, @concurrent for explicit background offloading, isolated conformances for main actor types. Use when adopting Swift 6.2 concurrency — offloading with @concurrent or resolving main-actor isolation.
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Swift 6.2 Approachable Concurrency

--- a/skills/swift-protocol-di-testing/SKILL.md
+++ b/skills/swift-protocol-di-testing/SKILL.md
@@ -3,6 +3,8 @@ name: swift-protocol-di-testing
 description: Protocol-based dependency injection for testable Swift code — mock file system, network, and external APIs using focused protocols and Swift Testing. Use when Swift code needs testing and file system, network, or external APIs must be mocked.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Swift Protocol-Based Dependency Injection for Testing

--- a/skills/swiftui-patterns/SKILL.md
+++ b/skills/swiftui-patterns/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: swiftui-patterns
 description: SwiftUI architecture patterns, state management with @Observable, view composition, navigation, performance optimization, and modern iOS/macOS UI best practices. Use when building or reviewing SwiftUI views, @Observable state, navigation, or render performance.
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # SwiftUI Patterns

--- a/skills/taste/SKILL.md
+++ b/skills/taste/SKILL.md
@@ -2,6 +2,8 @@
 name: taste
 description: A creative-direction (taste) layer for music videos and short-form edits in the angelcore / cloud-trance / hyperpop visual family. Distills a named-genre aesthetic vocabulary, a mood + color + light system, and a beat-synced editing grammar, then chains ECC's video skills (video-editing, fal-ai-media, remotion-video-creation, motion-*, content-engine) into one production pipeline. Use when the work is not just making a video function but making it feel intentional, when building a music video, a fancam/edit, a moodboard-driven reel, or when choosing a coherent visual direction for AI-generated b-roll.
 origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Taste

--- a/skills/tasteforge-video/SKILL.md
+++ b/skills/tasteforge-video/SKILL.md
@@ -3,6 +3,8 @@ name: tasteforge-video
 description: Use for file-driven multimodal image, video, and 3D-asset discovery; taste interviews; distill or apply workflows; style-pack validation; editable EDL/FCPXML export; provenance audits; and offline planning that must fail closed before provider generation.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # TasteForge Video

--- a/skills/tdd-workflow/SKILL.md
+++ b/skills/tdd-workflow/SKILL.md
@@ -4,6 +4,8 @@ description: Use this skill when writing new features, fixing bugs, or refactori
 argument-hint: <path/to/*.plan.md>
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Test-Driven Development Workflow

--- a/skills/team-agent-orchestration/SKILL.md
+++ b/skills/team-agent-orchestration/SKILL.md
@@ -3,6 +3,8 @@ name: team-agent-orchestration
 description: "Run team-based orchestration for agent squads using work items, ownership, agent Kanban, merge gates, and control pane handoffs. Use when coordinating an agent squad with work items, ownership, Kanban, and merge gates."
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Team Agent Orchestration

--- a/skills/team-builder/SKILL.md
+++ b/skills/team-builder/SKILL.md
@@ -3,6 +3,8 @@ name: team-builder
 description: Interactive agent picker for composing and dispatching parallel teams. Use when composing and dispatching a parallel team of agents for a task.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Team Builder

--- a/skills/terminal-opener/SKILL.md
+++ b/skills/terminal-opener/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: terminal-opener
 description: Open an executable and its argument array in a visible terminal window through a reusable, shell-free launch plan with dry-run, JSON, capability detection, detached fallback, and standalone recovery modes. Use when Codex needs to open an interactive CLI, SSH session, local development process, sandbox, or other argv-based command in a new host terminal; diagnose whether a supported terminal is available; or provide an actionable plan when the requested terminal is unsupported.
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Terminal Opener

--- a/skills/terminal-ops/SKILL.md
+++ b/skills/terminal-ops/SKILL.md
@@ -3,6 +3,8 @@ name: terminal-ops
 description: Evidence-first repo execution workflow for ECC. Use when the user wants a command run, a repo checked, a CI failure debugged, or a narrow fix pushed with exact proof of what was executed and verified.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Terminal Ops

--- a/skills/tinystruct-patterns/SKILL.md
+++ b/skills/tinystruct-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: tinystruct-patterns
 description: Expert guidance for developing with the tinystruct Java framework. Use when working on the tinystruct codebase or any project built on tinystruct — including creating Application classes, @Action-mapped routes, unit tests, ActionRegistry, HTTP/CLI dual-mode handling, the built-in HTTP server, the event system, JSON with Builder/Builders, database persistence with AbstractData, POJO generation, Server-Sent Events (SSE), file uploads, and outbound HTTP networking.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # tinystruct Development Patterns

--- a/skills/token-budget-advisor/SKILL.md
+++ b/skills/token-budget-advisor/SKILL.md
@@ -15,6 +15,8 @@ description: >-
   "token" refers to auth/session/payment tokens rather than response size.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Token Budget Advisor (TBA)

--- a/skills/ui-demo/SKILL.md
+++ b/skills/ui-demo/SKILL.md
@@ -3,6 +3,8 @@ name: ui-demo
 description: Record polished UI demo videos using Playwright. Use when the user asks to create a demo, walkthrough, screen recording, or tutorial video of a web application. Produces WebM videos with visible cursor, natural pacing, and professional feel.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # UI Demo Video Recorder

--- a/skills/ui-to-vue/SKILL.md
+++ b/skills/ui-to-vue/SKILL.md
@@ -3,6 +3,8 @@ name: ui-to-vue
 description: Use when the user has UI screenshots or design exports that need batch conversion into Vue 3 components, especially with Vant, Element Plus, or Ant Design Vue.
 metadata:
   origin: community
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # UI To Vue

--- a/skills/uncloud/SKILL.md
+++ b/skills/uncloud/SKILL.md
@@ -3,6 +3,8 @@ name: uncloud
 description: Use when managing an Uncloud cluster — deploying services, configuring Caddy ingress, adding static proxy routes for non-cluster devices, publishing ports, scaling, inspecting logs, or managing machines and volumes with the `uc` CLI.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Uncloud Cluster Management

--- a/skills/unified-memory/SKILL.md
+++ b/skills/unified-memory/SKILL.md
@@ -3,6 +3,8 @@ name: unified-memory
 description: Share durable, inspectable context and handoffs between Claude, Codex, Hermes, Cursor, OpenCode, and other agents through the local ECC Memory Vault. Use when an agent must save work state, transfer context, resume another agent's task, or search shared project knowledge.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Unified Memory

--- a/skills/unified-notifications-ops/SKILL.md
+++ b/skills/unified-notifications-ops/SKILL.md
@@ -3,6 +3,8 @@ name: unified-notifications-ops
 description: Operate notifications as one ECC-native workflow across GitHub, Linear, desktop alerts, hooks, and connected communication surfaces. Use when the real problem is alert routing, deduplication, escalation, or inbox collapse.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Unified Notifications Ops

--- a/skills/verification-loop/SKILL.md
+++ b/skills/verification-loop/SKILL.md
@@ -4,6 +4,7 @@ description: "A comprehensive verification system for Claude Code sessions. Use 
 license: MIT
 metadata:
   origin: ECC
+compatibility: [claude-code, codex]
 ---
 
 # Verification Loop Skill

--- a/skills/video-editing/SKILL.md
+++ b/skills/video-editing/SKILL.md
@@ -3,6 +3,8 @@ name: video-editing
 description: AI-assisted video editing workflows for cutting, structuring, and augmenting real footage. Covers the full pipeline from raw capture through FFmpeg, Remotion, ElevenLabs, fal.ai, and final polish in Descript or CapCut. Use when the user wants to edit video, cut footage, create vlogs, or build video content.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Video Editing

--- a/skills/videodb/SKILL.md
+++ b/skills/videodb/SKILL.md
@@ -5,6 +5,8 @@ metadata:
   origin: ECC
 allowed-tools: Read Grep Glob Bash(python:*)
 argument-hint: "[task description]"
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # VideoDB Skill

--- a/skills/visa-doc-translate/SKILL.md
+++ b/skills/visa-doc-translate/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: visa-doc-translate
 description: Translate visa application documents (images) to English and create a bilingual PDF with original and translation. Use when visa application document images must be translated to English as a bilingual PDF.
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 You are helping translate visa application documents for visa applications.

--- a/skills/vite-patterns/SKILL.md
+++ b/skills/vite-patterns/SKILL.md
@@ -3,6 +3,8 @@ name: vite-patterns
 description: Vite build tool patterns including config, plugins, HMR, env variables, proxy setup, SSR, library mode, dependency pre-bundling, and build optimization. Activate when working with vite.config.ts, Vite plugins, or Vite-based projects.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Vite Patterns

--- a/skills/vue-patterns/SKILL.md
+++ b/skills/vue-patterns/SKILL.md
@@ -2,6 +2,8 @@
 name: vue-patterns
 description: Vue.js 3 Composition API patterns, component architecture, reactivity best practices, Pinia state management, Vue Router navigation, and Nuxt SSR patterns. Activates for Vue, Nuxt, Vite, or Pinia projects. Use when building or reviewing Vue 3, Nuxt, or Pinia code — Composition API, reactivity, or router navigation.
 origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Vue.js Patterns and Best Practices

--- a/skills/windows-desktop-e2e/SKILL.md
+++ b/skills/windows-desktop-e2e/SKILL.md
@@ -3,6 +3,8 @@ name: windows-desktop-e2e
 description: E2E testing for Windows native desktop apps (WPF, WinForms, Win32/MFC, Qt) using pywinauto and Windows UI Automation. Use when writing E2E tests for a Windows native desktop app with pywinauto or UI Automation.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Windows Desktop E2E Testing

--- a/skills/workspace-surface-audit/SKILL.md
+++ b/skills/workspace-surface-audit/SKILL.md
@@ -3,6 +3,8 @@ name: workspace-surface-audit
 description: Audit the active repo, MCP servers, plugins, connectors, env surfaces, and harness setup, then recommend the highest-value ECC-native skills, hooks, agents, and operator workflows. Use when the user wants help setting up Claude Code or understanding what capabilities are actually available in their environment.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # Workspace Surface Audit

--- a/skills/x-api/SKILL.md
+++ b/skills/x-api/SKILL.md
@@ -3,6 +3,8 @@ name: x-api
 description: X/Twitter API integration for posting tweets, threads, reading timelines, search, and analytics. Covers OAuth auth patterns, rate limits, and platform-native content posting. Use when the user wants to interact with X programmatically.
 metadata:
   origin: ECC
+license: MIT
+compatibility: [claude-code, codex]
 ---
 
 # X API

--- a/tests/ci/ito-training-skill.test.js
+++ b/tests/ci/ito-training-skill.test.js
@@ -26,7 +26,7 @@ function test(name, fn) { tests.push([name, fn]); }
 
 test("has valid discoverable frontmatter and trigger phrases", () => {
   const skill = read("skills/ito-training/SKILL.md");
-  assert.match(skill, /^---\nname: ito-training\ndescription: [^\n]+\nmetadata:\n {2}origin: ECC\n {2}status: scaffold\n---\n/);
+  assert.match(skill, /^---\nname: ito-training\ndescription: [^\n]+\nmetadata:\n {2}origin: ECC\n {2}status: scaffold\n/);
   assert.match(skill, /completed Itô compute booking/i);
   assert.match(skill, /pre-training, fine-tuning, or RL/i);
   assert.match(skill, /ECC implements no training stack of its own/i);

--- a/tests/ci/tasteforge-video-skill.test.js
+++ b/tests/ci/tasteforge-video-skill.test.js
@@ -172,7 +172,7 @@ test("has valid discoverable frontmatter and trigger phrases", () => {
   const skill = read("skills/tasteforge-video/SKILL.md");
   assert.match(
     skill,
-    /^---\nname: tasteforge-video\ndescription: [^\n]+\nmetadata:\n {2}origin: ECC\n---\n/
+    /^---\nname: tasteforge-video\ndescription: [^\n]+\nmetadata:\n {2}origin: ECC\n/
   );
   for (const trigger of [
     /interview .*video taste|video .*taste interview/i,

--- a/tests/skills/terminal-opener.test.js
+++ b/tests/skills/terminal-opener.test.js
@@ -433,7 +433,7 @@ function runTests() {
       .split('\n')
       .filter(line => /^[a-z][a-z-]*:/.test(line))
       .map(line => line.split(':')[0]);
-    assert.deepStrictEqual(frontmatterKeys, ['name', 'description']);
+    assert.deepStrictEqual(frontmatterKeys, ['name', 'description', 'license', 'compatibility']);
     assert.match(frontmatter, /executable.*argument array/i);
     assert.match(frontmatter, /visible terminal/i);
     assert.match(skill, /shell:\s*false/);


### PR DESCRIPTION
`skillforge validate skills/` reports two warnings on nearly every skill: **SF1009** (no license declared, 268 of 286) and **SF1010** (no agent compatibility declared, 286 of 286). This closes both for the canonical `skills/` tree.

> **Split for reviewability.** This PR was 325 files, over CodeRabbit's 300-file cap, which has no bypass. It is now **289 files** — the `skills/` tree plus three test updates. The `.agents/skills` Codex mirror moved to **#2997** (39 files). The two are independent; neither depends on the other landing first.

## Changes

**`license: MIT`** — added only where no license was declared. The 18 skills that already declare one (8 `Apache-2.0`, 10 `MIT`) are left exactly as they are; those values read as deliberate, carried over from wherever the material came from, and a blanket rewrite would misstate them.

**`compatibility: [claude-code, codex]`** — added to all 286. ECC ships the `.agents/skills` mirror for Codex, so both providers apply. Validated against each afterwards: no new findings from either.

Frontmatter only — **+593 lines, 0 deletions** in `skills/`, no body text touched.

## Three test updates

Three tests pinned specific skills' frontmatter tightly enough that any added top-level key broke them. `@greptile-apps` found the equivalent problem in the Codex mirror; these three surfaced from running the full suite.

| Test | What it asserted | Change |
|---|---|---|
| `ci/ito-training-skill.test.js` | regex requiring `---` immediately after the `metadata` block | dropped the trailing `---\n`; required keys still asserted in order from the start of the file |
| `ci/tasteforge-video-skill.test.js` | same shape | same |
| `skills/terminal-opener.test.js` | `deepStrictEqual(keys, ['name', 'description'])` | extended to include `license` and `compatibility` — that assertion guards against frontmatter bloat, so it is extended rather than loosened |

## Why compatibility is the part that matters

Without a declared `compatibility`, SkillForge never runs its provider-specific rules, so a whole class of problems stays invisible. The one worth naming is the **1024-character description limit**: past that, Claude Code truncates the description in the skill list, and what gets cut is the tail — exactly where the `Use when …` activation triggers live. The skill quietly stops being selected, with no error anywhere.

No ECC skill exceeds it today. The point is that from now on, if one does, `skillforge validate` will say so.

## Verification

```
skillforge validate skills/                     607 → 53 warnings
node scripts/ci/validate-skills.js              Validated 805 skill directories
node tests/ci/codex-skill-surface.test.js       4 passed, 0 failed
node tests/ci/ito-training-skill.test.js        7 passed, 0 failed
node tests/ci/tasteforge-video-skill.test.js   11 passed, 1 skipped
node tests/skills/terminal-opener.test.js      27 passed, 0 failed
npm run catalog:check                           counts match
```

## Deliberately out of scope

- **6 × SF0008** — `../../rules/react/…`, `../../docs/…`, `../../ECC-Tools` references. These reach outside a skill directory, which is simply how ECC is laid out; same reasoning as #2618.
- **20 × SF1011** (sibling-skill references), **16 × SF1006**, **7 × SF4001**, **3 × SF5001**, **6 × SF1007** (all `rm -rf` sites reviewed — each is a quoted temp-dir cleanup behind a guard or a `trap`).
- The localized trees under `docs/*/skills/` and the `.kiro/` and `.cursor/` mirrors — downstream copies; folding them in would triple the diff without adding a decision to review.