### PR TITLE
chore(skills): declare a license on the Codex skill mirror

### DIFF
--- a/.agents/skills/agent-introspection-debugging/SKILL.md
+++ b/.agents/skills/agent-introspection-debugging/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: agent-introspection-debugging
 description: Structured self-debugging workflow for AI agent failures using capture, diagnosis, contained recovery, and introspection reports. Use when an agent run fails and you need a reproducible diagnosis instead of a retry.
+license: MIT
 ---
 
 # Agent Introspection Debugging

--- a/.agents/skills/agent-sort/SKILL.md
+++ b/.agents/skills/agent-sort/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: agent-sort
 description: Build an evidence-backed ECC install plan for a specific repo by sorting skills, commands, rules, hooks, and extras into DAILY vs LIBRARY buckets using parallel repo-aware review passes. Use when ECC should be trimmed to what a project actually needs instead of loading the full bundle.
+license: MIT
 ---
 
 # Agent Sort

--- a/.agents/skills/api-design/SKILL.md
+++ b/.agents/skills/api-design/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: api-design
 description: REST API design patterns including resource naming, status codes, pagination, filtering, error responses, versioning, and rate limiting for production APIs. Use when designing or reviewing REST endpoints, resource names, status codes, pagination, or versioning.
+license: MIT
 ---
 
 # API Design Patterns

--- a/.agents/skills/article-writing/SKILL.md
+++ b/.agents/skills/article-writing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: article-writing
 description: Write articles, guides, blog posts, tutorials, newsletter issues, and other long-form content in a distinctive voice derived from supplied examples or brand guidance. Use when the user wants polished written content longer than a paragraph, especially when voice consistency, structure, and credibility matter.
+license: MIT
 ---
 
 # Article Writing

--- a/.agents/skills/backend-patterns/SKILL.md
+++ b/.agents/skills/backend-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: backend-patterns
 description: Backend architecture patterns, API design, database optimization, and server-side best practices for Node.js, Express, and Next.js API routes. Use when building or reviewing Node.js, Express, or Next.js API routes and their data access.
+license: MIT
 ---
 
 # Backend Development Patterns

--- a/.agents/skills/benchmark-methodology/SKILL.md
+++ b/.agents/skills/benchmark-methodology/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   visual craft, offer packaging, evidence, enterprise-readiness, thought
   leadership, pricing, client's strategic tension) with explicit 1–5 rubrics
   and a tension-plot. Precedes competitive-report-structure.
+license: MIT
 ---
 
 # Benchmark Methodology

--- a/.agents/skills/brand-discovery/SKILL.md
+++ b/.agents/skills/brand-discovery/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   personality, voice, narrative, and founder-brand tension across 8 modules
   using laddering, 5 Whys, and projective techniques. Produces a resumable
   session with disk-persisted state and a master brandbook (90_SYNTHESIS.md).
+license: MIT
 ---
 
 # Brand Discovery

--- a/.agents/skills/brand-voice/SKILL.md
+++ b/.agents/skills/brand-voice/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: brand-voice
 description: Build a source-derived writing style profile from real posts, essays, launch notes, docs, or site copy, then reuse that profile across content, outreach, and social workflows. Use when the user wants voice consistency without generic AI writing tropes.
+license: MIT
 ---
 
 # Brand Voice

--- a/.agents/skills/bun-runtime/SKILL.md
+++ b/.agents/skills/bun-runtime/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: bun-runtime
 description: Bun as runtime, package manager, bundler, and test runner. When to choose Bun vs Node, migration notes, and Vercel support.
+license: MIT
 ---
 
 # Bun Runtime

--- a/.agents/skills/coding-standards/SKILL.md
+++ b/.agents/skills/coding-standards/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: coding-standards
 description: Baseline cross-project coding conventions for naming, readability, immutability, and code-quality review. Use detailed frontend or backend skills for framework-specific patterns. Use when reviewing code quality or naming with no framework-specific skill that applies.
+license: MIT
 ---
 
 # Coding Standards & Best Practices

--- a/.agents/skills/competitive-platform-analysis/SKILL.md
+++ b/.agents/skills/competitive-platform-analysis/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   counts as a competitor, which tier they belong to, and which sources to mine.
   First step in the three-skill competitive pipeline; precedes
   benchmark-methodology.
