### PR TITLE
fix(gateguard): match destructive SQL passed to a database client in a quoted argument

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -366,7 +366,12 @@ const SHELL_WRAPPERS = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh']);
 // client. `valueOptions` consume the next token; `positionals` are leading
 // operands of the prefix itself (`timeout DURATION`, `chroot NEWROOT`).
 const EXECUTION_PREFIXES = {
-  env: { assignments: true, valueOptions: ['-u', '--unset', '-C', '--chdir', '-S', '--split-string'] },
+  env: {
+    assignments: true,
+    valueOptions: ['-u', '--unset', '-C', '--chdir'],
+    // `env -S '<string>'` splits the string into a command line and runs it.
+    commandStringOptions: ['-S', '--split-string'],
+  },
   sudo: {
     valueOptions: [
       '-u', '--user', '-g', '--group', '-C', '--close-from', '-D', '--chdir', '-h', '--host',
@@ -378,7 +383,7 @@ const EXECUTION_PREFIXES = {
   exec: { valueOptions: ['-a'] },
   nice: { valueOptions: ['-n', '--adjustment'] },
   nohup: {},
-  time: {},
+  time: { valueOptions: ['-f', '--format', '-o', '--output'] },
   timeout: { valueOptions: ['-s', '--signal', '-k', '--kill-after'], positionals: 1 },
   stdbuf: { valueOptions: ['-i', '-o', '-e', '--input', '--output', '--error'] },
   ionice: { valueOptions: ['-c', '--class', '-n', '--classdata', '-p', '--pid'] },
@@ -392,17 +397,22 @@ const EXECUTION_PREFIXES = {
 
 /**
  * Drop leading execution prefixes (`env`, `sudo`, `nice`, ...) with their
- * options so the real command sits at index 0.
+ * options so the real command sits at index 0. Every recognised prefix is
+ * removed, however many are stacked; each round drops at least one token,
+ * so the loop terminates. Option payloads that are themselves command lines
+ * (`env -S '<string>'`) are returned separately for a recursive scan.
  *
  * @param {string[]} tokens
- * @returns {string[]}
+ * @returns {{ command: string[], commandStrings: string[] }}
  */
 function stripExecutionPrefixes(tokens) {
   let rest = tokens;
-  for (let guard = 0; guard < 8 && rest.length > 0; guard++) {
+  const commandStrings = [];
+  while (rest.length > 0) {
     const spec = EXECUTION_PREFIXES[commandBasename(rest[0])];
     if (!spec) break;
     const valueOptions = new Set(spec.valueOptions || []);
+    const commandStringOptions = spec.commandStringOptions || [];
     let i = 1;
     let consumedValueOption = false;
     while (i < rest.length) {
@@ -416,7 +426,16 @@ function stripExecutionPrefixes(tokens) {
         continue;
       }
       if (token.startsWith('-') && token.length > 1) {
-        if (valueOptions.has(token)) {
+        const inline = commandStringOptions.find(
+          opt => token.startsWith(opt) && token.length > opt.length && (opt.length === 2 || token.charAt(opt.length) === '=')
+        );
+        if (inline) {
+          commandStrings.push(token.slice(inline.length + (opt => (opt.length === 2 ? 0 : 1))(inline)));
+          i++;
+        } else if (commandStringOptions.includes(token)) {
+          if (rest[i + 1] !== undefined) commandStrings.push(rest[i + 1]);
+          i += 2;
+        } else if (valueOptions.has(token)) {
           i += 2;
           consumedValueOption = true;
         } else {
@@ -430,7 +449,7 @@ function stripExecutionPrefixes(tokens) {
     if (spec.positionalUnlessValueOption && consumedValueOption) positionals = 0;
     rest = rest.slice(i + positionals);
   }
-  return rest;
+  return { command: rest, commandStrings };
 }
 
 // A short-option cluster of a shell that includes `c` (`-c`, `-lc`, `-ec`,
@@ -509,7 +528,11 @@ function isDestructiveQuoteAware(raw, depth = 0) {
     if (isDestructiveRm(tokens)) return true;
     if (isDestructiveGit(tokens)) return true;
     if (isDestructiveFindExec(tokens.join(' '))) return true;
-    const command = stripExecutionPrefixes(tokens);
+    const { command, commandStrings } = stripExecutionPrefixes(tokens);
+    // `env -S '<string>'` executes the string as a command line of its own.
+    for (const commandString of commandStrings) {
+      if (isDestructiveQuoteAware(commandString, depth + 1)) return true;
+    }
     if (command.length === 0) continue;
     const base = commandBasename(command[0]);
     // SQL passed to a database client lives inside a quoted argument, which

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -390,7 +390,11 @@ const EXECUTION_PREFIXES = {
   setsid: {},
   unshare: {},
   busybox: {},
-  runuser: { valueOptions: ['-u', '--user', '-g', '--group', '-G', '--supp-group'] },
+  runuser: {
+    valueOptions: ['-u', '--user', '-g', '--group', '-G', '--supp-group'],
+    // `runuser -c '<string>'` hands the string to a shell.
+    commandStringOptions: ['-c', '--command', '--session-command'],
+  },
   chroot: { positionals: 1 },
   taskset: { valueOptions: ['-c', '--cpu-list'], positionals: 1, positionalUnlessValueOption: true },
 };
@@ -407,7 +411,7 @@ const EXECUTION_PREFIXES = {
  */
 function stripExecutionPrefixes(tokens) {
   let rest = tokens;
-  const commandStrings = [];
+  let commandStrings = [];
   while (rest.length > 0) {
     const spec = EXECUTION_PREFIXES[commandBasename(rest[0])];
     if (!spec) break;
@@ -430,10 +434,11 @@ function stripExecutionPrefixes(tokens) {
           opt => token.startsWith(opt) && token.length > opt.length && (opt.length === 2 || token.charAt(opt.length) === '=')
         );
         if (inline) {
-          commandStrings.push(token.slice(inline.length + (opt => (opt.length === 2 ? 0 : 1))(inline)));
+          const payload = token.slice(inline.length + (inline.length === 2 ? 0 : 1));
+          commandStrings = [...commandStrings, payload];
           i++;
         } else if (commandStringOptions.includes(token)) {
-          if (rest[i + 1] !== undefined) commandStrings.push(rest[i + 1]);
+          if (rest[i + 1] !== undefined) commandStrings = [...commandStrings, rest[i + 1]];
           i += 2;
         } else if (valueOptions.has(token)) {
           i += 2;

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -359,6 +359,112 @@ function quoteAwareSegments(input) {
 
 const SHELL_WRAPPERS = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh']);
 
+// Programs that only run the command following them. They are stripped
+// (together with their own options and `NAME=value` assignments) before
+// argv0 is classified, so `env PGHOST=db psql -c "..."`, `sudo -u postgres
+// psql -c "..."` and `timeout 30 mysql -e "..."` are treated like the bare
+// client. `valueOptions` consume the next token; `positionals` are leading
+// operands of the prefix itself (`timeout DURATION`, `chroot NEWROOT`).
+const EXECUTION_PREFIXES = {
+  env: { assignments: true, valueOptions: ['-u', '--unset', '-C', '--chdir', '-S', '--split-string'] },
+  sudo: {
+    valueOptions: [
+      '-u', '--user', '-g', '--group', '-C', '--close-from', '-D', '--chdir', '-h', '--host',
+      '-p', '--prompt', '-r', '--role', '-t', '--type', '-T', '--command-timeout', '-U', '--other-user',
+    ],
+  },
+  doas: { valueOptions: ['-u', '-C'] },
+  command: {},
+  exec: { valueOptions: ['-a'] },
+  nice: { valueOptions: ['-n', '--adjustment'] },
+  nohup: {},
+  time: {},
+  timeout: { valueOptions: ['-s', '--signal', '-k', '--kill-after'], positionals: 1 },
+  stdbuf: { valueOptions: ['-i', '-o', '-e', '--input', '--output', '--error'] },
+  ionice: { valueOptions: ['-c', '--class', '-n', '--classdata', '-p', '--pid'] },
+  setsid: {},
+  unshare: {},
+  busybox: {},
+  runuser: { valueOptions: ['-u', '--user', '-g', '--group', '-G', '--supp-group'] },
+  chroot: { positionals: 1 },
+  taskset: { valueOptions: ['-c', '--cpu-list'], positionals: 1, positionalUnlessValueOption: true },
+};
+
+/**
+ * Drop leading execution prefixes (`env`, `sudo`, `nice`, ...) with their
+ * options so the real command sits at index 0.
+ *
+ * @param {string[]} tokens
+ * @returns {string[]}
+ */
+function stripExecutionPrefixes(tokens) {
+  let rest = tokens;
+  for (let guard = 0; guard < 8 && rest.length > 0; guard++) {
+    const spec = EXECUTION_PREFIXES[commandBasename(rest[0])];
+    if (!spec) break;
+    const valueOptions = new Set(spec.valueOptions || []);
+    let i = 1;
+    let consumedValueOption = false;
+    while (i < rest.length) {
+      const token = rest[i];
+      if (token === '--') {
+        i++;
+        break;
+      }
+      if (spec.assignments && /^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) {
+        i++;
+        continue;
+      }
+      if (token.startsWith('-') && token.length > 1) {
+        if (valueOptions.has(token)) {
+          i += 2;
+          consumedValueOption = true;
+        } else {
+          i++;
+        }
+        continue;
+      }
+      break;
+    }
+    let positionals = spec.positionals || 0;
+    if (spec.positionalUnlessValueOption && consumedValueOption) positionals = 0;
+    rest = rest.slice(i + positionals);
+  }
+  return rest;
+}
+
+// A short-option cluster of a shell that includes `c` (`-c`, `-lc`, `-ec`,
+// `-xc`): the next token is the command string the shell executes.
+const SHELL_COMMAND_OPTION = /^-[A-Za-z]*c[A-Za-z]*$/;
+
+// A bare word that carries a path separator or ends in a file extension is
+// a filename (`truncate.db`, `psql -f truncate.sql`, `--file=x.sql`), not a
+// SQL phrase. `if=...` is kept so `dd if=disk.img` still matches the dd
+// pattern. Used on single arguments and on flattened command text.
+const FILE_LIKE_ARGUMENT = /^(?!if=)\S*(?:[\\/]\S*|\.[A-Za-z0-9]{1,8})$/;
+const FILE_LIKE_TOKEN = /(^|\s)(?!if=)\S*(?:[\\/]\S*|\.[A-Za-z0-9]{1,8})(?=\s|$)/g;
+
+/**
+ * Argument text of a SQL client invocation with filename-like tokens removed.
+ *
+ * @param {string[]} args
+ * @returns {string}
+ */
+function sqlArgumentText(args) {
+  return args.filter(arg => !FILE_LIKE_ARGUMENT.test(arg)).join(' ');
+}
+
+/**
+ * Flattened command text with filename-like words removed, for the SQL/dd
+ * phrase regex.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function stripFileLikeTokens(text) {
+  return text.replace(FILE_LIKE_TOKEN, '$1');
+}
+
 // Interactive database clients that take a SQL statement as an argument
 // (`psql -c "..."`, `mysql -e "..."`, `sqlite3 db.sqlite "..."`). A real
 // SQL invocation is always quoted, so the generic quote-stripped scan can
@@ -403,19 +509,21 @@ function isDestructiveQuoteAware(raw, depth = 0) {
     if (isDestructiveRm(tokens)) return true;
     if (isDestructiveGit(tokens)) return true;
     if (isDestructiveFindExec(tokens.join(' '))) return true;
-    const base = commandBasename(tokens[0]);
+    const command = stripExecutionPrefixes(tokens);
+    if (command.length === 0) continue;
+    const base = commandBasename(command[0]);
     // SQL passed to a database client lives inside a quoted argument, which
     // the generic scan strips on purpose (a commit message that mentions
     // "drop table" must not trip the gate). The tokens here carry the
     // unquoted argument text, so test the SQL phrases on them when the
     // executable is a known SQL client — `git commit -m "drop table ..."`
     // still has no SQL client in argv0.
-    if (SQL_CLIENTS.has(base) && DESTRUCTIVE_SQL_DD.test(tokens.slice(1).join(' '))) {
+    if (SQL_CLIENTS.has(base) && DESTRUCTIVE_SQL_DD.test(sqlArgumentText(command.slice(1)))) {
       return true;
     }
     if (SHELL_WRAPPERS.has(base)) {
-      const ci = tokens.indexOf('-c');
-      if (ci !== -1 && tokens[ci + 1] && isDestructiveQuoteAware(tokens[ci + 1], depth + 1)) {
+      const ci = command.findIndex((token, index) => index > 0 && SHELL_COMMAND_OPTION.test(token));
+      if (ci !== -1 && command[ci + 1] && isDestructiveQuoteAware(command[ci + 1], depth + 1)) {
         return true;
       }
     }
@@ -737,7 +845,7 @@ function isDestructiveBash(command) {
   const raw = String(command || '');
   const executable = stripHeredocBodies(raw);
   const flattened = explodeSubshells(stripQuotedStrings(executable));
-  if (DESTRUCTIVE_SQL_DD.test(flattened)) return true;
+  if (DESTRUCTIVE_SQL_DD.test(stripFileLikeTokens(flattened))) return true;
 
   // Operator-supplied additional destructive patterns. Same scope as the
   // built-in SQL/dd regex: matched against the quote-stripped, subshell-
@@ -764,7 +872,7 @@ function isDestructiveBash(command) {
   const segments = bodies.flatMap(splitCommandSegments);
   for (const segment of segments) {
     const stripped = stripQuotedStrings(segment);
-    if (DESTRUCTIVE_SQL_DD.test(stripped)) return true;
+    if (DESTRUCTIVE_SQL_DD.test(stripFileLikeTokens(stripped))) return true;
     if (extra && extra.test(stripped)) return true;
     const tokens = tokenize(segment);
     if (isDestructiveRm(tokens)) return true;

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -391,7 +391,7 @@ const EXECUTION_PREFIXES = {
   unshare: {},
   busybox: {},
   runuser: {
-    valueOptions: ['-u', '--user', '-g', '--group', '-G', '--supp-group'],
+    valueOptions: ['-u', '--user', '-g', '--group', '-G', '--supp-group', '-s', '--shell'],
     // `runuser -c '<string>'` hands the string to a shell.
     commandStringOptions: ['-c', '--command', '--session-command'],
   },

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -359,6 +359,34 @@ function quoteAwareSegments(input) {
 
 const SHELL_WRAPPERS = new Set(['sh', 'bash', 'zsh', 'dash', 'ksh']);
 
+// Interactive database clients that take a SQL statement as an argument
+// (`psql -c "..."`, `mysql -e "..."`, `sqlite3 db.sqlite "..."`). A real
+// SQL invocation is always quoted, so the generic quote-stripped scan can
+// never see it; for these executables the destructive-SQL phrases are
+// matched against the (unquoted) argument text instead.
+const SQL_CLIENTS = new Set([
+  'psql',
+  'pgcli',
+  'mysql',
+  'mariadb',
+  'mycli',
+  'sqlite3',
+  'sqlite',
+  'litecli',
+  'duckdb',
+  'usql',
+  'sqlcmd',
+  'clickhouse-client',
+  'clickhouse',
+  'cockroach',
+  'mongosh',
+  'mongo',
+  'cqlsh',
+  'trino',
+  'presto',
+  'beeline',
+]);
+
 /**
  * Quote-aware destructive check: catches quoted command words, newline
  * separators, quoted `find -exec`, and `sh -c`/`bash -c` wrappers that evade
@@ -376,6 +404,15 @@ function isDestructiveQuoteAware(raw, depth = 0) {
     if (isDestructiveGit(tokens)) return true;
     if (isDestructiveFindExec(tokens.join(' '))) return true;
     const base = commandBasename(tokens[0]);
+    // SQL passed to a database client lives inside a quoted argument, which
+    // the generic scan strips on purpose (a commit message that mentions
+    // "drop table" must not trip the gate). The tokens here carry the
+    // unquoted argument text, so test the SQL phrases on them when the
+    // executable is a known SQL client — `git commit -m "drop table ..."`
+    // still has no SQL client in argv0.
+    if (SQL_CLIENTS.has(base) && DESTRUCTIVE_SQL_DD.test(tokens.slice(1).join(' '))) {
+      return true;
+    }
     if (SHELL_WRAPPERS.has(base)) {
       const ci = tokens.indexOf('-c');
       if (ci !== -1 && tokens[ci + 1] && isDestructiveQuoteAware(tokens[ci + 1], depth + 1)) {

--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -395,7 +395,7 @@ const EXECUTION_PREFIXES = {
     // `runuser -c '<string>'` hands the string to a shell.
     commandStringOptions: ['-c', '--command', '--session-command'],
   },
-  chroot: { positionals: 1 },
+  chroot: { valueOptions: ['--userspec', '--groups'], positionals: 1 },
   taskset: { valueOptions: ['-c', '--cpu-list'], positionals: 1, positionalUnlessValueOption: true },
 };
 
@@ -412,6 +412,10 @@ const EXECUTION_PREFIXES = {
 function stripExecutionPrefixes(tokens) {
   let rest = tokens;
   let commandStrings = [];
+  // Set once a wrapper option this table does not model is skipped: it may
+  // or may not have consumed a value, so where the command starts is no
+  // longer certain and the caller scans every later token (fail closed).
+  let inconclusive = false;
   while (rest.length > 0) {
     const spec = EXECUTION_PREFIXES[commandBasename(rest[0])];
     if (!spec) break;
@@ -444,6 +448,8 @@ function stripExecutionPrefixes(tokens) {
           i += 2;
           consumedValueOption = true;
         } else {
+          // `--opt=value` carries its value; a bare unknown option may not.
+          if (!(token.startsWith('--') && token.includes('='))) inconclusive = true;
           i++;
         }
         continue;
@@ -454,7 +460,7 @@ function stripExecutionPrefixes(tokens) {
     if (spec.positionalUnlessValueOption && consumedValueOption) positionals = 0;
     rest = rest.slice(i + positionals);
   }
-  return { command: rest, commandStrings };
+  return { command: rest, commandStrings, inconclusive };
 }
 
 // A short-option cluster of a shell that includes `c` (`-c`, `-lc`, `-ec`,
@@ -465,6 +471,8 @@ const SHELL_COMMAND_OPTION = /^-[A-Za-z]*c[A-Za-z]*$/;
 // a filename (`truncate.db`, `psql -f truncate.sql`, `--file=x.sql`), not a
 // SQL phrase. `if=...` is kept so `dd if=disk.img` still matches the dd
 // pattern. Used on single arguments and on flattened command text.
+// Options of the SQL clients whose next argument is a script file, not SQL.
+const SQL_FILE_OPTIONS = new Set(['-f', '--file']);
 const FILE_LIKE_ARGUMENT = /^(?!if=)\S*(?:[\\/]\S*|\.[A-Za-z0-9]{1,8})$/;
 const FILE_LIKE_TOKEN = /(^|\s)(?!if=)\S*(?:[\\/]\S*|\.[A-Za-z0-9]{1,8})(?=\s|$)/g;
 
@@ -475,7 +483,20 @@ const FILE_LIKE_TOKEN = /(^|\s)(?!if=)\S*(?:[\\/]\S*|\.[A-Za-z0-9]{1,8})(?=\s|$)
  * @returns {string}
  */
 function sqlArgumentText(args) {
-  return args.filter(arg => !FILE_LIKE_ARGUMENT.test(arg)).join(' ');
+  const kept = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    // A script path given to the client (`-f FILE`, `--file FILE`, `-fFILE`,
+    // `--file=FILE`) is a filename even when it contains spaces.
+    if (SQL_FILE_OPTIONS.has(arg)) {
+      i++;
+      continue;
+    }
+    if (arg.startsWith('--file=') || (arg.startsWith('-f') && arg.length > 2 && !arg.startsWith('--'))) continue;
+    if (FILE_LIKE_ARGUMENT.test(arg)) continue;
+    kept.push(arg);
+  }
+  return kept.join(' ');
 }
 
 /**
@@ -527,33 +548,51 @@ const SQL_CLIENTS = new Set([
  * @returns {boolean}
  */
 function isDestructiveQuoteAware(raw, depth = 0) {
-  if (depth > 4) return false;
+  // Past the nesting limit the payload is not inspected at all, so it is
+  // treated as destructive rather than waved through unseen (fail closed).
+  if (depth > 4) return true;
   for (const tokens of quoteAwareSegments(raw)) {
     if (tokens.length === 0) continue;
     if (isDestructiveRm(tokens)) return true;
     if (isDestructiveGit(tokens)) return true;
     if (isDestructiveFindExec(tokens.join(' '))) return true;
-    const { command, commandStrings } = stripExecutionPrefixes(tokens);
+    const { command, commandStrings, inconclusive } = stripExecutionPrefixes(tokens);
     // `env -S '<string>'` executes the string as a command line of its own.
     for (const commandString of commandStrings) {
       if (isDestructiveQuoteAware(commandString, depth + 1)) return true;
     }
     if (command.length === 0) continue;
-    const base = commandBasename(command[0]);
-    // SQL passed to a database client lives inside a quoted argument, which
-    // the generic scan strips on purpose (a commit message that mentions
-    // "drop table" must not trip the gate). The tokens here carry the
-    // unquoted argument text, so test the SQL phrases on them when the
-    // executable is a known SQL client — `git commit -m "drop table ..."`
-    // still has no SQL client in argv0.
-    if (SQL_CLIENTS.has(base) && DESTRUCTIVE_SQL_DD.test(sqlArgumentText(command.slice(1)))) {
-      return true;
+    // With an unmodelled wrapper option the command boundary is uncertain,
+    // so every later token is tried as the command start.
+    const starts = inconclusive ? command.map((_, index) => index) : [0];
+    for (const start of starts) {
+      if (isDestructiveClientCommand(command.slice(start), depth)) return true;
     }
-    if (SHELL_WRAPPERS.has(base)) {
-      const ci = command.findIndex((token, index) => index > 0 && SHELL_COMMAND_OPTION.test(token));
-      if (ci !== -1 && command[ci + 1] && isDestructiveQuoteAware(command[ci + 1], depth + 1)) {
-        return true;
-      }
+  }
+  return false;
+}
+
+/**
+ * SQL passed to a database client lives inside a quoted argument, which the
+ * generic scan strips on purpose (a commit message that mentions "drop
+ * table" must not trip the gate). The tokens here carry the unquoted
+ * argument text, so the SQL phrases are tested on them when argv0 is a known
+ * SQL client — `git commit -m "drop table ..."` still has no client in
+ * argv0. A shell wrapper hands its `-c` string to a recursive scan.
+ *
+ * @param {string[]} command tokens with execution prefixes removed
+ * @param {number} depth recursion guard, forwarded to nested scans
+ * @returns {boolean}
+ */
+function isDestructiveClientCommand(command, depth) {
+  const base = commandBasename(command[0]);
+  if (SQL_CLIENTS.has(base) && DESTRUCTIVE_SQL_DD.test(sqlArgumentText(command.slice(1)))) {
+    return true;
+  }
+  if (SHELL_WRAPPERS.has(base)) {
+    const ci = command.findIndex((token, index) => index > 0 && SHELL_COMMAND_OPTION.test(token));
+    if (ci !== -1 && command[ci + 1] && isDestructiveQuoteAware(command[ci + 1], depth + 1)) {
+      return true;
     }
   }
   return false;
@@ -1517,4 +1556,4 @@ function run(rawInput) {
   return rawInput; // allow
 }
 
-module.exports = { classifyDestructiveCommand, run };
+module.exports = { classifyDestructiveCommand, run, isDestructiveQuoteAware };

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -1521,6 +1521,39 @@ function runTests() {
   else failed++;
 
   if (
+    test('denies destructive SQL passed to a database client in a quoted argument', () => {
+      expectDestructiveDeny('psql -c "drop table users"', 'psql -c drop table');
+      expectDestructiveDeny("psql -c 'truncate audit_log'", 'psql -c truncate');
+      expectDestructiveDeny("psql --command='truncate audit_log'", 'psql --command= truncate');
+      expectDestructiveDeny('mysql -e "delete from sessions"', 'mysql -e delete from');
+      expectDestructiveDeny('sqlite3 app.db "drop table users"', 'sqlite3 positional drop table');
+      expectDestructiveDeny('/usr/local/bin/psql -h db -U app -c "DROP TABLE users"', 'psql with path and flags');
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('denies destructive SQL to a database client behind a shell wrapper or chain', () => {
+      expectDestructiveDeny('sh -c "psql -c \'drop table users\'"', 'psql inside sh -c');
+      expectDestructiveDeny('echo migrating && mysql -e "truncate sessions"', 'mysql in second segment');
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('allows non-destructive SQL and SQL phrases outside a database client', () => {
+      expectAllow('psql -c "select count(*) from users"', 'psql select');
+      expectAllow('psql -c "delete_from_queue()"', 'psql identifier, not a phrase');
+      expectAllow('git commit -m "refactor: drop table indirection"', 'drop table in commit message');
+      expectAllow('echo "psql -c \'drop table users\'"', 'echo of a SQL command string');
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
     test('allows destructive SQL prose inside a quoted heredoc', () => {
       expectAllow(
         [

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -1563,6 +1563,12 @@ function runTests() {
       expectDestructiveDeny('runuser -u postgres --session-command \'mysql -e "delete from sessions"\'', 'runuser --session-command');
       expectDestructiveDeny('runuser -u postgres -s /usr/local/bin/fish -c \'psql -c "drop table users"\'', 'runuser -s SHELL -c command string');
       expectDestructiveDeny('runuser --shell=/usr/local/bin/fish -u postgres -c \'psql -c "drop table users"\'', 'runuser --shell= -c command string');
+      expectDestructiveDeny(
+        `runuser --shell /usr/local/bin/fish -u postgres -c 'psql -c "drop table users"'`,
+        'runuser --shell separate value + -c command string'
+      );
+      expectDestructiveDeny('chroot --userspec nobody:nogroup / psql -c "drop table users"', 'chroot --userspec VALUE + psql');
+      expectDestructiveDeny('chroot --made-up-flag value / psql -c "drop table users"', 'unmodelled wrapper option, fail closed');
     })
   )
     passed++;
@@ -1577,7 +1583,21 @@ function runTests() {
       expectAllow('sqlite3 truncate.db "select 1"', 'filename that contains a SQL word');
       expectAllow('psql -f truncate.sql', 'script filename via -f');
       expectAllow('psql --file=./sql/truncate.sql', 'script path via --file=');
+      expectAllow('psql -f "drop table.sql"', 'script filename with a space via -f');
+      expectAllow('psql --file "drop table.sql"', 'script filename with a space via --file');
+      expectAllow('chroot --userspec nobody:nogroup / ls -la', 'chroot --userspec with a harmless command');
       expectAllow('env PGHOST=db psql -c "select 1"', 'prefixed non-destructive SQL');
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('denies a script plus a destructive statement and fails closed past the nesting limit', () => {
+      expectDestructiveDeny('psql -f schema.sql -c "drop table users"', 'script file plus destructive -c');
+      const { isDestructiveQuoteAware } = require(hookScript);
+      assert.strictEqual(isDestructiveQuoteAware('ls -la', 5), true, 'sixth nesting level is not inspected and fails closed');
+      assert.strictEqual(isDestructiveQuoteAware('ls -la', 4), false, 'fifth nesting level is still inspected');
     })
   )
     passed++;

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -1561,6 +1561,8 @@ function runTests() {
       expectDestructiveDeny('runuser -u postgres -c \'psql -c "drop table users"\'', 'runuser -c command string');
       expectDestructiveDeny('runuser -u postgres --command=\'psql -c "truncate audit_log"\'', 'runuser --command= command string');
       expectDestructiveDeny('runuser -u postgres --session-command \'mysql -e "delete from sessions"\'', 'runuser --session-command');
+      expectDestructiveDeny('runuser -u postgres -s /usr/local/bin/fish -c \'psql -c "drop table users"\'', 'runuser -s SHELL -c command string');
+      expectDestructiveDeny('runuser --shell=/usr/local/bin/fish -u postgres -c \'psql -c "drop table users"\'', 'runuser --shell= -c command string');
     })
   )
     passed++;

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -1558,6 +1558,9 @@ function runTests() {
       expectDestructiveDeny('env time -f "%E" psql -c "drop table users"', 'GNU time -f FORMAT + psql');
       expectDestructiveDeny('/usr/bin/time -o /tmp/t.log psql -c "truncate audit_log"', 'GNU time -o FILE + psql');
       expectDestructiveDeny(`${'env '.repeat(12)}psql -c "drop table users"`, 'twelve stacked prefixes');
+      expectDestructiveDeny('runuser -u postgres -c \'psql -c "drop table users"\'', 'runuser -c command string');
+      expectDestructiveDeny('runuser -u postgres --command=\'psql -c "truncate audit_log"\'', 'runuser --command= command string');
+      expectDestructiveDeny('runuser -u postgres --session-command \'mysql -e "delete from sessions"\'', 'runuser --session-command');
     })
   )
     passed++;

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -1536,7 +1536,23 @@ function runTests() {
   if (
     test('denies destructive SQL to a database client behind a shell wrapper or chain', () => {
       expectDestructiveDeny('sh -c "psql -c \'drop table users\'"', 'psql inside sh -c');
+      expectDestructiveDeny('bash -lc \'psql -c "drop table users"\'', 'psql inside bash -lc');
+      expectDestructiveDeny('sh -ec \'mysql -e "delete from sessions"\'', 'mysql inside sh -ec');
       expectDestructiveDeny('echo migrating && mysql -e "truncate sessions"', 'mysql in second segment');
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('denies destructive SQL to a database client behind an execution prefix', () => {
+      expectDestructiveDeny('env PGHOST=db psql -c "drop table users"', 'env assignment + psql');
+      expectDestructiveDeny('env psql -c "drop table users"', 'bare env + psql');
+      expectDestructiveDeny('sudo -u postgres psql -c "truncate audit_log"', 'sudo -u + psql');
+      expectDestructiveDeny('command mysql -e "delete from sessions"', 'command + mysql');
+      expectDestructiveDeny('nice -n 10 psql -c "drop table users"', 'nice -n + psql');
+      expectDestructiveDeny('timeout 30 mysql -e "truncate sessions"', 'timeout DURATION + mysql');
+      expectDestructiveDeny('sudo env PGHOST=db psql -c "drop table users"', 'stacked prefixes');
     })
   )
     passed++;
@@ -1548,6 +1564,10 @@ function runTests() {
       expectAllow('psql -c "delete_from_queue()"', 'psql identifier, not a phrase');
       expectAllow('git commit -m "refactor: drop table indirection"', 'drop table in commit message');
       expectAllow('echo "psql -c \'drop table users\'"', 'echo of a SQL command string');
+      expectAllow('sqlite3 truncate.db "select 1"', 'filename that contains a SQL word');
+      expectAllow('psql -f truncate.sql', 'script filename via -f');
+      expectAllow('psql --file=./sql/truncate.sql', 'script path via --file=');
+      expectAllow('env PGHOST=db psql -c "select 1"', 'prefixed non-destructive SQL');
     })
   )
     passed++;

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -1553,6 +1553,11 @@ function runTests() {
       expectDestructiveDeny('nice -n 10 psql -c "drop table users"', 'nice -n + psql');
       expectDestructiveDeny('timeout 30 mysql -e "truncate sessions"', 'timeout DURATION + mysql');
       expectDestructiveDeny('sudo env PGHOST=db psql -c "drop table users"', 'stacked prefixes');
+      expectDestructiveDeny('env -S \'psql -c "drop table users"\'', 'env -S command string');
+      expectDestructiveDeny('env --split-string=\'mysql -e "delete from sessions"\'', 'env --split-string= command string');
+      expectDestructiveDeny('env time -f "%E" psql -c "drop table users"', 'GNU time -f FORMAT + psql');
+      expectDestructiveDeny('/usr/bin/time -o /tmp/t.log psql -c "truncate audit_log"', 'GNU time -o FILE + psql');
+      expectDestructiveDeny(`${'env '.repeat(12)}psql -c "drop table users"`, 'twelve stacked prefixes');
     })
   )
     passed++;


### PR DESCRIPTION
## What Changed
`scripts/hooks/gateguard-fact-force.js`: the quote-aware pass now tests the `DESTRUCTIVE_SQL_DD` phrases (`drop table`, `delete from`, `truncate`) against the unquoted argument text of a segment whose executable is a known database client (`psql`, `pgcli`, `mysql`, `mariadb`, `mycli`, `sqlite3`, `duckdb`, `usql`, `sqlcmd`, `clickhouse-client`, `cockroach`, `mongosh`, `cqlsh`, `trino`, `presto`, `beeline`, ...). The generic quote-stripped scan is unchanged, so a commit message that mentions `drop table` still passes. Because the check lives in `isDestructiveQuoteAware`, it also applies behind `sh -c` and in chained segments.

Tests added to `tests/hooks/gateguard-fact-force.test.js`:
- deny: `psql -c "drop table users"`, `psql -c 'truncate audit_log'`, `psql --command='truncate audit_log'`, `mysql -e "delete from sessions"`, `sqlite3 app.db "drop table users"`, `/usr/local/bin/psql -h db -U app -c "DROP TABLE users"`, `sh -c "psql -c 'drop table users'"`, `echo migrating && mysql -e "truncate sessions"`
- allow: `psql -c "select count(*) from users"`, `psql -c "delete_from_queue()"`, `git commit -m "refactor: drop table indirection"`, `echo "psql -c 'drop table users'"`

## Why This Change
Fixes #3024. `stripQuotedStrings()` ran before the `DESTRUCTIVE_SQL_DD` arm at both call sites, and a real SQL invocation must quote the statement, so the SQL phrases were unreachable: `psql -c "drop table users"` and `mysql -e "delete from sessions"` were allowed, only the unquoted spelling (which the shell would split into separate arguments) was caught. The stripping itself is right for the generic scan (it is what keeps commit messages from tripping the gate), so the fix scopes the unquoted scan to database clients in argv0 position instead of removing it.

## Testing Done
- [x] Manual testing completed (the reproducer from the issue: the four quoted commands now deny, the commit message still allows)
- [x] Automated tests pass locally (`node tests/hooks/gateguard-fact-force.test.js`: 199 passed; the two new deny tests fail on `main`)
- [x] Edge cases considered and tested (client with a path prefix and extra flags, `--command=` inline form, positional statement for `sqlite3`, shell wrapper, chained segment, `select`, identifier containing a keyword, `echo` of a SQL command string)

## Type of Change
- [x] `fix:` Bug fix

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly (none changed)
- [x] Shell scripts pass shellcheck (if applicable) (none changed)
- [x] Pre-commit hooks pass locally (if configured) (`npx eslint` on the changed files)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format
