### PR TITLE
feat: ship verified native Fusion presets and compatibility examples

### DIFF
--- a/skills/video-editing/SKILL.md
+++ b/skills/video-editing/SKILL.md
@@ -304,6 +304,12 @@ identify the 5 most engaging 30-second clips for social media."
 5. **Generate selectively.** Only use AI generation for assets that don't exist, not for everything.
 6. **Taste is the last layer.** AI clears repetitive work. You make the final creative calls.
 
+## Native Fusion Presets
+
+[ITO Production v1](assets/fusion/ito-production-v1/README.md) provides restrained highlight bloom, opposing RGB spatial offsets and a luminance/edge halo. The exact files passed prior native import, save/reopen and short motion-render checks after two-source visual review. These are starting values requiring shot-specific review; the halo does not detect or track subjects.
+
+[ITO V28](assets/fusion/ito-v28/README.md) contains preserved, native-verified Fusion graph snippets and an idempotent Lua installer. These are technical compatibility examples, **not recommended production defaults**: their documented visual limitations require tuning and taste review before use. See the bundle provenance for the scope of prior import and render checks.
+
 ## Related Skills
 
 - `fal-ai-media` — AI image, video, and audio generation

--- a/skills/video-editing/assets/fusion/ito-production-v1/ITO_PROD_HighlightBloom.setting
+++ b/skills/video-editing/assets/fusion/ito-production-v1/ITO_PROD_HighlightBloom.setting
@@ -1,0 +1,10 @@
+{
+ Tools = ordered() {
+  ITO_PROD_Bloom = SoftGlow { Inputs = {
+   Threshold = Input { Value = 0.70, }, Gain = Input { Value = 0.12, },
+   XGlowSize = Input { Value = 6.0, }, YGlowSize = Input { Value = 6.0, },
+   Blend = Input { Value = 0.22, }, Alpha = Input { Value = 0, },
+   ClippingMode = Input { Value = FuID { "Frame" }, },
+  } },
+ }
+}

--- a/skills/video-editing/assets/fusion/ito-production-v1/ITO_PROD_LumaHalo.setting
+++ b/skills/video-editing/assets/fusion/ito-production-v1/ITO_PROD_LumaHalo.setting
@@ -1,0 +1,16 @@
+{
+ Tools = ordered() {
+  ITO_PROD_Contours = Filter { Inputs = { FilterType = Input { Value = 3, }, Power = Input { Value = 1, }, Alpha = Input { Value = 0, }, } },
+  ITO_PROD_EdgeMask = BitmapMask { Inputs = {
+   Image = Input { SourceOp = "ITO_PROD_Contours", Source = "Output", },
+   Channel = Input { Value = FuID { "Luminance" }, }, Low = Input { Value = 0.07, }, High = Input { Value = 0.35, },
+  } },
+  ITO_PROD_Halo = SoftGlow { Inputs = {
+   Threshold = Input { Value = 0.55, }, Gain = Input { Value = 0.10, },
+   XGlowSize = Input { Value = 2.0, }, YGlowSize = Input { Value = 2.0, }, Blend = Input { Value = 0.25, }, Alpha = Input { Value = 0, },
+   ClippingMode = Input { Value = FuID { "Frame" }, },
+   EffectMask = Input { SourceOp = "ITO_PROD_EdgeMask", Source = "Mask", },
+   GlowMask = Input { SourceOp = "ITO_PROD_EdgeMask", Source = "Mask", },
+  } },
+ }
+}

--- a/skills/video-editing/assets/fusion/ito-production-v1/ITO_PROD_RGBFringe.setting
+++ b/skills/video-editing/assets/fusion/ito-production-v1/ITO_PROD_RGBFringe.setting
@@ -1,0 +1,15 @@
+{
+ Tools = ordered() {
+  ITO_PROD_RedOffset = Transform { Inputs = { Center = Input { Value = { 0.499, 0.5 }, }, Edges = Input { Value = 2, }, } },
+  ITO_PROD_BlueOffset = Transform { Inputs = { Center = Input { Value = { 0.501, 0.5 }, }, Edges = Input { Value = 2, }, } },
+  ITO_PROD_RedCopy = ChannelBoolean { Inputs = {
+   Operation = Input { Value = 0, }, ToRed = Input { Value = 0, }, ToGreen = Input { Value = 6, }, ToBlue = Input { Value = 7, }, ToAlpha = Input { Value = 8, },
+   Foreground = Input { SourceOp = "ITO_PROD_RedOffset", Source = "Output", },
+  } },
+  ITO_PROD_BlueCopy = ChannelBoolean { Inputs = {
+   Operation = Input { Value = 0, }, ToRed = Input { Value = 5, }, ToGreen = Input { Value = 6, }, ToBlue = Input { Value = 2, }, ToAlpha = Input { Value = 8, },
+   Background = Input { SourceOp = "ITO_PROD_RedCopy", Source = "Output", },
+   Foreground = Input { SourceOp = "ITO_PROD_BlueOffset", Source = "Output", },
+  } },
+ }
+}