+license: MIT
 ---
 
 # Competitive Platform Analysis

--- a/.agents/skills/competitive-report-structure/SKILL.md
+++ b/.agents/skills/competitive-report-structure/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   profiles, benchmarking matrix, white-space analysis, strategic recommendations,
   and team alignment trigger questions. Final step in the three-skill competitive
   pipeline.
+license: MIT
 ---
 
 # Competitive Report Structure

--- a/.agents/skills/content-engine/SKILL.md
+++ b/.agents/skills/content-engine/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: content-engine
 description: Create platform-native content systems for X, LinkedIn, TikTok, YouTube, newsletters, and repurposed multi-platform campaigns. Use when the user wants social posts, threads, scripts, content calendars, or one source asset adapted cleanly across platforms.
+license: MIT
 ---
 
 # Content Engine

--- a/.agents/skills/crosspost/SKILL.md
+++ b/.agents/skills/crosspost/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: crosspost
 description: Multi-platform content distribution across X, LinkedIn, Threads, and Bluesky. Adapts content per platform using content-engine patterns. Never posts identical content cross-platform. Use when the user wants to distribute content across social platforms.
+license: MIT
 ---
 
 # Crosspost

--- a/.agents/skills/deep-research/SKILL.md
+++ b/.agents/skills/deep-research/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: deep-research
 description: Multi-source deep research using firecrawl and exa MCPs. Searches the web, synthesizes findings, and delivers cited reports with source attribution. Use when the user wants thorough research on any topic with evidence and citations.
+license: MIT
 ---
 
 # Deep Research

--- a/.agents/skills/dmux-workflows/SKILL.md
+++ b/.agents/skills/dmux-workflows/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dmux-workflows
 description: Multi-agent orchestration using dmux (tmux pane manager for AI agents). Patterns for parallel agent workflows across Claude Code, Codex, OpenCode, and other harnesses. Use when running multiple agent sessions in parallel or coordinating multi-agent development workflows.
+license: MIT
 ---
 
 # dmux Workflows

--- a/.agents/skills/documentation-lookup/SKILL.md
+++ b/.agents/skills/documentation-lookup/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: documentation-lookup
 description: Use up-to-date library and framework docs via Context7 MCP instead of training data. Activates for setup questions, API references, code examples, or when the user names a framework (e.g. React, Next.js, Prisma).
+license: MIT
 ---
 
 # Documentation Lookup (Context7)

--- a/.agents/skills/e2e-testing/SKILL.md
+++ b/.agents/skills/e2e-testing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: e2e-testing
 description: Playwright E2E testing patterns, Page Object Model, configuration, CI/CD integration, artifact management, and flaky test strategies. Use when writing Playwright tests, structuring page objects, or fixing flaky E2E runs in CI.
+license: MIT
 ---
 
 # E2E Testing Patterns

--- a/.agents/skills/eval-harness/SKILL.md
+++ b/.agents/skills/eval-harness/SKILL.md
@@ -2,6 +2,7 @@
 name: eval-harness
 description: Formal evaluation framework for Claude Code sessions implementing eval-driven development (EDD) principles. Use when a Claude Code workflow needs a formal eval before it is trusted or changed.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
+license: MIT
 ---
 
 # Eval Harness Skill

--- a/.agents/skills/everything-claude-code/SKILL.md
+++ b/.agents/skills/everything-claude-code/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: everything-claude-code
 description: Development conventions and patterns for everything-claude-code. JavaScript project with conventional commits.
+license: MIT
 ---
 
 # Everything Claude Code Conventions

--- a/.agents/skills/exa-search/SKILL.md
+++ b/.agents/skills/exa-search/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: exa-search
 description: Neural search via Exa MCP for web, code, and company research. Use when the user needs web search, code examples, company intel, people lookup, or AI-powered deep research with Exa's neural search engine.
+license: MIT
 ---
 
 # Exa Search

