### PR TITLE
fix(install): handle missing Windows settings device IDs safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Claude settings updates now tolerate a missing Windows device ID while retaining full-precision inode checks and strict matching when both device IDs are available.
+
 ## 2.2.0 - 2026-08-25
 
 ### Added

--- a/scripts/lib/install/claude-settings-lock.js
+++ b/scripts/lib/install/claude-settings-lock.js
@@ -7,7 +7,16 @@ const path = require('path');
 const INVALID_LOCK_STALE_MS = 5 * 60 * 1000;
 
 function sameFileIdentity(left, right) {
-  return left.dev === right.dev && left.ino === right.ino;
+  if (left.ino !== right.ino) {
+    return false;
+  }
+  // Node's path-based stats can omit the Windows volume serial (`dev = 0`)
+  // while fstat() on the same file handle reports it. Preserve strict device
+  // checks everywhere else, including when both Windows stats report a device.
+  if (process.platform === 'win32' && (!left.dev || !right.dev)) {
+    return true;
+  }
+  return left.dev === right.dev;
 }
 
 function createSettingsLock(lockPath) {
@@ -167,4 +176,5 @@ function runWithSettingsLock(settingsPath, callback) {
 module.exports = {
   acquireSettingsLock,
   runWithSettingsLock,
+  sameFileIdentity,
 };

--- a/scripts/lib/install/claude-settings.js
+++ b/scripts/lib/install/claude-settings.js
@@ -4,7 +4,11 @@ const fs = require('fs');
 const path = require('path');
 const { isDeepStrictEqual } = require('util');
 const { writeFileAtomic } = require('../atomic-write');
-const { acquireSettingsLock, runWithSettingsLock } = require('./claude-settings-lock');
+const {
+  acquireSettingsLock,
+  runWithSettingsLock,
+  sameFileIdentity,
+} = require('./claude-settings-lock');
 
 const CLAUDE_SETTINGS_FILENAME = 'settings.json';
 const CLAUDE_HOOKS_CONFIG_PATH = 'hooks/hooks.json';
@@ -340,10 +344,10 @@ function readSettingsSnapshot(settingsPath) {
   }
 
   try {
-    const descriptorStat = fs.fstatSync(descriptor);
+    const descriptorStat = fs.fstatSync(descriptor, { bigint: true });
     let pathStat;
     try {
-      pathStat = fs.lstatSync(settingsPath);
+      pathStat = fs.lstatSync(settingsPath, { bigint: true });
     } catch (error) {
       if (error && error.code === 'ENOENT') {
         error.code = 'ECC_SETTINGS_CHANGED';
@@ -354,8 +358,7 @@ function readSettingsSnapshot(settingsPath) {
       !descriptorStat.isFile()
       || !pathStat.isFile()
       || pathStat.isSymbolicLink()
-      || descriptorStat.dev !== pathStat.dev
-      || descriptorStat.ino !== pathStat.ino
+      || !sameFileIdentity(descriptorStat, pathStat)
     ) {
       const error = new Error(`Refusing to read changed Claude settings at ${settingsPath}`);
       error.code = 'ECC_SETTINGS_CHANGED';
@@ -366,7 +369,7 @@ function readSettingsSnapshot(settingsPath) {
       exists: true,
       raw,
       settings: parseSettings(raw, `Claude settings at ${settingsPath}`),
-      mode: descriptorStat.mode & 0o777,
+      mode: Number(descriptorStat.mode & 0o777n),
       dev: descriptorStat.dev,
       ino: descriptorStat.ino,
     };

--- a/tests/lib/claude-settings.test.js
+++ b/tests/lib/claude-settings.test.js
@@ -22,6 +22,7 @@ const {
   updateSettingsAtomic,
   validateManagedHooks,
 } = require('../../scripts/lib/install/claude-settings');
+const { sameFileIdentity } = require('../../scripts/lib/install/claude-settings-lock');
 
 function test(name, fn) {
   try {
@@ -277,6 +278,80 @@ function runTests() {
       }),
       error => error === denied
     );
+  })) passed++; else failed++;
+
+  if (test('compares file identities strictly except for missing Windows device ids', () => {
+    const originalPlatform = process.platform;
+    try {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      assert.strictEqual(
+        sameFileIdentity({ dev: 0, ino: 42 }, { dev: 2162558900, ino: 42 }),
+        true
+      );
+      assert.strictEqual(
+        sameFileIdentity(
+          { dev: 0n, ino: 19421773395341796n },
+          { dev: 2162558900n, ino: 19421773395341796n }
+        ),
+        true
+      );
+      assert.strictEqual(
+        sameFileIdentity(
+          { dev: 1n, ino: 9007199254740992n },
+          { dev: 1n, ino: 9007199254740993n }
+        ),
+        false
+      );
+      assert.strictEqual(
+        sameFileIdentity({ dev: 1n, ino: 42n }, { dev: 2n, ino: 42n }),
+        false
+      );
+
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      assert.strictEqual(
+        sameFileIdentity({ dev: 0n, ino: 42n }, { dev: 2n, ino: 42n }),
+        false
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
+  })) passed++; else failed++;
+
+  if (test('atomic settings updates accept Windows path stats with an omitted device id', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-settings-win-dev-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    const originalLstatSync = fs.lstatSync;
+    const originalPlatform = process.platform;
+    try {
+      fs.writeFileSync(settingsPath, '{"theme":"dark"}\n');
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      fs.lstatSync = function(...args) {
+        const stats = originalLstatSync.apply(fs, args);
+        stats.dev = typeof stats.dev === 'bigint' ? 0n : 0;
+        return stats;
+      };
+
+      updateSettingsAtomic(
+        settingsPath,
+        settings => ({ settings: { ...settings, managed: true } })
+      );
+
+      assert.deepStrictEqual(JSON.parse(fs.readFileSync(settingsPath, 'utf8')), {
+        theme: 'dark',
+        managed: true,
+      });
+      assert.ok(!fs.existsSync(`${settingsPath}.ecc.lock`));
+    } finally {
+      fs.lstatSync = originalLstatSync;
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+      });
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   })) passed++; else failed++;
 
   if (test('atomic settings updates retry after a concurrent change and preserve secure mode', () => {

--- a/tests/lib/claude-settings.test.js
+++ b/tests/lib/claude-settings.test.js
@@ -49,6 +49,16 @@ function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
+function deriveStats(stats, overrides) {
+  return Object.create(stats, Object.fromEntries(
+    Object.entries(overrides).map(([name, value]) => [name, {
+      configurable: true,
+      enumerable: true,
+      value,
+    }])
+  ));
+}
+
 function assertAtomicParentReplacementRejected(stage) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-settings-parent-race-'));
   const targetRoot = path.join(tempDir, 'target');
@@ -330,8 +340,7 @@ function runTests() {
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
       fs.lstatSync = function(...args) {
         const stats = originalLstatSync.apply(fs, args);
-        stats.dev = typeof stats.dev === 'bigint' ? 0n : 0;
-        return stats;
+        return deriveStats(stats, { dev: typeof stats.dev === 'bigint' ? 0n : 0 });
       };
 
       updateSettingsAtomic(
@@ -350,6 +359,96 @@ function runTests() {
         value: originalPlatform,
         configurable: true,
       });
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('atomic settings updates reject unequal nonzero Windows device ids', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-settings-win-dev-mismatch-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    const originalLstatSync = fs.lstatSync;
+    const originalPlatform = process.platform;
+    const initial = '{"theme":"initial"}\n';
+    try {
+      fs.writeFileSync(settingsPath, initial);
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      fs.lstatSync = function(targetPath, ...args) {
+        const stats = originalLstatSync.call(fs, targetPath, ...args);
+        if (targetPath !== settingsPath) return stats;
+        const mismatchedDev = typeof stats.dev === 'bigint' ? stats.dev + 1n : stats.dev + 1;
+        return deriveStats(stats, { dev: mismatchedDev });
+      };
+
+      assert.throws(
+        () => updateSettingsAtomic(
+          settingsPath,
+          settings => ({ settings: { ...settings, managed: true } })
+        ),
+        error => error.code === 'ECC_SETTINGS_CHANGED'
+      );
+      assert.strictEqual(fs.readFileSync(settingsPath, 'utf8'), initial);
+      assert.ok(!fs.existsSync(`${settingsPath}.ecc.lock`));
+    } finally {
+      fs.lstatSync = originalLstatSync;
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+      });
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('settings snapshots request BigInt stats and reject inodes that collide as Numbers', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-settings-bigint-identity-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    const originalOpenSync = fs.openSync;
+    const originalFstatSync = fs.fstatSync;
+    const originalLstatSync = fs.lstatSync;
+    let settingsDescriptor;
+    let sawBigIntFstat = false;
+    let sawBigIntLstat = false;
+    const descriptorIno = 9007199254740992n;
+    const pathIno = 9007199254740993n;
+    try {
+      fs.writeFileSync(settingsPath, '{"theme":"initial"}\n');
+      fs.openSync = function(targetPath, ...args) {
+        const descriptor = originalOpenSync.call(fs, targetPath, ...args);
+        if (targetPath === settingsPath) settingsDescriptor = descriptor;
+        return descriptor;
+      };
+      fs.fstatSync = function(descriptor, options) {
+        const stats = originalFstatSync.call(fs, descriptor, options);
+        if (descriptor !== settingsDescriptor) return stats;
+        sawBigIntFstat = options && options.bigint === true;
+        return deriveStats(stats, {
+          ino: typeof stats.ino === 'bigint' ? descriptorIno : Number(descriptorIno),
+        });
+      };
+      fs.lstatSync = function(targetPath, options) {
+        const stats = originalLstatSync.call(fs, targetPath, options);
+        if (targetPath !== settingsPath) return stats;
+        sawBigIntLstat = options && options.bigint === true;
+        return deriveStats(stats, {
+          ino: typeof stats.ino === 'bigint' ? pathIno : Number(pathIno),
+        });
+      };
+
+      assert.throws(
+        () => updateSettingsAtomic(
+          settingsPath,
+          settings => ({ settings: { ...settings, managed: true } })
+        ),
+        error => error.code === 'ECC_SETTINGS_CHANGED'
+      );
+      assert.strictEqual(sawBigIntFstat, true);
+      assert.strictEqual(sawBigIntLstat, true);
+      assert.deepStrictEqual(JSON.parse(fs.readFileSync(settingsPath, 'utf8')), {
+        theme: 'initial',
+      });
+    } finally {
+      fs.openSync = originalOpenSync;
+      fs.fstatSync = originalFstatSync;
+      fs.lstatSync = originalLstatSync;
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   })) passed++; else failed++;
@@ -500,6 +599,77 @@ function runTests() {
       assert.ok(caught.releaseError);
       assert.strictEqual(caught.releaseError.code, 'ENOENT');
     } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('settings lock release preserves a lock with an unequal nonzero Windows device id', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-settings-release-dev-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    const lockPath = `${settingsPath}.ecc.lock`;
+    const originalLstatSync = fs.lstatSync;
+    const originalPlatform = process.platform;
+    let lockContents;
+    try {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      fs.lstatSync = function(targetPath, ...args) {
+        const stats = originalLstatSync.call(fs, targetPath, ...args);
+        if (!String(targetPath).includes('.ecc.lock.release-')) return stats;
+        const mismatchedDev = typeof stats.dev === 'bigint' ? stats.dev + 1n : stats.dev + 1;
+        return deriveStats(stats, { dev: mismatchedDev });
+      };
+
+      assert.throws(
+        () => runWithSettingsLock(settingsPath, () => {
+          lockContents = fs.readFileSync(lockPath, 'utf8');
+        }),
+        /Refusing to release a changed Claude settings lock/
+      );
+      assert.strictEqual(fs.readFileSync(lockPath, 'utf8'), lockContents);
+    } finally {
+      fs.lstatSync = originalLstatSync;
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+      });
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
+  if (test('stale lock recovery preserves a lock with an unequal nonzero Windows device id', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-settings-stale-dev-'));
+    const settingsPath = path.join(tempDir, 'settings.json');
+    const lockPath = `${settingsPath}.ecc.lock`;
+    const originalLstatSync = fs.lstatSync;
+    const originalPlatform = process.platform;
+    const lockContents = 'foreign stale lock\n';
+    try {
+      fs.writeFileSync(lockPath, lockContents, { mode: 0o600 });
+      const stale = new Date(Date.now() - (10 * 60 * 1000));
+      fs.utimesSync(lockPath, stale, stale);
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      fs.lstatSync = function(targetPath, ...args) {
+        const stats = originalLstatSync.call(fs, targetPath, ...args);
+        if (!stats || !String(targetPath).includes('.ecc.lock.stale-')) return stats;
+        const mismatchedDev = typeof stats.dev === 'bigint' ? stats.dev + 1n : stats.dev + 1;
+        return deriveStats(stats, { dev: mismatchedDev });
+      };
+
+      assert.throws(
+        () => updateSettingsAtomic(
+          settingsPath,
+          settings => ({ settings: { ...settings, recovered: true } })
+        ),
+        /Another ECC process is updating Claude settings/
+      );
+      assert.strictEqual(fs.readFileSync(lockPath, 'utf8'), lockContents);
+      assert.ok(!fs.existsSync(`${lockPath}.recover`));
+    } finally {
+      fs.lstatSync = originalLstatSync;
+      Object.defineProperty(process, 'platform', {
+        value: originalPlatform,
+        configurable: true,
+      });
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   })) passed++; else failed++;


### PR DESCRIPTION
## What Changed

- Share an inode-first identity check between Claude settings snapshots and lock ownership checks.
- Allow a zero/missing device ID only on Windows, while continuing to reject changed inodes and unequal nonzero device IDs.
- Request BigInt snapshot stats so inode comparisons retain their full precision.
- Add regressions for settings updates, lock release, and stale-lock recovery, and document the fix in the changelog.

## Why This Change

On affected Windows filesystems, path-based stats can report `dev = 0` while descriptor stats for the same file report a device ID. Strictly comparing those values rejects safe settings updates. The Windows-only fallback accepts that metadata shape without weakening inode checks or nonzero device comparisons.

This was compared with related PR #3043 before submission. This version retains BigInt snapshot identities and the Windows-only fallback, and incorporates #3043's useful nonzero-device settings regression plus the lock and immutable-mock coverage raised during its review.

Fixes affaan-m/ECC#3041

Related: #3043

## Testing Done

- [x] `node tests/lib/claude-settings.test.js` (42 passed)
- [x] `npm test` (4,401 passed)
- [x] `npx eslint scripts/lib/install/claude-settings.js scripts/lib/install/claude-settings-lock.js tests/lib/claude-settings.test.js`
- [x] `npx markdownlint CHANGELOG.md`
- [x] `git diff --check 5064474d..HEAD`

The Windows metadata shapes are simulated in the focused tests; no native Windows device test was performed.

## Type of Change

- [x] `fix:` Bug fix

## Security & Quality Checklist

- [x] No secrets or API keys committed
- [x] Follows conventional commits format