--- a/skills/video-editing/assets/fusion/ito-production-v1/README.md
+++ b/skills/video-editing/assets/fusion/ito-production-v1/README.md
@@ -1,0 +1,33 @@
+# ITO Production v1 native Fusion presets
+
+These restrained presets are separate from the preserved ITO_V28 compatibility examples. The parent review approved their two-source still previews. Exact installed imports, parameter/connection readbacks, save/reopen and six 30-frame renders passed verification. The Lua installer also passed actual installation and an idempotent rerun, with original presets unchanged. They do not change the finished V28 film.
+
+## Presets
+
+| Preset | Behavior | Starting strength |
+|---|---|---|
+| HighlightBloom | Glow limited to brighter image content, without an exposure or color-gain node | Threshold 0.70, glow gain 0.12, 6px glow size, 22% blend |
+| RGBFringe | Opposing red/blue spatial offsets with unchanged original green/alpha routing and duplicated edge pixels | Normalized horizontal offsets −0.001/+0.001, approximately −1.92/+1.92 px at 1920 px width |
+| LumaHalo | Thin glow through a Sobel/luminance mask recomputed from each source frame, without translating the image | 2 px glow size, glow gain 0.10, 25% blend |
+
+The halo follows image edges through its per-frame mask. It performs no object detection or tracking. These are conservative starting values, not a universal match for every shot or reference. RGB output is recombined from actual spatially offset channels; it does not remap green from alpha as the compatibility example does. Both glow nodes use frame clipping. Alpha preservation is established by node routing/disabled alpha processing; H264 proof renders do not contain alpha.
+
+## Install
+
+Keep the three .setting files beside install_ito_production_v1.lua. On macOS run the saved installer from its absolute path:
+
+```sh
+"/Applications/DaVinci Resolve/DaVinci Resolve.app/Contents/Libraries/Fusion/fuscript" -l lua "/absolute/path/to/reusable/install_ito_production_v1.lua"
+```
+
+It installs into your user Fusion/Macros/ITO_Production_v1 directory. It preflights every source, refuses conflicting installed bytes and verifies readback. Identical reruns are allowed. Existing ITO_V22 and ITO_V28 files remain untouched.
+
+## Import and connect
+
+Use Resolve's TimelineItem.ImportFusionComp with the actual installed .setting path in a new composition or duplicated clip. These are serialized tool-graph snippets, so add the clip's MediaIn and MediaOut boundaries. Internal links are already serialized.
+
+- HighlightBloom: connect MediaIn to ITO_PROD_Bloom.Input; connect Bloom output to MediaOut.
+- RGBFringe: connect MediaIn to RedOffset.Input, BlueOffset.Input and RedCopy.Background. Connect BlueCopy output to MediaOut. Each node name carries the ITO_PROD_ prefix.
+- LumaHalo: connect MediaIn to Contours.Input and Halo.Input. Connect Halo output to MediaOut. Each node name carries the ITO_PROD_ prefix.
+
+[provenance.json](provenance.json) records exact shipped hashes and a sanitized summary of prior native verification, with hashes of the separately retained evidence. The earlier [ITO V28 compatibility examples](../ito-v28/README.md) are not recommended production defaults. This package does not include the source footage, native project or proof renders.