--- a/.agents/skills/fal-ai-media/SKILL.md
+++ b/.agents/skills/fal-ai-media/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: fal-ai-media
 description: Unified media generation via fal.ai MCP — image, video, and audio. Covers text-to-image (Nano Banana), text/image-to-video (Seedance, Kling, Veo 3), text-to-speech (CSM-1B), and video-to-audio (ThinkSound). Use when the user wants to generate images, videos, or audio with AI.
+license: MIT
 ---
 
 # fal.ai Media Generation

--- a/.agents/skills/frontend-patterns/SKILL.md
+++ b/.agents/skills/frontend-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: frontend-patterns
 description: Frontend development patterns for React, Next.js, state management, performance optimization, and UI best practices. Use when building or reviewing React or Next.js components, state, or render performance.
+license: MIT
 ---
 
 # Frontend Development Patterns

--- a/.agents/skills/frontend-slides/SKILL.md
+++ b/.agents/skills/frontend-slides/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: frontend-slides
 description: Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or create slides for a talk/pitch. Helps non-designers discover their aesthetic through visual exploration rather than abstract choices.
+license: MIT
 ---
 
 # Frontend Slides

--- a/.agents/skills/investor-materials/SKILL.md
+++ b/.agents/skills/investor-materials/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: investor-materials
 description: Create and update pitch decks, one-pagers, investor memos, accelerator applications, financial models, and fundraising materials. Use when the user needs investor-facing documents, projections, use-of-funds tables, milestone plans, or materials that must stay internally consistent across multiple fundraising assets.
+license: MIT
 ---
 
 # Investor Materials

--- a/.agents/skills/investor-outreach/SKILL.md
+++ b/.agents/skills/investor-outreach/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: investor-outreach
 description: Draft cold emails, warm intro blurbs, follow-ups, update emails, and investor communications for fundraising. Use when the user wants outreach to angels, VCs, strategic investors, or accelerators and needs concise, personalized, investor-facing messaging.
+license: MIT
 ---
 
 # Investor Outreach

--- a/.agents/skills/market-research/SKILL.md
+++ b/.agents/skills/market-research/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: market-research
 description: Conduct market research, competitive analysis, investor due diligence, and industry intelligence with source attribution and decision-oriented summaries. Use when the user wants market sizing, competitor comparisons, fund research, technology scans, or research that informs business decisions.
+license: MIT
 ---
 
 # Market Research

--- a/.agents/skills/mcp-server-patterns/SKILL.md
+++ b/.agents/skills/mcp-server-patterns/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: mcp-server-patterns
 description: Build MCP servers with Node/TypeScript SDK — tools, resources, prompts, Zod validation, stdio vs Streamable HTTP. Use Context7 or official MCP docs for latest API. Use when building or debugging an MCP server — tools, resources, prompts, validation, or transport choice.
+license: MIT
 ---
 
 # MCP Server Patterns

--- a/.agents/skills/mle-workflow/SKILL.md
+++ b/.agents/skills/mle-workflow/SKILL.md
@@ -2,6 +2,7 @@
 name: mle-workflow
 description: Production machine-learning engineering workflow for data contracts, reproducible training, model evaluation, deployment, monitoring, and rollback. Use when building, reviewing, or hardening ML systems beyond one-off notebooks.
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
+license: MIT
 ---
 
 # Machine Learning Engineering Workflow

--- a/.agents/skills/nextjs-turbopack/SKILL.md
+++ b/.agents/skills/nextjs-turbopack/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nextjs-turbopack
 description: Next.js 16+ and Turbopack — incremental bundling, FS caching, dev speed, and when to use Turbopack vs webpack.
+license: MIT
 ---
 
 # Next.js and Turbopack

--- a/.agents/skills/plan-canvas/SKILL.md
+++ b/.agents/skills/plan-canvas/SKILL.md
@@ -3,6 +3,7 @@ name: plan-canvas
 description: Open plans and HTML artifacts in a local browser canvas where the human annotates elements, chats, and approves or requests changes without leaving the page. Use when presenting a plan for review, or when feedback like "move this, change that" is easier pointed at than typed.
 metadata:
   origin: ECC
+license: MIT
 ---
 
 # Plan Canvas

