### PR TITLE
perf: avoid duplicate dashboard skill reads

### DIFF
--- a/scripts/dashboard-web.js
+++ b/scripts/dashboard-web.js
@@ -21,24 +21,32 @@ function parsePort(v) {
 const PORT = parsePort(process.argv[2] || process.env.ECC_DASHBOARD_PORT || '3456');
 const ROOT = path.resolve(__dirname, '..');
 
+function parseFrontmatter(c) {
+  const m = c.match(/^---\n([\s\S]*?)\n---/);
+  if (!m) return {};
+  const fm = {};
+  for (const l of m[1].split('\n')) {
+    const s = l.indexOf(':'); if (s <= 0) continue;
+    let k = l.slice(0, s).trim(), v = l.slice(s + 1).trim();
+    if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+    if (v.startsWith('[') && v.endsWith(']')) { try { v = JSON.parse(v); } catch { v = v.slice(1, -1).split(',').map(x => x.trim().replace(/["']/g, '')); } }
+    fm[k] = v;
+  }
+  fm._body = c.replace(/^---[\s\S]*?---\n*/, '').trim();
+  return fm;
+}
 function readFrontmatter(p) {
   try {
-    const c = fs.readFileSync(p, 'utf8');
-    const m = c.match(/^---\n([\s\S]*?)\n---/);
-    if (!m) return {};
-    const fm = {};
-    for (const l of m[1].split('\n')) {
-      const s = l.indexOf(':'); if (s <= 0) continue;
-      let k = l.slice(0, s).trim(), v = l.slice(s + 1).trim();
-      if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
-      if (v.startsWith('[') && v.endsWith(']')) { try { v = JSON.parse(v); } catch { v = v.slice(1, -1).split(',').map(x => x.trim().replace(/["']/g, '')); } }
-      fm[k] = v;
-    }
-    fm._body = c.replace(/^---[\s\S]*?---\n*/, '').trim();
-    return fm;
+    return parseFrontmatter(fs.readFileSync(p, 'utf8'));
   } catch { return {}; }
 }
-function readSkill(p) { try { const c = fs.readFileSync(p, 'utf8'); const fm = readFrontmatter(p); return { d: fm.description || '', b: c.replace(/^---[\s\S]*?---\n*/, '').trim() }; } catch { return { d: '', b: '' }; } }
+function readSkill(p) {
+  try {
+    const c = fs.readFileSync(p, 'utf8');
+    const fm = parseFrontmatter(c);
+    return { d: fm.description || '', b: c.replace(/^---[\s\S]*?---\n*/, '').trim() };
+  } catch { return { d: '', b: '' }; }
+}
 
 function loadAgents(_root) {
   const root = _root || ROOT;

--- a/tests/scripts/dashboard-web.test.js
+++ b/tests/scripts/dashboard-web.test.js
@@ -179,6 +179,28 @@ test('readSkill parses skill frontmatter and body', () => {
   cleanup(testRoot);
 });
 
+test('readSkill reads each skill file only once', () => {
+  const { readSkill } = require(SCRIPT);
+  testRoot = createTempDir('ecc-test-');
+  const skillPath = path.join(testRoot, 'SKILL.md');
+  writeFile(testRoot, 'SKILL.md', '---\ndescription: A test skill\n---\nbody');
+  const originalReadFileSync = fs.readFileSync;
+  let readCount = 0;
+  fs.readFileSync = (...args) => {
+    readCount++;
+    return originalReadFileSync(...args);
+  };
+
+  try {
+    readSkill(skillPath);
+  } finally {
+    fs.readFileSync = originalReadFileSync;
+    cleanup(testRoot);
+  }
+
+  assert.strictEqual(readCount, 1);
+});
+
 test('readSkill returns empty defaults for missing file', () => {
   const { readSkill } = require(SCRIPT);
   const skill = readSkill('/nonexistent/skill/SKILL.md');


### PR DESCRIPTION
## Summary

- Avoid duplicate synchronous reads when loading each `SKILL.md` in the web dashboard.
- `readSkill()` now parses frontmatter from the content it already read.
- Added a regression test proving each skill file is read once.

## Ten performance opportunities identified

1. **Dashboard skill loading (implemented):** `readSkill()` read every `SKILL.md` twice; parsing the existing buffer removes one synchronous filesystem read per skill.
2. **Dashboard request caching:** `/` and `/api/data` rebuild the full agents/skills/commands/rules/MCP/hooks inventory on every request; cache the snapshot and invalidate on a bounded TTL or explicit refresh.
3. **Directory entry metadata:** `loadSkills()` and `loadRules()` call `statSync()` for every entry; use `readdirSync(..., { withFileTypes: true })` to avoid one syscall per entry.
4. **Test runner process fan-out:** `tests/run-all.js` starts one Node process per test file serially; parallelize independent test files with a bounded worker pool.
5. **Test runner output buffering:** `run-all.js` captures complete stdout/stderr for every child before printing; stream output or cap buffers to reduce peak memory on verbose suites.
6. **Supply-chain scanner probes:** `inspectPackageDir()` performs `existsSync()` followed by `statSync()` for each candidate; use one `statSync()`/`lstatSync()` with error handling.
7. **Supply-chain scanner duplicate reads:** findings that need both content and hashes can read the same file more than once; reuse a single buffer per inspected file.
8. **Command validation metadata:** `validate-commands.js` repeats directory enumeration and per-entry stats; build one shared directory index for command, agent, and skill validation.
9. **Install lifecycle comparisons:** `areFilesEqual()` reads both entire files after statting them; short-circuit using size and mtime before full byte comparison for unchanged files.
10. **Hook subprocess overhead:** several hook paths synchronously spawn external commands for capability checks; cache stable executable discovery per process to avoid repeated probes.

## Validation

- `node tests/scripts/dashboard-web.test.js` (52 passed, 0 failed)
- ESLint could not run in the isolated worktree because `@eslint/js` is not installed there.