### PR TITLE
fix(codex): leave pytest execution to CI

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -103,3 +103,10 @@ Codex supports a narrower native hook subset than Claude Code, with explicit tru
 3. Run `npm audit` / `pip audit` before committing
 4. Review `git diff` before every push
 5. Use `sandbox_mode = "workspace-write"` in config
+
+## Python Test Validation
+
+ECC Git hooks do not run pytest. Continuous integration (CI) is the authoritative
+automated Python test gate. Before you create a pull request, run every new or
+changed test with the repository's test command. Put the exact commands and
+results in the pull request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@
 <!-- Describe the testing you performed to validate your changes -->
 - [ ] Manual testing completed
 - [ ] Automated tests pass locally (`node tests/run-all.js`)
+- [ ] Every new or changed test was run before this pull request was created
 - [ ] Edge cases considered and tested
 
 ## Type of Change
@@ -23,7 +24,7 @@
 - [ ] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
 - [ ] JSON files validate cleanly
 - [ ] Shell scripts pass shellcheck (if applicable)
-- [ ] Pre-commit hooks pass locally (if configured)
+- [ ] Pre-commit and pre-push hooks pass locally (if configured); pytest is enforced by CI
 - [ ] No sensitive data exposed in logs or output
 - [ ] Follows conventional commits format
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
         run: python -m mypy src
 
       - name: Run Python tests
-        run: python -m pytest tests/test_*.py -m "not integration"
+        run: python -m pytest tests -m "not integration"
 
   security:
     name: Security Scan

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,10 @@ Use parallel execution for independent operations — launch multiple agents sim
 
 **Minimum coverage: 80%**
 
+ECC Git hooks do not run pytest. CI is the authoritative automated Python test
+gate. Before you create a pull request, run every new or changed test with the
+repository's test command. Put the exact commands and results in the pull request.
+
 Test types (all required):
 1. **Unit tests** — Individual functions, utilities, components
 2. **Integration tests** — API endpoints, database operations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -464,6 +464,11 @@ How you tested this.
 - [ ] Clear descriptions
 ```
 
+Before you create a pull request, run every new or changed test with the
+repository's test command. Include the exact command and result in the `Testing`
+section. ECC Git hooks do not run pytest. Continuous integration (CI) is the
+authoritative automated Python test gate.
+
 ### 3. Before You Push (avoid red CI)
 
 Run `npm test` locally. It is the same gauntlet CI runs, and it catches almost everything below.
@@ -489,7 +494,7 @@ Run `npm test` locally. It is the same gauntlet CI runs, and it catches almost e
 ### Do
 - Keep contributions focused and modular
 - Include clear descriptions
-- Test before submitting
+- Run every new or changed test before creating a pull request
 - Follow existing patterns
 - Document dependencies
 

--- a/README.md
+++ b/README.md
@@ -1719,6 +1719,16 @@ npm install && bash scripts/sync-ecc-to-codex.sh
 cp .codex/config.toml ~/.codex/config.toml
 ```
 
+The compatibility sync installs Git safety hooks. The pre-commit hook scans
+staged additions for high-signal secrets. The pre-push hook can run supported
+fast checks, but it does not run pytest. Project CI is the authoritative
+automated Python test gate.
+
+Before you create a pull request, run every new or changed test with the
+project-native test command. Record the commands and results in the pull request.
+Do not use the absence of a local pytest hook as a reason to submit unvalidated
+tests.
+
 The sync script safely merges ECC MCP servers into your existing `~/.codex/config.toml` using an **add-only** strategy: it never removes or modifies your existing servers. Run with `--dry-run` to preview changes, or `--update-mcp` to force-refresh ECC servers to the latest recommended config.
 
 For Context7, ECC uses the canonical Codex section name `[mcp_servers.context7]` while still launching the `@upstash/context7-mcp` package. If you already have a legacy `[mcp_servers.context7-mcp]` entry, `--update-mcp` migrates it to the canonical section name.

