### PR TITLE
fix: serialize Claude tool-use round trips

### DIFF
--- a/src/llm/core/types.py
+++ b/src/llm/core/types.py
@@ -59,18 +59,18 @@ class Message:
             }
 
         if self.role == Role.ASSISTANT and self.tool_calls:
-            content: list[dict[str, Any]] = []
-            if self.content:
-                content.append({"type": "text", "text": self.content})
-            content.extend(
-                {
-                    "type": "tool_use",
-                    "id": tool_call.id,
-                    "name": tool_call.name,
-                    "input": tool_call.arguments,
-                }
-                for tool_call in self.tool_calls
-            )
+            content: list[dict[str, Any]] = [
+                *([{"type": "text", "text": self.content}] if self.content else []),
+                *(
+                    {
+                        "type": "tool_use",
+                        "id": tool_call.id,
+                        "name": tool_call.name,
+                        "input": tool_call.arguments,
+                    }
+                    for tool_call in self.tool_calls
+                ),
+            ]
             return {"role": Role.ASSISTANT.value, "content": content}
 
         return {"role": self.role.value, "content": self.content}

--- a/src/llm/core/types.py
+++ b/src/llm/core/types.py
@@ -44,6 +44,37 @@ class Message:
             ]
         return result
 
+    def to_anthropic_dict(self) -> dict[str, Any]:
+        """Serialize a message using the Anthropic Messages API format."""
+        if self.role == Role.TOOL:
+            return {
+                "role": Role.USER.value,
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": self.tool_call_id or "",
+                        "content": self.content,
+                    }
+                ],
+            }
+
+        if self.role == Role.ASSISTANT and self.tool_calls:
+            content: list[dict[str, Any]] = []
+            if self.content:
+                content.append({"type": "text", "text": self.content})
+            content.extend(
+                {
+                    "type": "tool_use",
+                    "id": tool_call.id,
+                    "name": tool_call.name,
+                    "input": tool_call.arguments,
+                }
+                for tool_call in self.tool_calls
+            )
+            return {"role": Role.ASSISTANT.value, "content": content}
+
+        return {"role": self.role.value, "content": self.content}
+
 
 @dataclass(frozen=True)
 class ToolDefinition:

--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -64,13 +64,18 @@ class ClaudeProvider(LLMProvider):
                 if message.role == Role.SYSTEM:
                     continue
                 serialized = message.to_anthropic_dict()
-                if (
+                merges_with_previous = (
                     message.role == Role.TOOL
-                    and api_messages
+                    and bool(api_messages)
                     and api_messages[-1]["role"] == Role.USER.value
                     and isinstance(api_messages[-1]["content"], list)
-                ):
-                    api_messages[-1]["content"].extend(serialized["content"])
+                )
+                if merges_with_previous:
+                    previous = api_messages[-1]
+                    api_messages[-1] = {
+                        **previous,
+                        "content": [*previous["content"], *serialized["content"]],
+                    }
                 else:
                     api_messages.append(serialized)
 

--- a/src/llm/providers/claude.py
+++ b/src/llm/providers/claude.py
@@ -59,9 +59,20 @@ class ClaudeProvider(LLMProvider):
         try:
             model = input.model or _DEFAULT_MODEL
             system_parts = [msg.content for msg in input.messages if msg.role == Role.SYSTEM]
-            api_messages = [
-                msg.to_dict() for msg in input.messages if msg.role not in (Role.SYSTEM,)
-            ]
+            api_messages: list[dict[str, Any]] = []
+            for message in input.messages:
+                if message.role == Role.SYSTEM:
+                    continue
+                serialized = message.to_anthropic_dict()
+                if (
+                    message.role == Role.TOOL
+                    and api_messages
+                    and api_messages[-1]["role"] == Role.USER.value
+                    and isinstance(api_messages[-1]["content"], list)
+                ):
+                    api_messages[-1]["content"].extend(serialized["content"])
+                else:
+                    api_messages.append(serialized)
 
             params: dict[str, Any] = {
                 "model": model,

--- a/tests/test_claude_provider.py
+++ b/tests/test_claude_provider.py
@@ -94,7 +94,10 @@ def test_generate_serializes_tool_round_trip_for_anthropic() -> None:
                 Message(
                     role=Role.ASSISTANT,
                     content="",
-                    tool_calls=[ToolCall(id="toolu_1", name="search", arguments={"query": "claude"})],
+                    tool_calls=[
+                        ToolCall(id="toolu_1", name="search", arguments={"query": "claude"}),
+                        ToolCall(id="toolu_2", name="read", arguments={"path": "README.md"}),
+                    ],
                 ),
                 Message(role=Role.TOOL, content="results", tool_call_id="toolu_1"),
                 Message(role=Role.TOOL, content="more results", tool_call_id="toolu_2"),
@@ -112,7 +115,13 @@ def test_generate_serializes_tool_round_trip_for_anthropic() -> None:
                     "id": "toolu_1",
                     "name": "search",
                     "input": {"query": "claude"},
-                }
+                },
+                {
+                    "type": "tool_use",
+                    "id": "toolu_2",
+                    "name": "read",
+                    "input": {"path": "README.md"},
+                },
             ],
         },
         {

--- a/tests/test_claude_provider.py
+++ b/tests/test_claude_provider.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pytest
 
-from llm.core.types import LLMInput, Message, Role
+from llm.core.types import LLMInput, Message, Role, ToolCall
 from llm.providers.claude import ClaudeProvider
 
 
@@ -81,6 +81,48 @@ def test_generate_collects_multiple_tool_use_blocks() -> None:
     assert output.content == ""
     assert [call.id for call in output.tool_calls or []] == ["toolu_1", "toolu_2"]
     assert (output.tool_calls or [])[1].arguments == {"path": "README.md"}
+
+
+@pytest.mark.unit
+def test_generate_serializes_tool_round_trip_for_anthropic() -> None:
+    provider = make_provider(make_response([SimpleNamespace(type="text", text="Done.")], stop_reason="end_turn"))
+
+    provider.generate(
+        LLMInput(
+            messages=[
+                Message(role=Role.USER, content="Search"),
+                Message(
+                    role=Role.ASSISTANT,
+                    content="",
+                    tool_calls=[ToolCall(id="toolu_1", name="search", arguments={"query": "claude"})],
+                ),
+                Message(role=Role.TOOL, content="results", tool_call_id="toolu_1"),
+                Message(role=Role.TOOL, content="more results", tool_call_id="toolu_2"),
+            ]
+        )
+    )
+
+    assert provider.client.messages.last_params["messages"] == [
+        {"role": "user", "content": "Search"},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "search",
+                    "input": {"query": "claude"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_1", "content": "results"},
+                {"type": "tool_result", "tool_use_id": "toolu_2", "content": "more results"},
+            ],
+        },
+    ]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- serialize assistant tool calls as Anthropic `tool_use` content blocks
- serialize tool results as `tool_result` blocks in a user turn and group consecutive results
- add regression coverage for a Claude tool-use round trip

This fixes the existing `ReActAgent` history path, which currently sends OpenAI-shaped `role: tool` / `tool_calls` messages to the Anthropic Messages API.

Closes #3056

## Testing

- `python3 -m ruff check src/llm tests/test_claude_provider.py`
- `PYTHONPATH=src python3 -m pytest` (96 passed)
