### PR TITLE
fix(install): compare settings dev ids only when both stats report one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Managed Claude settings writes (`install-apply.js --enable-hooks`, `/auto-update`) failed closed on Windows under Node 22.12-22.16 and 24.0-24.1 with `Refusing to read changed Claude settings`, then left a stale `settings.json.ecc.lock` behind because the lock release hit the same guard. Both guards compared `fstat()` `dev` against a path-based `lstat()` `dev` that libuv 1.49.0-1.50.x reports as `0` on Windows. They now compare `dev` only when both stats report one, matching the memory vault guard; the inode, regular-file, and symlink checks still fail closed.
+
 ## 2.2.0 - 2026-08-25
 
 ### Added

--- a/scripts/lib/install/claude-settings-lock.js
+++ b/scripts/lib/install/claude-settings-lock.js
@@ -7,7 +7,13 @@ const path = require('path');
 const INVALID_LOCK_STALE_MS = 5 * 60 * 1000;
 
 function sameFileIdentity(left, right) {
-  return left.dev === right.dev && left.ino === right.ino;
+  if (left.ino !== right.ino) return false;
+  // libuv 1.49.0 through 1.50.x (Node 22.12-22.16 and 24.0-24.1) resolve
+  // path-based lstat() on Windows without setting the volume serial, while
+  // fstat() on the open descriptor reports it. Compare dev only when both
+  // sides report one so the lock can still be released on those runtimes.
+  if (!left.dev || !right.dev) return true;
+  return left.dev === right.dev;
 }
 
 function createSettingsLock(lockPath) {

--- a/scripts/lib/install/claude-settings.js
+++ b/scripts/lib/install/claude-settings.js
@@ -327,6 +327,17 @@ function readSettings(settingsPath, fileSystem = fs) {
   return parseSettings(rawSettings, `Claude settings at ${settingsPath}`);
 }
 
+// libuv 1.49.0 through 1.50.x (Node 22.12-22.16 and 24.0-24.1) resolve
+// path-based lstat() on Windows without setting the volume serial, while
+// fstat() on the open descriptor reports it, so a strict dev comparison can
+// never pass there. Compare dev only when both sides report one; the inode,
+// regular-file and symlink checks still fail closed. POSIX always reports dev,
+// so the strict behaviour is preserved on those platforms.
+function sameDeviceId(left, right) {
+  if (!left.dev || !right.dev) return true;
+  return left.dev === right.dev;
+}
+
 function readSettingsSnapshot(settingsPath) {
   const flags = fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0);
   let descriptor;
@@ -354,7 +365,7 @@ function readSettingsSnapshot(settingsPath) {
       !descriptorStat.isFile()
       || !pathStat.isFile()
       || pathStat.isSymbolicLink()
-      || descriptorStat.dev !== pathStat.dev
+      || !sameDeviceId(descriptorStat, pathStat)
       || descriptorStat.ino !== pathStat.ino
     ) {
       const error = new Error(`Refusing to read changed Claude settings at ${settingsPath}`);

--- a/tests/lib/claude-settings.test.js
+++ b/tests/lib/claude-settings.test.js
@@ -48,6 +48,14 @@ function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
+// Derive a stats object with a different dev without mutating the fs.Stats
+// instance; the prototype chain keeps isFile()/isSymbolicLink() working.
+function withDev(stats, dev) {
+  // fs.rmSync probes with { throwIfNoEntry: false }, which yields undefined.
+  if (!stats) return stats;
+  return Object.create(stats, { dev: { value: dev, enumerable: true } });
+}
+
 function assertAtomicParentReplacementRejected(stage) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-settings-parent-race-'));
   const targetRoot = path.join(tempDir, 'target');
@@ -463,8 +471,7 @@ function runTests() {
       fs.writeFileSync(settingsPath, '{"theme":"initial"}\n');
       fs.lstatSync = function(target, options) {
         const stats = originalLstat.call(fs, target, options);
-        stats.dev = options && options.bigint ? 0n : 0;
-        return stats;
+        return withDev(stats, options && options.bigint ? 0n : 0);
       };
       const result = updateSettingsAtomic(
         settingsPath,
@@ -488,7 +495,7 @@ function runTests() {
       fs.lstatSync = function(target, options) {
         const stats = originalLstat.call(fs, target, options);
         if (path.resolve(String(target)) === settingsPath) {
-          stats.dev = options && options.bigint ? stats.dev + 1n : stats.dev + 1;
+          return withDev(stats, options && options.bigint ? stats.dev + 1n : stats.dev + 1);
         }
         return stats;
       };
@@ -500,6 +507,59 @@ function runTests() {
         error => error.code === 'ECC_SETTINGS_CHANGED'
       );
       assert.deepStrictEqual(JSON.parse(fs.readFileSync(settingsPath, 'utf8')), { theme: 'initial' });
+    } finally {
+      fs.lstatSync = originalLstat;
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('lock release refuses a quarantined lock on a different device', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-settings-lock-dev-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    const lockPath = `${settingsPath}.ecc.lock`;
+    const originalLstat = fs.lstatSync;
+    try {
+      fs.writeFileSync(settingsPath, '{"theme":"initial"}\n');
+      fs.lstatSync = function(target, options) {
+        const stats = originalLstat.call(fs, target, options);
+        if (stats && String(target).includes('.ecc.lock.release-')) {
+          return withDev(stats, options && options.bigint ? stats.dev + 1n : stats.dev + 1);
+        }
+        return stats;
+      };
+      assert.throws(
+        () => runWithSettingsLock(settingsPath, () => 'done'),
+        /Refusing to release a changed Claude settings lock/
+      );
+      assert.strictEqual(fs.existsSync(lockPath), true);
+    } finally {
+      fs.lstatSync = originalLstat;
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('stale lock recovery keeps a quarantined lock on a different device', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-settings-stale-dev-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    const lockPath = `${settingsPath}.ecc.lock`;
+    const originalLstat = fs.lstatSync;
+    try {
+      fs.writeFileSync(settingsPath, '{"theme":"initial"}\n');
+      // A dead owner pid makes the lock stale, so recovery quarantines it and
+      // compares the quarantined identity with the one it inspected.
+      fs.writeFileSync(lockPath, `${JSON.stringify({ pid: 2147483647, startedAt: new Date().toISOString() })}\n`);
+      fs.lstatSync = function(target, options) {
+        const stats = originalLstat.call(fs, target, options);
+        if (stats && String(target).includes('.ecc.lock.stale-')) {
+          return withDev(stats, options && options.bigint ? stats.dev + 1n : stats.dev + 1);
+        }
+        return stats;
+      };
+      assert.throws(
+        () => runWithSettingsLock(settingsPath, () => 'done'),
+        /Another ECC process is updating Claude settings/
+      );
+      assert.strictEqual(fs.existsSync(lockPath), true);
     } finally {
       fs.lstatSync = originalLstat;
       fs.rmSync(tempDir, { recursive: true, force: true });

--- a/tests/lib/claude-settings.test.js
+++ b/tests/lib/claude-settings.test.js
@@ -453,6 +453,59 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('atomic settings updates tolerate path stats that omit the device id', () => {
+    // Node 22.12-22.16 and 24.0-24.1 on Windows report dev = 0 from path-based
+    // lstat() while fstat() on the open descriptor reports the volume serial.
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-settings-zero-dev-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    const originalLstat = fs.lstatSync;
+    try {
+      fs.writeFileSync(settingsPath, '{"theme":"initial"}\n');
+      fs.lstatSync = function(target, options) {
+        const stats = originalLstat.call(fs, target, options);
+        stats.dev = options && options.bigint ? 0n : 0;
+        return stats;
+      };
+      const result = updateSettingsAtomic(
+        settingsPath,
+        settings => ({ settings: { ...settings, managed: true } })
+      );
+      assert.deepStrictEqual(result.settings, { theme: 'initial', managed: true });
+      assert.deepStrictEqual(JSON.parse(fs.readFileSync(settingsPath, 'utf8')), result.settings);
+      assert.strictEqual(fs.existsSync(`${settingsPath}.ecc.lock`), false);
+    } finally {
+      fs.lstatSync = originalLstat;
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('atomic settings updates still reject a path stat on a different device', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-settings-other-dev-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    const originalLstat = fs.lstatSync;
+    try {
+      fs.writeFileSync(settingsPath, '{"theme":"initial"}\n');
+      fs.lstatSync = function(target, options) {
+        const stats = originalLstat.call(fs, target, options);
+        if (path.resolve(String(target)) === settingsPath) {
+          stats.dev = options && options.bigint ? stats.dev + 1n : stats.dev + 1;
+        }
+        return stats;
+      };
+      assert.throws(
+        () => updateSettingsAtomic(
+          settingsPath,
+          settings => ({ settings: { ...settings, managed: true } })
+        ),
+        error => error.code === 'ECC_SETTINGS_CHANGED'
+      );
+      assert.deepStrictEqual(JSON.parse(fs.readFileSync(settingsPath, 'utf8')), { theme: 'initial' });
+    } finally {
+      fs.lstatSync = originalLstat;
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
   if (test('fresh merge appends managed entries while preserving unrelated settings and hooks', () => {
     const userEntry = { matcher: 'Bash', hooks: [{ type: 'command', command: 'user-hook' }] };
     const settings = {


### PR DESCRIPTION
## What Changed
- `scripts/lib/install/claude-settings.js`: `readSettingsSnapshot()` compares the descriptor `dev` against the path `dev` through a new `sameDeviceId()` helper that treats a missing (`0`/`0n`) device id on either side as "no evidence" instead of "changed file".
- `scripts/lib/install/claude-settings-lock.js`: `sameFileIdentity()` applies the same rule, so lock release and stale-lock inspection stop rejecting the lock the process created itself.
- `tests/lib/claude-settings.test.js`: two new cases. One stubs `fs.lstatSync` to report `dev = 0` (Number and BigInt) and asserts an atomic update succeeds and releases its lock; it fails on `main` with `Refusing to read changed Claude settings` and, after the first guard alone is fixed, with `Refusing to release a changed Claude settings lock`, matching the sequence in #3041. The other stubs a *different* non-zero `dev` and asserts the update is still rejected with `ECC_SETTINGS_CHANGED`.
- `CHANGELOG.md`: Unreleased / Fixed entry, following the format of #2637.

Fixes #3041

## Why This Change
On Windows, Node 22.12-22.16 and 24.0-24.1 (libuv 1.49.0-1.50.x) resolve path-based `lstat()` through `GetFileInformationByName` and leave `dev` as `0`, while `fstat()` on the open descriptor reports the real volume serial. The two settings guards required `descriptorStat.dev === pathStat.dev`, so every managed settings write failed closed and each failure left a stale `settings.json.ecc.lock` behind. This is the same defect class #2637 fixed in the memory vault guard, and the fix uses the same rule: compare `dev` only when both stats report one. The inode, regular-file, and `isSymbolicLink()` checks are unchanged, so the guards still fail closed on an actual swap. POSIX always reports `dev`, so behaviour on Linux/macOS is identical to before.

The fix is platform-agnostic rather than gated on `process.platform === 'win32'`, matching the memory vault helper, so a runtime that omits `dev` elsewhere would not reintroduce the lockout.

## Testing Done
- [x] Manual testing completed — reproduced the issue's failure sequence deterministically by stubbing `fs.lstatSync` to zero `dev` (see the new test), on macOS with Node 20.20.2. I do not have a Windows machine; the reporter confirmed on Windows 11 / Node 22.14.0 that `tests/lib/claude-settings.test.js` fails 6/36 on `5064474d` and passes 36/36 with this exact `sameDeviceId` rule applied.
- [x] Automated tests pass locally (`node tests/run-all.js`) — see the gauntlet result below.
- [x] Edge cases considered and tested — differing non-zero `dev` still rejected; BigInt stats in the lock module (`0n` is falsy, so the same rule covers both).

Targeted runs, all green: `tests/lib/claude-settings.test.js` (38/38), `tests/lib/claude-settings-array.test.js` (7/7), `tests/scripts/install-apply.test.js` (42/42), `tests/lib/install-lifecycle.test.js` (66/66), `tests/lib/install-executor.test.js` (20/20), `tests/lib/hook-consent.test.js` (8/8), `tests/lib/install-state.test.js` (6/6). `eslint` and `markdownlint` clean on touched files.

`node tests/run-all.js`: 4360 tests, 4353 passed, 7 failed. The 7 failures are in `tests/hooks/detect-project-worktree.test.js` (5) and `tests/hooks/observe-subdirectory-detection.test.js` (2) and fail identically on unmodified `main` in my environment: my login shell profile prints an SSH-agent banner into bash stdout, which those tests compare byte-for-byte. They do not touch the settings guards.

## Type of Change
- [x] `fix:` Bug fix

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly (none touched)
- [x] Shell scripts pass shellcheck (not applicable)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## If you changed dependencies or `package.json` (`bin` / `files` / deps)
Not applicable.

## If you added a skill, command, agent, hook, or CLI tool
Not applicable.

## Documentation
- [x] Updated relevant documentation (CHANGELOG)
- [x] Added comments for complex logic
- [ ] README updated (not needed)

---
Prepared with AI assistance (Claude Code); reviewed and tested locally by @apetcu.