--- a/docs/adr/0001-ci-owns-python-test-execution.md
+++ b/docs/adr/0001-ci-owns-python-test-execution.md
@@ -1,0 +1,39 @@
+# ADR-0001: CI Owns Python Test Execution
+
+**Status:** Accepted
+
+**Date:** 2026-09-08
+
+## Context
+
+The ECC global pre-push hook ran pytest when it found a Python project. The hook
+used the ambient host environment. A project could therefore get different
+results from a developer machine and CI because Python versions, dependencies,
+plugins, operating systems, and test configuration were different. A full test
+suite also made each push slow.
+
+CI already provides the controlled and reviewable test boundary for each project.
+Contributors still need fast feedback for tests that they add or change.
+
+## Decision
+
+ECC pre-commit and pre-push hooks do not run pytest. Project CI is the
+authoritative automated Python test gate.
+
+Before a contributor creates a pull request, the contributor must run every new
+or changed test with the project's test command. The pull request must include
+the exact commands and results.
+
+The pre-commit hook continues to scan staged additions for high-signal secrets.
+The pre-push hook can continue to run its other supported checks.
+
+## Consequences
+
+- A push does not run a Python test suite in an ambient local environment.
+- Python test results come from the project's configured CI environment.
+- Contributors get focused local feedback by running each new or changed test
+  before they create a pull request.
+- A project without a Python CI gate must add one. ECC does not supply a fallback
+  pytest gate in its Git hooks.
+- Existing installations must run `scripts/codex/install-global-git-hooks.sh` or
+  the ECC Codex sync command to receive the changed hook.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,8 @@
+# Architecture Decision Records
+
+Architecture decision records (ADRs) explain accepted project decisions and
+their consequences.
+
+| ADR | Title | Status | Date |
+| --- | --- | --- | --- |
+| [0001](0001-ci-owns-python-test-execution.md) | CI owns Python test execution | Accepted | 2026-09-08 |

--- a/scripts/codex-git-hooks/pre-push
+++ b/scripts/codex-git-hooks/pre-push
@@ -117,16 +117,6 @@ if [[ -f "go.mod" ]] && command -v go >/dev/null 2>&1; then
   go test ./... || fail "go test failed"
 fi
 
-if [[ -f "pyproject.toml" || -f "requirements.txt" ]]; then
-  if command -v pytest >/dev/null 2>&1; then
-    ran_any_check=1
-    log "Python project detected. Running: pytest -q"
-    pytest -q || fail "pytest failed"
-  else
-    log "Python project detected but pytest is not installed. Skipping."
-  fi
-fi
-
 if [[ "$ran_any_check" -eq 0 ]]; then
   log "No supported checks found in this repository. Skipping."
 else

--- a/scripts/codex/check-codex-global-state.sh
+++ b/scripts/codex/check-codex-global-state.sh
@@ -211,7 +211,7 @@ fi
 
 if [[ -x "$HOOKS_DIR_EXPECT/pre-push" ]]; then
   ok "Global pre-push hook is installed and executable"
-  if rg -n 'pytest' "$HOOKS_DIR_EXPECT/pre-push" >/dev/null 2>&1; then
+  if search_file 'pytest' "$HOOKS_DIR_EXPECT/pre-push"; then
     fail "Global pre-push hook must leave pytest execution to CI"
   else
     ok "Global pre-push hook leaves pytest execution to CI"

--- a/scripts/codex/check-codex-global-state.sh
+++ b/scripts/codex/check-codex-global-state.sh
@@ -211,6 +211,11 @@ fi
 
 if [[ -x "$HOOKS_DIR_EXPECT/pre-push" ]]; then
   ok "Global pre-push hook is installed and executable"
+  if rg -n 'pytest' "$HOOKS_DIR_EXPECT/pre-push" >/dev/null 2>&1; then
+    fail "Global pre-push hook must leave pytest execution to CI"
+  else
+    ok "Global pre-push hook leaves pytest execution to CI"
+  fi
 else
   fail "Global pre-push hook missing or not executable"
 fi