--- a/.agents/skills/product-capability/SKILL.md
+++ b/.agents/skills/product-capability/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: product-capability
 description: Translate PRD intent, roadmap asks, or product discussions into an implementation-ready capability plan that exposes constraints, invariants, interfaces, and unresolved decisions before multi-service work starts. Use when the user needs an ECC-native PRD-to-SRS lane instead of vague planning prose.
+license: MIT
 ---
 
 # Product Capability

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: security-review
 description: Use this skill when adding authentication, handling user input, working with secrets, creating API endpoints, or implementing payment/sensitive features. Provides comprehensive security checklist and patterns.
+license: MIT
 ---
 
 # Security Review Skill

--- a/.agents/skills/strategic-compact/SKILL.md
+++ b/.agents/skills/strategic-compact/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: strategic-compact
 description: Suggests manual context compaction at logical intervals to preserve context through task phases rather than arbitrary auto-compaction. Use when a session is approaching a context limit and a task phase is a natural place to compact.
+license: MIT
 ---
 
 # Strategic Compact Skill

--- a/.agents/skills/tdd-workflow/SKILL.md
+++ b/.agents/skills/tdd-workflow/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tdd-workflow
 description: Use this skill when writing new features, fixing bugs, or refactoring code. Enforces test-driven development with 80%+ coverage including unit, integration, and E2E tests.
+license: MIT
 ---
 
 # Test-Driven Development Workflow

--- a/.agents/skills/unified-memory/SKILL.md
+++ b/.agents/skills/unified-memory/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: unified-memory
 description: Share durable, inspectable context and handoffs between Claude, Codex, Hermes, Cursor, OpenCode, and other agents through the local ECC Memory Vault. Use when an agent must save work state, transfer context, resume another agent's task, or search shared project knowledge.
+license: MIT
 ---
 
 # Unified Memory

--- a/.agents/skills/verification-loop/SKILL.md
+++ b/.agents/skills/verification-loop/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: verification-loop
 description: "A comprehensive verification system for Claude Code sessions. Use when verifying a Claude Code session's work before claiming it is complete."
+license: MIT
 ---
 
 # Verification Loop Skill

--- a/.agents/skills/video-editing/SKILL.md
+++ b/.agents/skills/video-editing/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: video-editing
 description: AI-assisted video editing workflows for cutting, structuring, and augmenting real footage. Covers the full pipeline from raw capture through FFmpeg, Remotion, ElevenLabs, fal.ai, and final polish in Descript or CapCut. Use when the user wants to edit video, cut footage, create vlogs, or build video content.
+license: MIT
 ---
 
 # Video Editing

--- a/.agents/skills/x-api/SKILL.md
+++ b/.agents/skills/x-api/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: x-api
 description: X/Twitter API integration for posting tweets, threads, reading timelines, search, and analytics. Covers OAuth auth patterns, rate limits, and platform-native content posting. Use when the user wants to interact with X programmatically.
+license: MIT
 ---
 
 # X API


### PR DESCRIPTION
Split out of #2993 so both halves land under the review-bot file limits (CodeRabbit caps at 300 files and has no bypass; #2993 was 325).

This is the smaller half: **39 files, +39 lines, 0 deletions.** One line each.

```yaml
license: MIT
```

`skillforge validate` reports SF1009 (no license declared) on every skill under `.agents/skills`. `MIT` matches the repository `LICENSE`.

### Why license only

The Codex mirror's frontmatter is governed by an allowlist in `tests/ci/codex-skill-surface.test.js`:

```js
const ALLOWED_FRONTMATTER_KEYS = new Set([
  'allowed-tools', 'description', 'license', 'metadata', 'name',
]);
```

`license` is on it. `compatibility` is not, and adding it makes the check exit 1 and takes `npm test` down with it — @greptile-apps caught exactly that on #2993 and reproduced it. So `compatibility` is deliberately absent here. Widening that allowlist is a separate decision about what the Codex surface actually supports, and not one a metadata PR should make on its own.

The canonical `skills/` tree, which has no such allowlist, gets both fields in #2993.

### Verification

```
node tests/ci/codex-skill-surface.test.js   →  4 passed, 0 failed
node scripts/ci/validate-skills.js          →  Validated 805 skill directories
```