### PR TITLE
fix(block-no-verify): treat a git command line quoted as data as data, not a command

### DIFF
--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -353,45 +353,49 @@ function commandBasename(word) {
 }
 
 /**
- * Runtimes that run a quoted argument as program source once they are given
- * an eval flag (`node -e`, `python3 -c`, `perl -E`, `deno eval`). That source
- * can spawn git itself, so it stays subject to the guard. The same runtime
- * without an eval flag receives a script argument, which is data
- * (`node cli.js 'git commit --no-verify'`).
+ * Runtimes that run a quoted argument as program source, each with the
+ * flags that do it: `node -e`, `python3 -c`, `perl -E`, `php -r`,
+ * `deno eval`. That source can spawn git itself, so it stays subject to the
+ * guard. The same runtime without one of its own eval flags receives a
+ * script path and arguments, which are data (`node cli.js 'git commit
+ * --no-verify'`).
+ *
+ * The flags are per runtime because the same letter means different things:
+ * node's `-r` preloads a module and leaves the rest of the command line as
+ * ordinary arguments, while php's `-r` is how php is handed code.
  */
-const CODE_EVALUATORS = new Set([
-  'node',
-  'nodejs',
-  'bun',
-  'deno',
-  'python',
-  'python2',
-  'python3',
-  'pythonw',
-  'perl',
-  'ruby',
-  'php',
-  'lua',
-  'luajit',
-  'rscript',
-  'osascript',
-  'tclsh',
-  'groovy',
-  'julia',
-  'elixir',
-  'erl',
+const CODE_EVALUATORS = new Map([
+  ['node', ['-e', '--eval', '-p', '--print']],
+  ['nodejs', ['-e', '--eval', '-p', '--print']],
+  ['bun', ['-e', '--eval', '-p', '--print']],
+  ['deno', ['-e', '--eval', 'eval']],
+  ['python', ['-c']],
+  ['python2', ['-c']],
+  ['python3', ['-c']],
+  ['pythonw', ['-c']],
+  ['perl', ['-e', '-E']],
+  ['ruby', ['-e']],
+  ['php', ['-r']],
+  ['lua', ['-e']],
+  ['luajit', ['-e']],
+  ['rscript', ['-e']],
+  ['osascript', ['-e']],
+  ['groovy', ['-e']],
+  ['julia', ['-e', '-E']],
+  ['elixir', ['-e']],
+  ['erl', ['-eval']],
 ]);
-
-/** `-e`, `-E`, `--eval`, `-c`, `-p`, `--print`, `-r` and deno's `eval`. */
-const EVAL_FLAG = /(?:^|\s)(?:-{1,2}(?:e|eval|c|command|p|print|r)|eval)(?:=|\s|$)/i;
 
 /**
  * Whether the words between the program and its quoted argument turn that
- * argument into code.
+ * argument into code. A flag is matched as a whole word, or as the `=` form
+ * of itself, so a path that happens to end in one of them cannot qualify.
  */
 function evaluatesQuotedArgument(input, region, base) {
-  if (!CODE_EVALUATORS.has(base)) return false;
-  return EVAL_FLAG.test(input.slice(region.argv0Start, region.start));
+  const flags = CODE_EVALUATORS.get(base);
+  if (flags === undefined) return false;
+  const words = input.slice(region.argv0Start, region.start).split(/\s+/);
+  return words.some((word) => flags.some((flag) => word === flag || word.startsWith(`${flag}=`)));
 }
 
 /**

--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -42,7 +42,8 @@ const VALID_BEFORE_GIT = ' \t\n\r;&|$`(<{!"\']/.~\\';
  * `git` inside one of their quoted arguments is a command that must still
  * be checked (`sh -c "git commit --no-verify"`, `sudo`, `xargs`, `env`...).
  * For any other argv0 (`node cli.js 'git commit --no-verify'`,
- * `printf '%s' '...'`, `python3 -c "..."`) a quoted string is data.
+ * `printf '%s' '...'`, `grep -n '...' docs.md`) a quoted string is data,
+ * unless it is a runtime given an eval flag (see CODE_EVALUATORS).
  */
 const COMMAND_WRAPPERS = new Set([
   'sh',
@@ -352,9 +353,52 @@ function commandBasename(word) {
 }
 
 /**
+ * Runtimes that run a quoted argument as program source once they are given
+ * an eval flag (`node -e`, `python3 -c`, `perl -E`, `deno eval`). That source
+ * can spawn git itself, so it stays subject to the guard. The same runtime
+ * without an eval flag receives a script argument, which is data
+ * (`node cli.js 'git commit --no-verify'`).
+ */
+const CODE_EVALUATORS = new Set([
+  'node',
+  'nodejs',
+  'bun',
+  'deno',
+  'python',
+  'python2',
+  'python3',
+  'pythonw',
+  'perl',
+  'ruby',
+  'php',
+  'lua',
+  'luajit',
+  'rscript',
+  'osascript',
+  'tclsh',
+  'groovy',
+  'julia',
+  'elixir',
+  'erl',
+]);
+
+/** `-e`, `-E`, `--eval`, `-c`, `-p`, `--print`, `-r` and deno's `eval`. */
+const EVAL_FLAG = /(?:^|\s)(?:-{1,2}(?:e|eval|c|command|p|print|r)|eval)(?:=|\s|$)/i;
+
+/**
+ * Whether the words between the program and its quoted argument turn that
+ * argument into code.
+ */
+function evaluatesQuotedArgument(input, region, base) {
+  if (!CODE_EVALUATORS.has(base)) return false;
+  return EVAL_FLAG.test(input.slice(region.argv0Start, region.start));
+}
+
+/**
  * A `git` inside a quoted string is only a command when that string is
- * handed to something that executes it. Otherwise it is an argument of an
- * unrelated program (a CLI under test, printf, python -c, ...) and must not
+ * handed to something that executes it: a shell or process wrapper, or a
+ * runtime given an eval flag. Otherwise it is an argument of an unrelated
+ * program (a CLI under test, printf, grep, a script path, ...) and must not
  * be inspected for bypass flags. A double-quoted string that contains a
  * command substitution (`"$(git ...)"`, "`git ...`") runs git before any
  * program receives it, so it is never data.
@@ -364,7 +408,8 @@ function isQuotedDataArgument(input, idx) {
   if (region === null || region.argv0 === '') return false;
   if (region.substitution) return false;
   const base = commandBasename(region.argv0);
-  return base !== 'git' && !COMMAND_WRAPPERS.has(base);
+  if (base === 'git' || COMMAND_WRAPPERS.has(base)) return false;
+  return !evaluatesQuotedArgument(input, region, base);
 }
 
 /**
@@ -484,6 +529,16 @@ function isNoVerifyLongFlag(value) {
 }
 
 /**
+ * A flag inside a code payload is followed by the punctuation that closes the
+ * call (`execSync("git push --no-verify")`), and the word tokenizer keeps that
+ * punctuation in the token. Trim it so the flag is comparable; a real flag
+ * never ends in one of these characters.
+ */
+function flagToken(value) {
+  return value.replace(/[)\]}'"`;,]+$/, '');
+}
+
+/**
  * Check if the input contains a --no-verify flag for a specific git command.
  * Only inspects the portion of the input starting at `offset` (the position
  * right after the detected subcommand keyword) so that flags belonging to
@@ -495,7 +550,7 @@ function hasNoVerifyFlag(input, command, offset, limit = input.length) {
   let skipNext = false;
 
   for (const token of tokens) {
-    const value = token.value;
+    const value = flagToken(token.value);
 
     if (skipNext) {
       skipNext = false;

--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -15,6 +15,8 @@
 
 'use strict';
 
+const { quotedRegionAt } = require('../lib/shell-quotes');
+
 const MAX_STDIN = 1024 * 1024;
 let raw = '';
 
@@ -34,6 +36,52 @@ const GIT_COMMANDS_WITH_NO_VERIFY = [
  * Characters that can appear immediately before 'git' in a command string.
  */
 const VALID_BEFORE_GIT = ' \t\n\r;&|$`(<{!"\']/.~\\';
+
+/**
+ * Programs that execute a quoted argument as a shell command line, so a
+ * `git` inside one of their quoted arguments is a command that must still
+ * be checked (`sh -c "git commit --no-verify"`, `sudo`, `xargs`, `env`...).
+ * For any other argv0 (`node cli.js 'git commit --no-verify'`,
+ * `printf '%s' '...'`, `python3 -c "..."`) a quoted string is data.
+ */
+const COMMAND_WRAPPERS = new Set([
+  'sh',
+  'bash',
+  'zsh',
+  'dash',
+  'ksh',
+  'fish',
+  'busybox',
+  'eval',
+  'exec',
+  'command',
+  'xargs',
+  'sudo',
+  'doas',
+  'su',
+  'env',
+  'nice',
+  'ionice',
+  'nohup',
+  'timeout',
+  'time',
+  'watch',
+  'flock',
+  'ssh',
+  'script',
+  'csh',
+  'tcsh',
+  'setsid',
+  'stdbuf',
+  'taskset',
+  'chrt',
+  'unshare',
+  'chroot',
+  'runuser',
+  'npx',
+  'bunx',
+  'pnpx',
+]);
 
 // Git config section and variable names are case-insensitive
 // (subsection names are case-sensitive but core.hooksPath has none),
@@ -149,7 +197,11 @@ function tokenizeShellWords(input, start = 0, end = input.length) {
       continue;
     }
 
-    if (/\s/.test(char)) {
+    // Whitespace ends a word; so do the unquoted substitution delimiters,
+    // which can never be part of a word (`echo "$(git push --no-verify)"`,
+    // "`git push --no-verify`" used to yield the token `--no-verify)` /
+    // `--no-verify\``, hiding the flag).
+    if (/[\s`()]/.test(char)) {
       pushToken(i);
       continue;
     }
@@ -290,6 +342,32 @@ function isInComment(input, idx) {
 }
 
 /**
+ * Strip a leading path and a trailing `.exe` from a command word.
+ */
+function commandBasename(word) {
+  return String(word || '')
+    .replace(/^.*[\\/]/, '')
+    .replace(/\.exe$/i, '')
+    .toLowerCase();
+}
+
+/**
+ * A `git` inside a quoted string is only a command when that string is
+ * handed to something that executes it. Otherwise it is an argument of an
+ * unrelated program (a CLI under test, printf, python -c, ...) and must not
+ * be inspected for bypass flags. A double-quoted string that contains a
+ * command substitution (`"$(git ...)"`, "`git ...`") runs git before any
+ * program receives it, so it is never data.
+ */
+function isQuotedDataArgument(input, idx) {
+  const region = quotedRegionAt(input, idx);
+  if (region === null || region.argv0 === '') return false;
+  if (region.substitution) return false;
+  const base = commandBasename(region.argv0);
+  return base !== 'git' && !COMMAND_WRAPPERS.has(base);
+}
+
+/**
  * Find the next 'git' token in the input starting from a position.
  */
 function findGit(input, start) {
@@ -307,7 +385,9 @@ function findGit(input, start) {
     }
 
     const before = idx > 0 ? input[idx - 1] : ' ';
-    if (VALID_BEFORE_GIT.includes(before)) return { idx, len };
+    if (VALID_BEFORE_GIT.includes(before) && !isQuotedDataArgument(input, idx)) {
+      return { idx, len };
+    }
     pos = idx + 1;
   }
   return null;
@@ -409,8 +489,8 @@ function isNoVerifyLongFlag(value) {
  * right after the detected subcommand keyword) so that flags belonging to
  * earlier commands in a chain are not falsely matched.
  */
-function hasNoVerifyFlag(input, command, offset) {
-  const segmentEnd = findCommandSegmentEnd(input, offset);
+function hasNoVerifyFlag(input, command, offset, limit = input.length) {
+  const segmentEnd = Math.min(findCommandSegmentEnd(input, offset), limit);
   const tokens = tokenizeShellWords(input, offset, segmentEnd);
   let skipNext = false;
 
@@ -497,7 +577,13 @@ function checkCommand(input) {
       };
     }
 
-    if (hasNoVerifyFlag(input, gitCommand, offset)) {
+    // A git command line inside a quoted string (`sh -c 'git push ...'`)
+    // ends with that string: scanning past the closing quote would read the
+    // rest of the outer statement in the wrong quote state, so `sh -c 'git
+    // push --no-verify'; echo done` glued `; echo done` onto the flag token.
+    const region = quotedRegionAt(input, detected.gitStart);
+    const limit = region === null ? input.length : region.end;
+    if (hasNoVerifyFlag(input, gitCommand, offset, limit)) {
       return {
         blocked: true,
         reason: `BLOCKED: --no-verify flag is not allowed with git ${gitCommand}. Git hooks must not be bypassed.`,

--- a/scripts/lib/shell-quotes.js
+++ b/scripts/lib/shell-quotes.js
@@ -5,8 +5,9 @@
  *
  * One forward pass records every quoted region: where it starts and ends, the
  * argv0 of the statement containing it (the first non-assignment, non-reserved
- * word before the quote; '' when the quote is part of that first word) and
- * whether the string carries a command substitution. A `$(` or backtick inside
+ * word before the quote; '' when the quote is part of that first word, with
+ * `argv0Start` holding its offset so a caller can read the words in between)
+ * and whether the string carries a command substitution. A `$(` or backtick inside
  * "..." suspends the string: the substitution body is top-level shell again
  * (its own statements and quotes) until the matching `)` / backtick, after
  * which the string resumes as a new region. Both halves are flagged
@@ -37,9 +38,16 @@ function createState() {
     escaped: false,
     open: null,
     argv0: null,
+    argv0Start: -1,
     word: '',
+    wordStart: -1,
     inWord: false,
   };
+}
+
+function startWord(state, index) {
+  if (!state.inWord) state.wordStart = index;
+  state.inWord = true;
 }
 
 function endWord(state) {
@@ -51,6 +59,7 @@ function endWord(state) {
     !ASSIGNMENT_WORD.test(state.word)
   ) {
     state.argv0 = state.word;
+    state.argv0Start = state.wordStart;
   }
   state.word = '';
   state.inWord = false;
@@ -59,11 +68,12 @@ function endWord(state) {
 function newStatement(state) {
   endWord(state);
   state.argv0 = null;
+  state.argv0Start = -1;
 }
 
-function openRegion(state, start, quote, argv0, substitution) {
+function openRegion(state, start, quote, argv0, argv0Start, substitution) {
   state.quote = quote;
-  state.open = { start, quote, argv0, substitution };
+  state.open = { start, quote, argv0, argv0Start, substitution };
 }
 
 function closeRegion(state, end, substitution) {
@@ -84,6 +94,7 @@ function suspendString(state, index, char) {
     backtick: char === '`',
     depth: 0,
     argv0: state.open.argv0,
+    argv0Start: state.open.argv0Start,
     outer: { word: state.word, inWord: state.inWord, argv0: state.argv0 },
   });
   closeRegion(state, index, true);
@@ -98,7 +109,7 @@ function resumeString(state, index, outer) {
   state.word = outer.outer.word;
   state.inWord = outer.outer.inWord;
   state.argv0 = outer.outer.argv0;
-  openRegion(state, index, '"', outer.argv0, true);
+  openRegion(state, index, '"', outer.argv0, outer.argv0Start, true);
 }
 
 /** A character inside a quoted string. Returns the number of characters consumed. */
@@ -124,12 +135,12 @@ function scanQuotedChar(state, input, index) {
 function scanBareChar(state, index, char) {
   if (char === '\\') {
     state.escaped = true;
-    state.inWord = true;
+    startWord(state, index);
     return 1;
   }
   if (char === '"' || char === "'") {
-    state.inWord = true;
-    openRegion(state, index, char, state.argv0 === null ? '' : state.argv0, false);
+    startWord(state, index);
+    openRegion(state, index, char, state.argv0 === null ? '' : state.argv0, state.argv0Start, false);
     return 1;
   }
   const outer = state.suspended.length > 0 ? state.suspended[state.suspended.length - 1] : null;
@@ -153,7 +164,7 @@ function scanBareChar(state, index, char) {
     return 1;
   }
   state.word += char;
-  state.inWord = true;
+  startWord(state, index);
   return 1;
 }
 
@@ -161,7 +172,7 @@ function scanBareChar(state, index, char) {
  * Every quoted region of `input`, sorted by start and disjoint.
  *
  * @param {string} input
- * @returns {Array<{start: number, end: number, quote: string, argv0: string, substitution: boolean}>}
+ * @returns {Array<{start: number, end: number, quote: string, argv0: string, argv0Start: number, substitution: boolean}>}
  */
 function quotedRegions(input) {
   if (cache.input === input) return cache.regions;

--- a/scripts/lib/shell-quotes.js
+++ b/scripts/lib/shell-quotes.js
@@ -1,0 +1,210 @@
+'use strict';
+
+/**
+ * Quoted-region scanner for shell command lines.
+ *
+ * One forward pass records every quoted region: where it starts and ends, the
+ * argv0 of the statement containing it (the first non-assignment, non-reserved
+ * word before the quote; '' when the quote is part of that first word) and
+ * whether the string carries a command substitution. A `$(` or backtick inside
+ * "..." suspends the string: the substitution body is top-level shell again
+ * (its own statements and quotes) until the matching `)` / backtick, after
+ * which the string resumes as a new region. Both halves are flagged
+ * `substitution`. Regions are appended only once complete, in order, so they
+ * are disjoint and sorted. The result is cached per input, so a command line
+ * holding thousands of quoted tokens is scanned once.
+ */
+
+// Words that open or structure a compound command; none of them receives the
+// quoted string that follows, so none may become a statement's argv0.
+const SHELL_RESERVED_WORDS = new Set([
+  'if', 'then', 'else', 'elif', 'fi', 'do', 'done', 'while', 'until', 'for',
+  'case', 'esac', 'in', 'select', 'function', 'coproc', '!', '{', '}', '[[', ']]',
+]);
+
+const ASSIGNMENT_WORD = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+// Unquoted characters that start a new statement (or a nested command).
+const STATEMENT_SEPARATORS = new Set([';', '|', '&', '\n', '(', ')', '`']);
+
+let cache = { input: null, regions: [] };
+
+function createState() {
+  return {
+    regions: [],
+    suspended: [],
+    quote: null,
+    escaped: false,
+    open: null,
+    argv0: null,
+    word: '',
+    inWord: false,
+  };
+}
+
+function endWord(state) {
+  if (!state.inWord) return;
+  if (
+    state.argv0 === null &&
+    state.word !== '' &&
+    !SHELL_RESERVED_WORDS.has(state.word) &&
+    !ASSIGNMENT_WORD.test(state.word)
+  ) {
+    state.argv0 = state.word;
+  }
+  state.word = '';
+  state.inWord = false;
+}
+
+function newStatement(state) {
+  endWord(state);
+  state.argv0 = null;
+}
+
+function openRegion(state, start, quote, argv0, substitution) {
+  state.quote = quote;
+  state.open = { start, quote, argv0, substitution };
+}
+
+function closeRegion(state, end, substitution) {
+  const region = state.open;
+  state.regions.push({ ...region, end, substitution: region.substitution || substitution });
+  state.open = null;
+  state.quote = null;
+}
+
+/**
+ * `$(` or a backtick inside "...": park the outer statement's word state (the
+ * outer word `FOO="pre$(cmd)post"` continues after the substitution as if it
+ * were a single character) and scan the body as a fresh statement. Returns
+ * the number of characters consumed.
+ */
+function suspendString(state, index, char) {
+  state.suspended.push({
+    backtick: char === '`',
+    depth: 0,
+    argv0: state.open.argv0,
+    outer: { word: state.word, inWord: state.inWord, argv0: state.argv0 },
+  });
+  closeRegion(state, index, true);
+  state.word = '';
+  state.inWord = false;
+  state.argv0 = null;
+  return char === '$' ? 2 : 1;
+}
+
+function resumeString(state, index, outer) {
+  state.suspended.pop();
+  state.word = outer.outer.word;
+  state.inWord = outer.outer.inWord;
+  state.argv0 = outer.outer.argv0;
+  openRegion(state, index, '"', outer.argv0, true);
+}
+
+/** A character inside a quoted string. Returns the number of characters consumed. */
+function scanQuotedChar(state, input, index) {
+  const char = input.charAt(index);
+  if (state.quote === '"' && char === '\\') {
+    state.escaped = true;
+    return 1;
+  }
+  if (char === state.quote) {
+    closeRegion(state, index, false);
+    return 1;
+  }
+  if (state.quote === '"' && (char === '`' || (char === '$' && input.charAt(index + 1) === '('))) {
+    return suspendString(state, index, char);
+  }
+  state.word += char;
+  state.inWord = true;
+  return 1;
+}
+
+/** A character outside quotes. Returns the number of characters consumed. */
+function scanBareChar(state, index, char) {
+  if (char === '\\') {
+    state.escaped = true;
+    state.inWord = true;
+    return 1;
+  }
+  if (char === '"' || char === "'") {
+    state.inWord = true;
+    openRegion(state, index, char, state.argv0 === null ? '' : state.argv0, false);
+    return 1;
+  }
+  const outer = state.suspended.length > 0 ? state.suspended[state.suspended.length - 1] : null;
+  if (outer !== null) {
+    const resumes = outer.backtick ? char === '`' : char === ')' && outer.depth === 0;
+    if (resumes) {
+      resumeString(state, index, outer);
+      return 1;
+    }
+    if (!outer.backtick && (char === '(' || char === ')')) {
+      const depth = outer.depth + (char === '(' ? 1 : -1);
+      state.suspended = [...state.suspended.slice(0, -1), { ...outer, depth }];
+    }
+  }
+  if (STATEMENT_SEPARATORS.has(char)) {
+    newStatement(state);
+    return 1;
+  }
+  if (/\s/.test(char)) {
+    endWord(state);
+    return 1;
+  }
+  state.word += char;
+  state.inWord = true;
+  return 1;
+}
+
+/**
+ * Every quoted region of `input`, sorted by start and disjoint.
+ *
+ * @param {string} input
+ * @returns {Array<{start: number, end: number, quote: string, argv0: string, substitution: boolean}>}
+ */
+function quotedRegions(input) {
+  if (cache.input === input) return cache.regions;
+  const state = createState();
+  for (let i = 0; i < input.length; ) {
+    const char = input.charAt(i);
+    if (state.escaped) {
+      state.escaped = false;
+      state.word += char;
+      state.inWord = true;
+      i += 1;
+      continue;
+    }
+    i += state.quote ? scanQuotedChar(state, input, i) : scanBareChar(state, i, char);
+  }
+  if (state.open !== null) state.regions.push({ ...state.open, end: input.length });
+  cache = { input, regions: state.regions };
+  return state.regions;
+}
+
+/**
+ * The quoted region that strictly contains `idx`, or null when `idx` is not
+ * inside a quote. Regions are disjoint and sorted, so this is a binary search.
+ *
+ * @param {string} input
+ * @param {number} idx
+ */
+function quotedRegionAt(input, idx) {
+  const regions = quotedRegions(input);
+  let lo = 0;
+  let hi = regions.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const region = regions[mid];
+    if (idx <= region.start) {
+      hi = mid - 1;
+    } else if (idx >= region.end) {
+      lo = mid + 1;
+    } else {
+      return region;
+    }
+  }
+  return null;
+}
+
+module.exports = { quotedRegions, quotedRegionAt, SHELL_RESERVED_WORDS };

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -258,8 +258,38 @@ if (test('allows a quoted git command line passed as an argument to another prog
     "node /tmp/cli.js 'git commit --no-verify -m x'",
     'node /tmp/cli.js "git push --no-verify"',
     "printf '%s' 'git commit --no-verify -m x' | node /tmp/x.js",
-    'python3 -c "print(\'git commit --no-verify\')"',
+    "python3 /tmp/check.py 'git commit --no-verify'",
+    "node /tmp/cli.js --expect 'git push --no-verify'",
     "grep -n 'git commit --no-verify' docs/hooks.md",
+  ]) {
+    const r = runHook({ tool_input: { command } });
+    assert.strictEqual(r.code, 0, `expected exit 0 for ${command}, got ${r.code}: ${r.stderr}`);
+  }
+})) passed++; else failed++;
+
+// A runtime given an eval flag executes its quoted argument as source, so a
+// bypass in that source runs git for real and stays blocked.
+if (test('blocks a git bypass inside a runtime eval payload', () => {
+  for (const command of [
+    'node -e "require(\'child_process\').execSync(\'git commit --no-verify -m x\')"',
+    "node -e 'require(\"child_process\").execSync(\"git push --no-verify\")'",
+    'node --eval="git commit --no-verify -m x"',
+    'node -p "cp.execSync(\'git push --no-verify\')"',
+    "python3 -c 'import os; os.system(\"git push --no-verify\")'",
+    "perl -e 'system(\"git commit --no-verify -m x\")'",
+    "ruby -e 'system(\"git push --no-verify\")'",
+    "php -r 'shell_exec(\"git commit --no-verify -m x\");'",
+    'deno eval "git push --no-verify"',
+  ]) {
+    const r = runHook({ tool_input: { command } });
+    assert.strictEqual(r.code, 2, `expected exit 2 for ${command}, got ${r.code}`);
+  }
+})) passed++; else failed++;
+
+if (test('still allows a bypass phrase in an eval payload that does not run git', () => {
+  for (const command of [
+    'node -e "console.log(\'use --no-verify only in emergencies\')"',
+    "python3 -c 'print(\"never pass -n to commit\")'",
   ]) {
     const r = runHook({ tool_input: { command } });
     assert.strictEqual(r.code, 0, `expected exit 0 for ${command}, got ${r.code}: ${r.stderr}`);

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -251,6 +251,96 @@ if (test('allows --no-verbose (not a prefix of --no-verify)', () => {
   assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
 })) passed++; else failed++;
 
+// --- A git command line quoted as an argument to another program is data ---
+
+if (test('allows a quoted git command line passed as an argument to another program', () => {
+  for (const command of [
+    "node /tmp/cli.js 'git commit --no-verify -m x'",
+    'node /tmp/cli.js "git push --no-verify"',
+    "printf '%s' 'git commit --no-verify -m x' | node /tmp/x.js",
+    'python3 -c "print(\'git commit --no-verify\')"',
+    "grep -n 'git commit --no-verify' docs/hooks.md",
+  ]) {
+    const r = runHook({ tool_input: { command } });
+    assert.strictEqual(r.code, 0, `expected exit 0 for ${command}, got ${r.code}: ${r.stderr}`);
+  }
+})) passed++; else failed++;
+
+if (test('blocks a quoted git command line behind a process prefix or another shell', () => {
+  for (const command of [
+    "setsid sh -c 'git commit --no-verify -m x'",
+    'csh -c "git commit --no-verify -m x"',
+    "tcsh -c 'git push --no-verify'",
+    "stdbuf -oL bash -c 'git commit -n -m x'",
+    "taskset -c 0 sh -c 'git push --no-verify'",
+    "unshare -n sh -c 'git commit --no-verify -m x'",
+    "runuser -u deploy -- sh -c 'git push --no-verify'",
+    "npx some-runner 'git commit --no-verify -m x'",
+  ]) {
+    const r = runHook({ tool_input: { command } });
+    assert.strictEqual(r.code, 2, `expected exit 2 for ${command}, got ${r.code}`);
+  }
+})) passed++; else failed++;
+
+if (test('blocks a git command substituted inside a double-quoted data argument', () => {
+  for (const command of [
+    'echo "$(git commit --no-verify -m x)"',
+    'echo "$(git push --no-verify)"',
+    'printf "%s" "`git push --no-verify`"',
+    'node /tmp/cli.js "result: $(git commit -n -m x)"',
+  ]) {
+    const r = runHook({ tool_input: { command } });
+    assert.strictEqual(r.code, 2, `expected exit 2 for ${command}, got ${r.code}`);
+  }
+})) passed++; else failed++;
+
+if (test('blocks a quoted git command line inside a compound command or a nested substitution', () => {
+  for (const command of [
+    "( sh -c 'git commit --no-verify -m x' )",
+    "{ sh -c 'git push --no-verify'; }",
+    "if sh -c 'git commit --no-verify -m x'; then echo ok; fi",
+    "for f in a b; do sh -c 'git commit --no-verify -m x'; done",
+    'echo "$(echo "x"; git commit --no-verify -m x)"',
+    'echo "before $(sh -c \'git commit --no-verify -m x\') after"',
+    'echo "$(echo "$(git push --no-verify)")"',
+    "FOO=\"pre$(echo x)post\" sh -c 'git commit --no-verify -m x'",
+    "PREFIX=\"`date`\" sh -c 'git push --no-verify'",
+    "sh -c 'git push --no-verify'; echo done",
+    "sh -c 'git push --no-verify' && echo done",
+    'sh -c "git commit --no-verify -m x" || true',
+  ]) {
+    const r = runHook({ tool_input: { command } });
+    assert.strictEqual(r.code, 2, `expected exit 2 for ${command}, got ${r.code}`);
+  }
+})) passed++; else failed++;
+
+if (test('stays fast on a large quoted data payload full of git tokens', () => {
+  const payload = 'git commit --no-verify -m x '.repeat(12000);
+  const command = `node /tmp/cli.js '${payload}'`;
+  assert.ok(command.length > 300000, 'payload should exceed 300 KB');
+  const started = Date.now();
+  const r = runHook({ tool_input: { command } });
+  const elapsed = Date.now() - started;
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+  assert.ok(elapsed < 5000, `hook took ${elapsed}ms on a 300 KB quoted payload`);
+})) passed++; else failed++;
+
+if (test('still blocks a quoted git command line handed to a shell or command wrapper', () => {
+  for (const command of [
+    'sh -c "git commit --no-verify -m x"',
+    "bash -lc 'git push --no-verify'",
+    'sudo git commit --no-verify -m x',
+    "xargs -0 git commit --no-verify",
+    'env FOO=1 git commit -n -m x',
+    "eval 'git commit --no-verify -m x'",
+    'node /tmp/cli.js "data" && git commit --no-verify -m x',
+    "echo 'git commit --no-verify' ; git push --no-verify",
+  ]) {
+    const r = runHook({ tool_input: { command } });
+    assert.strictEqual(r.code, 2, `expected exit 2 for ${command}, got ${r.code}`);
+  }
+})) passed++; else failed++;
+
 console.log('─'.repeat(50));
 console.log(`Passed: ${passed}  Failed: ${failed}`);
 

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -286,6 +286,31 @@ if (test('blocks a git bypass inside a runtime eval payload', () => {
   }
 })) passed++; else failed++;
 
+if (test('allows a runtime flag that loads code but leaves the quoted argument as data', () => {
+  for (const command of [
+    // node -r preloads a module; the script and its arguments stay data.
+    "node -r setup.js cli.js 'git push --no-verify'",
+    'node --require ts-node/register cli.js "git commit --no-verify -m x"',
+    "ruby -r./setup cli.rb 'git push --no-verify'",
+    "python3 -B check.py 'git commit --no-verify'",
+  ]) {
+    const r = runHook({ tool_input: { command } });
+    assert.strictEqual(r.code, 0, `expected exit 0 for ${command}, got ${r.code}: ${r.stderr}`);
+  }
+})) passed++; else failed++;
+
+if (test('blocks each runtime through its own eval flag', () => {
+  for (const command of [
+    'node -p "cp.execSync(\'git push --no-verify\')"',
+    "php -r 'shell_exec(\"git commit --no-verify -m x\");'",
+    "perl -E 'system(\"git push --no-verify\")'",
+    "lua -e 'os.execute(\"git commit --no-verify -m x\")'",
+  ]) {
+    const r = runHook({ tool_input: { command } });
+    assert.strictEqual(r.code, 2, `expected exit 2 for ${command}, got ${r.code}`);
+  }
+})) passed++; else failed++;
+
 if (test('still allows a bypass phrase in an eval payload that does not run git', () => {
   for (const command of [
     'node -e "console.log(\'use --no-verify only in emergencies\')"',


### PR DESCRIPTION
## What Changed
`scripts/hooks/block-no-verify.js`: when `findGit()` finds a `git` inside a quoted string, the new `isQuotedDataArgument()` looks at the argv0 of the statement that carries the quote (first word after the last top-level `;`, `|`, `&` or newline, skipping `VAR=value` assignments). If that argv0 is a shell or command wrapper (`sh`, `bash`, `zsh`, `dash`, `ksh`, `fish`, `busybox`, `eval`, `exec`, `command`, `xargs`, `sudo`, `doas`, `su`, `env`, `nice`, `nohup`, `timeout`, `time`, `watch`, `flock`, `ssh`, `script`) or `git` itself, the quoted git is still inspected as before. For any other program the quoted string is data and the occurrence is skipped. Unquoted `git` anywhere in a chain is unaffected.

Tests added to `tests/hooks/block-no-verify.test.js`:
- allow: `node /tmp/cli.js 'git commit --no-verify -m x'`, `node /tmp/cli.js "git push --no-verify"`, `printf '%s' 'git commit --no-verify -m x' | node /tmp/x.js`, `python3 -c "print('git commit --no-verify')"`, `grep -n 'git commit --no-verify' docs/hooks.md`
- block: `sh -c "git commit --no-verify -m x"`, `bash -lc 'git push --no-verify'`, `sudo git commit --no-verify -m x`, `xargs -0 git commit --no-verify`, `env FOO=1 git commit -n -m x`, `eval 'git commit --no-verify -m x'`, `node /tmp/cli.js "data" && git commit --no-verify -m x`, `echo 'git commit --no-verify' ; git push --no-verify`

## Why This Change
Fixes #3023. `findGit()` accepted a `git` preceded by a quote character wherever it appeared, so `node /tmp/cli.js 'git commit --no-verify -m x'` (a CLI under test) and `printf '%s' 'git commit --no-verify -m x' | node /tmp/x.js` were blocked although nothing runs git. That made the guard hardest to work on, document or test exactly when doing so. The quote-before-git acceptance is still needed for `sh -c "git ..."`, so the fix keys on who receives the quoted string rather than dropping quoted matches altogether.

One case changes from allow to block as a side effect: `echo 'git commit --no-verify' ; git push --no-verify` was previously allowed, because the quoted `git commit` was inspected first, the stray quote derailed `findCommandSegmentEnd`, and the real `git push --no-verify` in the next segment was never reached. With the quoted occurrence skipped, the real one is found.

## Testing Done
- [x] Manual testing completed (the two reproducers from the issue plus the tables in the report)
- [x] Automated tests pass locally (`node tests/hooks/block-no-verify.test.js`: 31 passed, `node tests/hooks/cursor-block-no-verify.test.js`: 14 passed; the two new tests fail on `main`)
- [x] Edge cases considered and tested (wrappers, `VAR=value` prefix, chains after a quoted data argument, pipes)

## Type of Change
- [x] `fix:` Bug fix

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly (none changed)
- [x] Shell scripts pass shellcheck (if applicable) (none changed)
- [x] Pre-commit hooks pass locally (if configured) (`npx eslint` on the changed files)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format