--- a/skills/video-editing/assets/fusion/ito-production-v1/install_ito_production_v1.lua
+++ b/skills/video-editing/assets/fusion/ito-production-v1/install_ito_production_v1.lua
@@ -1,0 +1,51 @@
+-- Run this file with Resolve's fuscript interpreter or Lua dofile().
+-- Keep the three .setting files beside it. Existing ITO_V22 and ITO_V28 files are untouched.
+local function need(ok, message)
+  if not ok then error(message, 0) end
+  return ok
+end
+local function read(path)
+  local file, message, code = io.open(path, "rb")
+  if not file then
+    need(code == 2, "Could not read " .. path .. ": " .. tostring(message))
+    return nil
+  end
+  local value = file:read("*a")
+  file:close()
+  need(value ~= nil, "Read failed: " .. path)
+  return value
+end
+local function quote(value)
+  return "'" .. value:gsub("'", "'\\''") .. "'"
+end
+local script = debug.getinfo(1, "S").source
+need(script:sub(1, 1) == "@", "Run the saved installer file, not pasted text")
+local sourceDir = need(script:sub(2):match("^(.*)/[^/]+$"), "Use the installer absolute path")
+local userHome = need(os.getenv("HOME"), "HOME is unavailable")
+local targetDir = userHome .. "/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Macros/ITO_Production_v1"
+local names = {
+  "ITO_PROD_HighlightBloom.setting",
+  "ITO_PROD_RGBFringe.setting",
+  "ITO_PROD_LumaHalo.setting",
+}
+local payloads = {}
+for _, name in ipairs(names) do
+  local payload = need(read(sourceDir .. "/" .. name), "Missing source setting: " .. name)
+  need(#payload > 0, "Empty source setting: " .. name)
+  local existing = read(targetDir .. "/" .. name)
+  need(existing == nil or existing == payload, "Refusing to overwrite a different installed setting: " .. name)
+  payloads[name] = payload
+end
+local result = os.execute("mkdir -p " .. quote(targetDir))
+need(result == 0 or result == true, "Could not create ITO_Production_v1 directory")
+for _, name in ipairs(names) do
+  local path = targetDir .. "/" .. name
+  if read(path) == nil then
+    local file = need(io.open(path, "wb"), "Could not create: " .. name)
+    need(file:write(payloads[name]), "Write failed: " .. name)
+    need(file:close(), "Close failed: " .. name)
+  end
+  need(read(path) == payloads[name], "Installed readback mismatch: " .. name)
+  print("VERIFIED " .. name)
+end
+print("ITO_PRODUCTION_V1_INSTALLED " .. targetDir)

--- a/skills/video-editing/assets/fusion/ito-production-v1/provenance.json
+++ b/skills/video-editing/assets/fusion/ito-production-v1/provenance.json
@@ -1,0 +1,45 @@
+{
+  "bundle": "ITO_Production_v1",
+  "classification": "visually approved restrained starting presets; review each shot",
+  "files": {
+    "ITO_PROD_HighlightBloom.setting": "859f20d4c3e29a91367cc0c1e4472be5f85919d7953957549a0afde5bac74ba1",
+    "ITO_PROD_RGBFringe.setting": "81aa1cde3412782d6ec4e0ca815ba52f1eaca1065df96d813a0885f72a9add9b",
+    "ITO_PROD_LumaHalo.setting": "fa767774ef6a20d52422f8dfea7f1577a1308261212d730cdba39a4df2169186",
+    "install_ito_production_v1.lua": "fcde297435ac97ae7b9f01b65615ed7b0cd6622774a9952b1a041d642808d2b8"
+  },
+  "native_verification": {
+    "interpreter": "DaVinci Resolve bundled fuscript -l lua",
+    "actual_install_passed": true,
+    "second_idempotent_run_passed": true,
+    "prior_v22_and_v28_preserved": true,
+    "import_api": "TimelineItem.ImportFusionComp",
+    "saved_and_reopened": true,
+    "parameter_and_connection_readback_passed": true,
+    "renders": {
+      "count": 6,
+      "width": 1920,
+      "height": 1080,
+      "frames_each": 30,
+      "fps": 30,
+      "fully_decoded": true,
+      "new_black_border_pixels": 0,
+      "border_width_pixels": 4
+    },
+    "visual_review": "Two-source full-frame and detail contacts approved before installation; installed bytes matched approved previews.",
+    "alpha_scope": "Graph routing and disabled alpha processing only; H264 proof renders do not contain alpha.",
+    "main_film_modified": false,
+    "scope": "Prior native verification reported by the video owner; packaging does not rerun the native application."
+  },
+  "limitations": [
+    "Starting strengths require shot-specific taste review.",
+    "LumaHalo uses a per-frame Sobel/luminance mask, not object detection or tracking."
+  ],
+  "evidence_sha256": {
+    "installation_verification.json": "a49d1dc7a1efec4e4f2d5e21b8bca8e8ec4553cda669ae4bc85b0017c9f2658e",
+    "final_receipt.json": "19faa40f6bd52954a72faecb044b2f79c040a7a81b0b8302842316a1da6ce794",
+    "final_pixel_qc.json": "1355db7b73b69a9502cb274c977098fb8b8eeb583679ab53ddd8344a37822448",
+    "final_main_restore.json": "c2ead0f4151f467da0cd75b80c96658b68df5c38cfd4980b41ecd82d018066b8",
+    "production_preview_pixel_qc.json": "25c2d3f79caf8e6313d790101190269be1d5e1bb13e18e2861b313c8a593b0dc",
+    "VALIDATION.md": "00deff144c000dcfedc84d794377d97f870989fd2f7a7b4fde9f70a5b52b3d0f"
+  }
+}

--- a/skills/video-editing/assets/fusion/ito-v28/ITO_V28_FlashEtherealBloom.setting
+++ b/skills/video-editing/assets/fusion/ito-v28/ITO_V28_FlashEtherealBloom.setting
@@ -1,0 +1,7 @@
+{
+ Tools = ordered() {
+  ITO_V28_FlashGain = BrightnessContrast { Inputs = { Gain = Input { Value = 1.22, }, Contrast = Input { Value = 1.16, }, } },
+  ITO_V28_FlashBloom = SoftGlow { Inputs = { Gain = Input { Value = 0.72, }, GlowSize = Input { Value = 18.0, }, Input = Input { SourceOp = "ITO_V28_FlashGain", Source = "Output", }, } },
+  ITO_V28_FlashColor = ColorGain { Inputs = { GainRed = Input { Value = 0.93, }, GainGreen = Input { Value = 1.04, }, GainBlue = Input { Value = 1.16, }, Input = Input { SourceOp = "ITO_V28_FlashBloom", Source = "Output", }, } }
+ }
+}

--- a/skills/video-editing/assets/fusion/ito-v28/ITO_V28_RGBDisplacement.setting
+++ b/skills/video-editing/assets/fusion/ito-v28/ITO_V28_RGBDisplacement.setting
@@ -1,0 +1,7 @@
+{
+ Tools = ordered() {
+  ITO_V28_RGBBase = Transform { Inputs = { Size = Input { Value = 1.008, }, } },
+  ITO_V28_RGBShift = ChannelBoolean { Inputs = { ToRed = Input { Value = 4, }, ToGreen = Input { Value = 3, }, ToBlue = Input { Value = 2, }, Background = Input { SourceOp = "ITO_V28_RGBBase", Source = "Output", }, Foreground = Input { SourceOp = "ITO_V28_RGBBase", Source = "Output", }, } },
+  ITO_V28_RGBSmear = DirectionalBlur { Inputs = { Length = Input { Value = 0.018, }, Angle = Input { Value = 0.0, }, Input = Input { SourceOp = "ITO_V28_RGBShift", Source = "Output", }, } }
+ }
+}

--- a/skills/video-editing/assets/fusion/ito-v28/ITO_V28_SubjectHalo.setting
+++ b/skills/video-editing/assets/fusion/ito-v28/ITO_V28_SubjectHalo.setting
@@ -1,0 +1,7 @@
+{
+ Tools = ordered() {
+  ITO_V28_SubjectRect = RectangleMask { Inputs = { Width = Input { Value = 0.28, }, Height = Input { Value = 0.34, }, BorderWidth = Input { Value = 0.012, }, Solid = Input { Value = 0, }, } },
+  ITO_V28_SubjectGlow = SoftGlow { Inputs = { Gain = Input { Value = 0.85, }, GlowSize = Input { Value = 12.0, }, EffectMask = Input { SourceOp = "ITO_V28_SubjectRect", Source = "Mask", }, } },
+  ITO_V28_SubjectFrame = Transform { Inputs = { Center = Input { Value = { 0.5, 0.42 }, }, Input = Input { SourceOp = "ITO_V28_SubjectGlow", Source = "Output", }, } }
+ }
+}

--- a/skills/video-editing/assets/fusion/ito-v28/README.md
+++ b/skills/video-editing/assets/fusion/ito-v28/README.md
@@ -1,0 +1,35 @@
+# ITO V28 Fusion compatibility examples
+
+These are preserved technical compatibility examples, **not recommended production defaults**. Native import and render checks establish that the graphs execute; visual review found blown highlights in Bloom, a strong green channel remap in RGB, and a translated full-frame border in Halo. Tune and visually review any derived look before production use.
+
+This versioned bundle preserves the original ITO_V22 installation. It contains three serialized Fusion tool graphs and a Lua installer. A sanitized summary and hashes of the separately retained native evidence are recorded in [provenance.json](provenance.json); installation alone is not import/render proof.
+
+## Install on macOS
+
+Keep the three .setting files beside install_ito_v28.lua. Run the installer from its absolute path with Resolve's bundled interpreter:
+
+```sh
+"/Applications/DaVinci Resolve/DaVinci Resolve.app/Contents/Libraries/Fusion/fuscript" -l lua "/absolute/path/to/reusable/install_ito_v28.lua"
+```
+
+The installer writes to your user Fusion/Macros/ITO_V28 folder, verifies exact bytes and is safe to rerun when those bytes match. It refuses a conflicting existing file and never replaces ITO_V22. The prior native verification run passed both the initial execution and an idempotent second execution using the bundled Lua runtime. See [provenance.json](provenance.json).
+
+## Import and wire
+
+The verified host API route is TimelineItem.ImportFusionComp with the actual .setting path. These files are tool-graph snippets, not complete footage compositions or one-click tracked effects. Connect the clip's MediaIn output to the first image tool, then the last image tool to MediaOut. Preserve the serialized internal links.
+
+| Setting | External image chain |
+|---|---|
+| FlashEtherealBloom | MediaIn → ITO_V28_FlashGain → FlashBloom → FlashColor → MediaOut |
+| RGBDisplacement | MediaIn → ITO_V28_RGBBase → RGBShift → RGBSmear → MediaOut |
+| SubjectHalo | MediaIn → ITO_V28_SubjectGlow → SubjectFrame → MediaOut; SubjectRect connects to SubjectGlow's EffectMask |
+
+Names after the first node in the table also carry the ITO_V28_ prefix. Use a new composition or duplicate clip when trying these effects, so the existing composition stays available.
+
+## Scope and correction
+
+The original RGB file used the unavailable ChannelBooleans registry identifier and an invalid image input name. V28 uses the live registered ChannelBoolean with Background and Foreground connected to RGBBase. It preserves the original selectors 4/3/2. The resulting effect is channel remapping, slight scale and directional smear; its historical filename does not establish separate-channel spatial displacement.
+
+SubjectHalo is a static rectangular effect mask plus a position adjustment. It performs no subject detection or tracking. Bloom and Halo otherwise retain their original numeric parameters. Original settings and failure evidence remain preserved.
+
+These native tests are separate from the finished V28 film, whose source-derived treatments use rendered media. They do not modify that film or its portable archive.

--- a/skills/video-editing/assets/fusion/ito-v28/install_ito_v28.lua
+++ b/skills/video-editing/assets/fusion/ito-v28/install_ito_v28.lua
@@ -1,0 +1,51 @@
+-- Run this file with Resolve's fuscript interpreter or Lua dofile().
+-- Keep the three .setting files beside it. Existing ITO_V22 files are untouched.
+local function need(ok, message)
+  if not ok then error(message, 0) end
+  return ok
+end
+local function read(path)
+  local file, message, code = io.open(path, "rb")
+  if not file then
+    need(code == 2, "Could not read " .. path .. ": " .. tostring(message))
+    return nil
+  end
+  local value = file:read("*a")
+  file:close()
+  need(value ~= nil, "Read failed: " .. path)
+  return value
+end
+local function quote(value)
+  return "'" .. value:gsub("'", "'\\''") .. "'"
+end
+local script = debug.getinfo(1, "S").source
+need(script:sub(1, 1) == "@", "Run the saved installer file, not pasted text")
+local sourceDir = need(script:sub(2):match("^(.*)/[^/]+$"), "Use the installer absolute path")
+local userHome = need(os.getenv("HOME"), "HOME is unavailable")
+local targetDir = userHome .. "/Library/Application Support/Blackmagic Design/DaVinci Resolve/Fusion/Macros/ITO_V28"
+local names = {
+  "ITO_V28_FlashEtherealBloom.setting",
+  "ITO_V28_RGBDisplacement.setting",
+  "ITO_V28_SubjectHalo.setting",
+}
+local payloads = {}
+for _, name in ipairs(names) do
+  local payload = need(read(sourceDir .. "/" .. name), "Missing source setting: " .. name)
+  need(#payload > 0, "Empty source setting: " .. name)
+  local existing = read(targetDir .. "/" .. name)
+  need(existing == nil or existing == payload, "Refusing to overwrite a different installed setting: " .. name)
+  payloads[name] = payload
+end
+local result = os.execute("mkdir -p " .. quote(targetDir))
+need(result == 0 or result == true, "Could not create ITO_V28 directory")
+for _, name in ipairs(names) do
+  local path = targetDir .. "/" .. name
+  if read(path) == nil then
+    local file = need(io.open(path, "wb"), "Could not create: " .. name)
+    need(file:write(payloads[name]), "Write failed: " .. name)
+    need(file:close(), "Close failed: " .. name)
+  end
+  need(read(path) == payloads[name], "Installed readback mismatch: " .. name)
+  print("VERIFIED " .. name)
+end
+print("ITO_V28_INSTALLED " .. targetDir)

--- a/skills/video-editing/assets/fusion/ito-v28/provenance.json
+++ b/skills/video-editing/assets/fusion/ito-v28/provenance.json
@@ -1,0 +1,39 @@
+{
+  "bundle": "ITO_V28",
+  "classification": "technical compatibility examples; not recommended production defaults",
+  "files": {
+    "ITO_V28_FlashEtherealBloom.setting": "6bc178e29cc1a39458f58d53d397357eb8ecb4510780d5993fb25cef30b26d47",
+    "ITO_V28_RGBDisplacement.setting": "66598d0c60e8551e1704932ef014691fc8cd684d50f1bf0646b39e3d2f4ccf36",
+    "ITO_V28_SubjectHalo.setting": "ac70fca7f622da29ad34963a737f668c73b526a7852c2504f66b719d2c14b638",
+    "install_ito_v28.lua": "b111d9ed0773e29682a8e426fa9f65099022cfac3de4330db187e9303d4a0dd4"
+  },
+  "native_verification": {
+    "reported_at_utc": "2026-09-07T11:45:06.454774+00:00",
+    "interpreter": "DaVinci Resolve bundled fuscript -l lua",
+    "syntax_passed": true,
+    "actual_install_passed": true,
+    "second_idempotent_run_passed": true,
+    "import_api": "TimelineItem.ImportFusionComp",
+    "saved_and_reopened": true,
+    "renders": {
+      "count": 6,
+      "width": 1920,
+      "height": 1080,
+      "frames_each": 30,
+      "fps": 30,
+      "fully_decoded": true
+    },
+    "original_v22_preserved": true,
+    "scope": "Prior native compatibility run. This packaging task does not rerun native installation or certify production visual quality."
+  },
+  "visual_limitations": [
+    "Bloom defaults blow highlights.",
+    "RGB performs channel remapping and smear, not independent RGB spatial displacement; defaults introduce a strong green tint.",
+    "Halo uses a static rectangular mask with no subject detection or tracking; full-frame translation introduces a border."
+  ],
+  "evidence_sha256": {
+    "installation_verification.json": "28e86f95029b8d76054236a5667cf67f181cd9b40a94b81fa0bdc1075b879bf2",
+    "verified_bundle_receipt.json": "d84f60dfefb110a8dd3ae3b8c4cfc3d73857b86aecbddf46fbcdd15f55df2008",
+    "VALIDATION.md": "76a7959394432e70e2946c166e395a2cd492a695f26668b2dbbc807bd1e8d46b"
+  }
+}

--- a/tests/ci/fusion-bundle.test.js
+++ b/tests/ci/fusion-bundle.test.js
@@ -1,0 +1,75 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const root = path.resolve(__dirname, "../..");
+const relative = "skills/video-editing/assets/fusion/ito-v28";
+const bundle = path.join(root, relative);
+const provenance = JSON.parse(fs.readFileSync(path.join(bundle, "provenance.json")));
+const digest = (bytes) => crypto.createHash("sha256").update(bytes).digest("hex");
+
+for (const [name, expected] of Object.entries(provenance.files)) {
+  assert.equal(digest(fs.readFileSync(path.join(bundle, name))), expected, name);
+}
+assert.equal(Object.keys(provenance.files).length, 4);
+const rgb = fs.readFileSync(path.join(bundle, "ITO_V28_RGBDisplacement.setting"), "utf8");
+assert.match(rgb, /ChannelBoolean \{/);
+assert.doesNotMatch(rgb, /ChannelBooleans/);
+for (const port of ["Background", "Foreground"]) {
+  assert.ok(rgb.includes(`${port} = Input { SourceOp = "ITO_V28_RGBBase"`));
+}
+const readme = fs.readFileSync(path.join(bundle, "README.md"), "utf8");
+assert.match(readme, /not recommended production defaults/);
+assert.match(readme, /channel remapping/);
+assert.match(readme, /static rectangular/);
+assert.match(readme, /no subject detection or tracking/);
+assert.match(readme, /ImportFusionComp/);
+assert.match(readme, /provenance.json/);
+assert.ok(JSON.parse(fs.readFileSync(path.join(root, "package.json"))).files.includes("skills/video-editing/"));
+console.log("Fusion source hashes, registered wiring, scope and package ownership passed.");
+
+const productionRelative = "skills/video-editing/assets/fusion/ito-production-v1";
+const production = path.join(root, productionRelative);
+const productionProvenance = JSON.parse(fs.readFileSync(path.join(production, "provenance.json")));
+assert.equal(Object.keys(productionProvenance.files).length, 4);
+for (const [name, expected] of Object.entries(productionProvenance.files)) {
+  assert.equal(digest(fs.readFileSync(path.join(production, name))), expected, name);
+}
+const productionReadme = fs.readFileSync(path.join(production, "README.md"), "utf8");
+assert.match(productionReadme, /no object detection or tracking/);
+assert.match(productionReadme, /H264 proof renders do not contain alpha/);
+assert.match(productionReadme, /provenance.json/);
+console.log("Approved production source hashes and documented limits passed.");
+
+if (process.env.ECC_TEST_NPM_PACK === "1") {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "ecc-fusion-pack-"));
+  try {
+    const packed = spawnSync("npm", ["pack", "--ignore-scripts", "--json", "--pack-destination", temp], {
+      cwd: root, encoding: "utf8", timeout: 120000,
+    });
+    assert.equal(packed.status, 0, packed.stderr);
+    const info = JSON.parse(packed.stdout)[0];
+    const archive = path.join(temp, info.filename);
+    const bundles = [
+      { relative, bundle, provenance },
+      { relative: productionRelative, bundle: production, provenance: productionProvenance },
+    ];
+    for (const item of bundles) {
+      for (const name of [...Object.keys(item.provenance.files), "README.md", "provenance.json"]) {
+        const extracted = spawnSync("tar", ["-xOf", archive, `package/${item.relative}/${name}`], {
+          maxBuffer: 1024 * 1024, timeout: 30000,
+        });
+        assert.equal(extracted.status, 0, String(extracted.stderr));
+        assert.deepEqual(extracted.stdout, fs.readFileSync(path.join(item.bundle, name)), name);
+      }
+    }
+    console.log("Actual npm tarball contains all twelve Fusion bundle files byte-for-byte.");
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
Adds reusable native Fusion graph snippets to the existing video-editing skill: restrained highlight bloom, opposing red/blue spatial offsets, and a source-driven luminance/edge halo. The production v1 files preserve the exact bytes approved in two-source visual review and verified by native import, save/reopen, parameter readback, and six short motion renders. Halo does not detect or track subjects; alpha claims are limited to graph routing because proof renders use H264.

Retains the earlier ITO_V28 files explicitly as technical compatibility examples, not recommended production defaults. Both bundles include byte-preserved Lua installers, documented external wiring, sanitized provenance and evidence hashes. Existing ITO_V22/V28 installations are preserved by the production installer. No main-film or application changes are part of this PR.

Validation: focused source hash and scope tests; actual npm tarball extraction matching all twelve files byte-for-byte; ESLint; Markdownlint for new READMEs; skill and personal-path validation; independent code/security review. Native execution evidence is from the prior video-owner run, not rerun by packaging. Hermes package/hash verification is recorded in the delivery receipt.

This focused PR starts from current main and is independent of consolidation PR #3009. Neither PR is merged; their package artifacts are separate.