--- a/scripts/codex/install-global-git-hooks.sh
+++ b/scripts/codex/install-global-git-hooks.sh
@@ -61,5 +61,6 @@ fi
 run_or_echo git config --global core.hooksPath "$DEST_DIR"
 
 log "Installed ECC global git hooks."
+log "Python test suites are CI-owned and are not run by these hooks."
 log "Disable per repo by creating .ecc-hooks-disable in project root."
 log "Temporary bypass: ECC_SKIP_PRECOMMIT=1 or ECC_SKIP_PREPUSH=1"

--- a/scripts/sync-ecc-to-codex.sh
+++ b/scripts/sync-ecc-to-codex.sh
@@ -6,7 +6,7 @@ set -Eeuo pipefail
 # - Merges ECC AGENTS.md into existing AGENTS.md (marker-based, preserves user content)
 # - Generates prompt files from commands/*.md
 # - Generates Codex QA wrappers and optional language rule-pack prompts
-# - Installs global git safety hooks (pre-commit and pre-push)
+# - Installs global git safety hooks (pre-commit and pre-push; no pytest execution)
 # - Runs a post-sync global regression sanity check
 # - Merges ECC MCP servers into config.toml (add-only via Node TOML parser)
 

--- a/tests/scripts/codex-git-hooks.test.js
+++ b/tests/scripts/codex-git-hooks.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PRE_PUSH_HOOK = path.join(
+  __dirname,
+  '..',
+  '..',
+  'scripts',
+  'codex-git-hooks',
+  'pre-push'
+);
+const PUSH_UPDATE = `refs/heads/main ${'1'.repeat(40)} refs/heads/main ${'2'.repeat(40)}\n`;
+
+console.log('=== Testing Codex git hooks ===\n');
+
+let passed = 0;
+let failed = 0;
+
+function test(description, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${description}`);
+    passed++;
+  } catch (error) {
+    console.log(`  ✗ ${description}: ${error.message}`);
+    failed++;
+  }
+}
+
+test('pre-push leaves Python test execution to CI', () => {
+  const projectMarkers = [
+    ['requirements.txt', 'pytest\n'],
+    ['pyproject.toml', '[tool.pytest.ini_options]\n']
+  ];
+
+  for (const [projectFile, projectContent] of projectMarkers) {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-pre-push-'));
+    const binDir = path.join(tempRoot, 'bin');
+    const pytestMarker = path.join(tempRoot, 'pytest-ran');
+
+    try {
+      fs.mkdirSync(binDir);
+      fs.writeFileSync(path.join(tempRoot, projectFile), projectContent);
+      fs.writeFileSync(
+        path.join(binDir, 'pytest'),
+        '#!/usr/bin/env bash\n: > "$PYTEST_MARKER"\nexit 42\n'
+      );
+      fs.chmodSync(path.join(binDir, 'pytest'), 0o755);
+      spawnSync('git', ['init'], { cwd: tempRoot, stdio: 'ignore' });
+
+      const result = spawnSync('bash', [PRE_PUSH_HOOK], {
+        cwd: tempRoot,
+        encoding: 'utf8',
+        input: PUSH_UPDATE,
+        env: {
+          ...process.env,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+          PYTEST_MARKER: pytestMarker
+        }
+      });
+
+      assert.strictEqual(result.status, 0, `${projectFile}: ${result.stderr || result.stdout}`);
+      assert.strictEqual(
+        fs.existsSync(pytestMarker),
+        false,
+        `${projectFile}: pre-push must not invoke pytest`
+      );
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  }
+});
+
+console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+if (failed > 0) process.exit(1);

--- a/tests/scripts/codex-git-hooks.test.js
+++ b/tests/scripts/codex-git-hooks.test.js
@@ -14,6 +14,15 @@ const PRE_PUSH_HOOK = path.join(
   'codex-git-hooks',
   'pre-push'
 );
+const GLOBAL_STATE_CHECK = path.join(
+  __dirname,
+  '..',
+  '..',
+  'scripts',
+  'codex',
+  'check-codex-global-state.sh'
+);
+const CI_WORKFLOW = path.join(__dirname, '..', '..', '.github', 'workflows', 'ci.yml');
 const PUSH_UPDATE = `refs/heads/main ${'1'.repeat(40)} refs/heads/main ${'2'.repeat(40)}\n`;
 
 console.log('=== Testing Codex git hooks ===\n');
@@ -51,20 +60,29 @@ test('pre-push leaves Python test execution to CI', () => {
         '#!/usr/bin/env bash\n: > "$PYTEST_MARKER"\nexit 42\n'
       );
       fs.chmodSync(path.join(binDir, 'pytest'), 0o755);
-      spawnSync('git', ['init'], { cwd: tempRoot, stdio: 'ignore' });
+      const init = spawnSync('git', ['init'], { cwd: tempRoot, encoding: 'utf8' });
+      assert.strictEqual(init.status, 0, `${projectFile}: git init failed: ${init.stderr}`);
+
+      const hookEnv = {
+        ...process.env,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+        PYTEST_MARKER: pytestMarker,
+        ECC_SKIP_GIT_HOOKS: '0',
+        ECC_SKIP_PREPUSH: '0'
+      };
+      for (const key of ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_COMMON_DIR', 'GIT_PREFIX']) {
+        delete hookEnv[key];
+      }
 
       const result = spawnSync('bash', [PRE_PUSH_HOOK], {
         cwd: tempRoot,
         encoding: 'utf8',
         input: PUSH_UPDATE,
-        env: {
-          ...process.env,
-          PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
-          PYTEST_MARKER: pytestMarker
-        }
+        env: hookEnv
       });
 
       assert.strictEqual(result.status, 0, `${projectFile}: ${result.stderr || result.stdout}`);
+      assert.match(result.stdout, /\[ECC pre-push\]/, `${projectFile}: hook did not run`);
       assert.strictEqual(
         fs.existsSync(pytestMarker),
         false,
@@ -76,5 +94,103 @@ test('pre-push leaves Python test execution to CI', () => {
   }
 });
 
-console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+test('global state check detects a stale pytest hook without ripgrep', () => {
+  if (process.platform === 'win32') return;
+
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-global-state-'));
+  const codexHome = path.join(tempRoot, 'codex');
+  const agentsHome = path.join(tempRoot, 'agents');
+  const hooksDir = path.join(codexHome, 'git-hooks');
+  const promptsDir = path.join(codexHome, 'prompts');
+  const binDir = path.join(tempRoot, 'bin');
+  const requiredCommands = ['awk', 'bash', 'dirname', 'find', 'grep', 'tr', 'wc'];
+  const requiredSkills = [
+    'api-design',
+    'article-writing',
+    'backend-patterns',
+    'coding-standards',
+    'content-engine',
+    'e2e-testing',
+    'eval-harness',
+    'frontend-patterns',
+    'frontend-slides',
+    'investor-materials',
+    'investor-outreach',
+    'market-research',
+    'security-review',
+    'strategic-compact',
+    'tdd-workflow',
+    'verification-loop'
+  ];
+
+  try {
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.mkdirSync(promptsDir, { recursive: true });
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.mkdirSync(path.join(agentsHome, 'skills'), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(codexHome, 'config.toml'),
+      [
+        'multi_agent = true',
+        '[profiles.strict]',
+        '[profiles.yolo]',
+        '[mcp_servers.chrome-devtools]'
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(codexHome, 'AGENTS.md'),
+      '# Everything Claude Code (ECC)\n# Codex Supplement (From ECC .codex/AGENTS.md)\n'
+    );
+    fs.writeFileSync(path.join(promptsDir, 'ecc-prompts-manifest.txt'), '');
+    fs.writeFileSync(path.join(promptsDir, 'ecc-extension-prompts-manifest.txt'), '');
+    for (let index = 0; index < 43; index++) {
+      fs.writeFileSync(path.join(promptsDir, `ecc-${index}.md`), '');
+    }
+    for (const skill of requiredSkills) {
+      fs.mkdirSync(path.join(agentsHome, 'skills', skill));
+    }
+    fs.writeFileSync(path.join(hooksDir, 'pre-commit'), '#!/usr/bin/env bash\nexit 0\n');
+    fs.writeFileSync(path.join(hooksDir, 'pre-push'), '#!/usr/bin/env bash\npytest -q\n');
+    fs.chmodSync(path.join(hooksDir, 'pre-commit'), 0o755);
+    fs.chmodSync(path.join(hooksDir, 'pre-push'), 0o755);
+
+    for (const command of requiredCommands) {
+      const resolved = spawnSync('sh', ['-c', `command -v ${command}`], { encoding: 'utf8' });
+      assert.strictEqual(resolved.status, 0, `cannot resolve ${command}: ${resolved.stderr}`);
+      fs.symlinkSync(resolved.stdout.trim(), path.join(binDir, command));
+    }
+    fs.writeFileSync(
+      path.join(binDir, 'git'),
+      '#!/usr/bin/env bash\nif [[ "$*" == "config --global --get core.hooksPath" ]]; then printf "%s\\n" "$TEST_HOOKS_PATH"; exit 0; fi\nexit 1\n'
+    );
+    fs.chmodSync(path.join(binDir, 'git'), 0o755);
+
+    const result = spawnSync(path.join(binDir, 'bash'), [GLOBAL_STATE_CHECK], {
+      encoding: 'utf8',
+      env: {
+        HOME: tempRoot,
+        CODEX_HOME: codexHome,
+        AGENTS_HOME: agentsHome,
+        ECC_GLOBAL_HOOKS_DIR: hooksDir,
+        TEST_HOOKS_PATH: hooksDir,
+        PATH: binDir
+      }
+    });
+
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stdout, /\[FAIL\] Global pre-push hook must leave pytest execution to CI/);
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('CI collects the complete Python test tree', () => {
+  const workflow = fs.readFileSync(CI_WORKFLOW, 'utf8');
+
+  assert.match(workflow, /python -m pytest tests -m "not integration"/);
+  assert.doesNotMatch(workflow, /python -m pytest tests\/test_\*\.py/);
+});
+
+console.log(`\n=== Results: Passed: ${passed}, Failed: ${failed} ===`);
 if (failed > 0) process.exit(1);


### PR DESCRIPTION
## What Changed

- Remove pytest execution from the ECC global pre-push hook.
- Add regression coverage for `requirements.txt` and `pyproject.toml` projects.
- Make CI the authoritative automated Python test gate, including nested Python tests.
- Require contributors to run every new or changed test before creating a pull request.
- Add ADR-0001 and update the README, contributor guidance, Codex guidance, installer output, global-state check, and PR template.

## Why This Change

The global pre-push hook used the ambient host Python environment. That environment can differ from a project's configured CI environment in Python version, dependencies, plugins, and operating system. Full pytest runs also made each push slow.

## Testing Done

- `node tests/scripts/codex-git-hooks.test.js` — 3 passed, 0 failed
- `node tests/ci/run-all.test.js` — 8 passed, 0 failed
- `node tests/ci/validate-workflow-security.test.js` — 26 passed, 0 failed
- `python -m pytest tests -m "not integration"` — 95 passed
- `python -m ruff check src tests` — passed
- `python -m mypy src` — passed, 20 source files checked
- `npm run lint` — passed
- `bash -n scripts/codex-git-hooks/pre-push scripts/codex/check-codex-global-state.sh scripts/codex/install-global-git-hooks.sh scripts/sync-ecc-to-codex.sh` — passed
- `git diff --check` — passed
- `npm test` — repository validators, catalog checks, and the new regression test passed; the broader suite encountered existing tests that write to the sandboxed user configuration directory, so CI remains the authoritative full-suite result

## Type of Change

- [x] `fix:` Bug fix
- [x] `docs:` Documentation
- [x] `test:` Tests
- [x] `ci:` CI/CD changes

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] JSON files validate cleanly
- [x] Shell scripts pass syntax validation
- [x] Every new or changed test was run before its commit was pushed
- [x] Updated relevant documentation
