### PR TITLE
docs: move Atlas Cloud to past sponsors

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,12 @@ The native path installs ECC's skills, agents, commands, and plugin-managed hook
 <p align="center" aria-label="Partners and sponsors">
   <a href="https://www.coderabbit.ai" title="CodeRabbit"><img src="assets/images/sponsors/coderabbit.png" height="54" alt="CodeRabbit" /></a>&nbsp;&nbsp;&nbsp;
   <a href="https://www.greptile.com/go/ecc" title="Greptile"><img src="assets/images/sponsors/greptile.png" height="54" alt="Greptile" /></a>&nbsp;&nbsp;&nbsp;
-  <a href="https://www.atlascloud.ai/?utm_source=github&amp;utm_medium=link&amp;utm_campaign=ECC" title="Atlas Cloud"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/images/sponsors/atlascloud-dark.svg" /><img src="assets/images/sponsors/atlascloud.svg" width="154" alt="Atlas Cloud" /></picture></a>&nbsp;&nbsp;&nbsp;
   <a href="https://platform.kimi.ai?aff=ecc" title="Moonshot AI - Kimi"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/images/sponsors/moonshot-dark.png" /><img src="assets/images/sponsors/moonshot.png" width="132" alt="Moonshot AI - Kimi" /></picture></a>&nbsp;&nbsp;&nbsp;
   <a href="https://compute.itomarkets.com" title="Itô Markets"><picture><source media="(prefers-color-scheme: light)" srcset="assets/images/sponsors/ito-transparent-light.png" /><img src="assets/images/sponsors/ito-transparent.png" width="96" alt="Itô Markets" /></picture></a>
 </p>
 
-<sub><strong>Community sponsors:</strong> <a href="https://github.com/mikejmorgan-ai">Mike Morgan</a> · <a href="https://github.com/jasonwu513">@jasonwu513</a> · <a href="https://github.com/1anter">@1anter</a> · <a href="https://github.com/massimotodaro">@massimotodaro</a> · <a href="https://github.com/meadmccabe">@meadmccabe</a></sub>
+<sub><strong>Community sponsors:</strong> <a href="https://github.com/mikejmorgan-ai">Mike Morgan (inactive)</a> · <a href="https://github.com/jasonwu513">@jasonwu513</a> · <a href="https://github.com/1anter">@1anter</a> · <a href="https://github.com/massimotodaro">@massimotodaro</a> · <a href="https://github.com/meadmccabe">@meadmccabe</a></sub>
+<sub><strong>Past sponsors:</strong> <a href="https://www.atlascloud.ai/?utm_source=github&amp;utm_medium=link&amp;utm_campaign=ECC">Atlas Cloud</a></sub>
 
 <sub><a href="https://github.com/sponsors/affaan-m"><strong>Become a Sponsor</strong></a> · <a href="SPONSORS.md">Sponsor Tiers</a> · <a href="SPONSORING.md">Sponsorship Program</a></sub>
 
@@ -827,6 +827,7 @@ It's harness- and model-agnostic: a plain CLI (`ecc-plan-canvas`) speaking JSON,
 - **Kimi Code install target** (`--target kimi`): ECC installs natively into [Moonshot AI](https://www.moonshot.ai)'s Kimi Code CLI
 - **Self-host on GPUs**: a verified path with [Itô](https://compute.itomarkets.com), ECC's preferred compute sponsor, including the opt-in `ecc ito find` RFQ bridge (details and disclosures above in [Self-Hosted Models and Custom Endpoints](#self-hosted-models-and-custom-endpoints))
 - **Moonshot AI (Kimi), Itô, and Atlas Cloud** are now public sponsors
+- **Historical note (2026-09-10):** Atlas Cloud was a past sponsor during the 2.1 release period and is no longer a current sponsor.
 - **Hermes + OpenClaw install targets**, a Codex navigation guide, consolidated PostToolUse hooks, and supply-chain hardening
 
 ### Current development: Unified Memory Vault

--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -12,7 +12,6 @@ Thank you to everyone funding ECC's open-source work. Your sponsorship is what l
 |---------|------|-------|
 | [**CodeRabbit**](https://www.coderabbit.ai) | <img src="assets/images/sponsors/coderabbit.png" width="60" alt="CodeRabbit logo" /> | 2026 |
 | [**Greptile**](https://www.greptile.com/go/ecc) | <img src="assets/images/sponsors/greptile.png" width="60" alt="Greptile logo" /> | 2026 |
-| [**Atlas Cloud**](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=ECC) | <picture><source media="(prefers-color-scheme: dark)" srcset="assets/images/sponsors/atlascloud-dark.svg" /><img src="assets/images/sponsors/atlascloud.svg" width="120" alt="Atlas Cloud logo" /></picture> | 2026 |
 | [**Moonshot AI (Kimi)**](https://www.moonshot.ai) | <picture><source media="(prefers-color-scheme: dark)" srcset="assets/images/sponsors/moonshot-dark.png" /><img src="assets/images/sponsors/moonshot.png" width="100" alt="Moonshot AI Kimi logo" /></picture> | 2026 |
 | [**Itô**](https://compute.itomarkets.com) | <picture><source media="(prefers-color-scheme: light)" srcset="assets/images/sponsors/ito-transparent-light.png" /><img src="assets/images/sponsors/ito-transparent.png" width="88" alt="Itô Markets logo" /></picture> | 2026 |
 
@@ -24,9 +23,15 @@ Run or self-host any open-source model. Itô partners with ECC on compute, while
 
 | Sponsor | Since |
 |---------|-------|
-| [Mike Morgan](https://github.com/mikejmorgan-ai) | 2026 |
 
 *[Become a Team sponsor](https://github.com/sponsors/affaan-m) to be listed in SPONSORS.md.*
+
+## Past Sponsors
+
+| Sponsor | Logo or tier | Since | Status |
+|---------|--------------|-------|--------|
+| [**Atlas Cloud**](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=ECC) | <picture><source media="(prefers-color-scheme: dark)" srcset="assets/images/sponsors/atlascloud-dark.svg" /><img src="assets/images/sponsors/atlascloud.svg" width="120" alt="Atlas Cloud logo" /></picture> | 2026 | Past sponsor |
+| [Mike Morgan](https://github.com/mikejmorgan-ai) | Team sponsor | 2026 | Inactive |
 
 ## Pro Sponsors — $50/mo
 

--- a/docs/ATLAS-CLOUD-GUIDE.md
+++ b/docs/ATLAS-CLOUD-GUIDE.md
@@ -1,5 +1,7 @@
 # Atlas Cloud — LLM Provider Guide
 
+> Historical sponsor note (2026-09-10): Atlas Cloud is a past sponsor. The provider integration remains valid.
+
 [Atlas Cloud](https://www.atlascloud.ai/?utm_source=github&utm_medium=link&utm_campaign=everything-claude-code) is a full-modal AI inference platform providing an OpenAI-compatible API for 59+ LLM models, image generation, and video generation.
 
 > Run or self-host any open-source model instead of using a managed API. Itô is ECC's preferred compute sponsor: [open the Itô dashboard to sign in and rent or manage GPUs](https://compute.itomarkets.com). Any GPU provider works. That sponsorship link is passive: it does not invoke an RFQ, reserve capacity, provision compute, or configure serving. Separately, the opt-in `ecc ito find` bridge invokes the explicitly configured canonical Itô CLI and submits a live authenticated RFQ; it does not reserve capacity. Managed inference through Itô is not live yet.

--- a/docs/uk-UA/README.md
+++ b/docs/uk-UA/README.md
@@ -103,12 +103,12 @@
 <p align="center" aria-label="Партнери та спонсори">
   <a href="https://www.coderabbit.ai" title="CodeRabbit"><img src="../../assets/images/sponsors/coderabbit.png" height="54" alt="CodeRabbit" /></a>&nbsp;&nbsp;&nbsp;
   <a href="https://www.greptile.com/go/ecc" title="Greptile"><img src="../../assets/images/sponsors/greptile.png" height="54" alt="Greptile" /></a>&nbsp;&nbsp;&nbsp;
-  <a href="https://www.atlascloud.ai/?utm_source=github&amp;utm_medium=link&amp;utm_campaign=ECC" title="Atlas Cloud"><picture><source media="(prefers-color-scheme: dark)" srcset="../../assets/images/sponsors/atlascloud-dark.svg" /><img src="../../assets/images/sponsors/atlascloud.svg" width="154" alt="Atlas Cloud" /></picture></a>&nbsp;&nbsp;&nbsp;
   <a href="https://www.moonshot.ai" title="Moonshot AI - Kimi"><picture><source media="(prefers-color-scheme: dark)" srcset="../../assets/images/sponsors/moonshot-dark.png" /><img src="../../assets/images/sponsors/moonshot.png" width="132" alt="Moonshot AI - Kimi" /></picture></a>&nbsp;&nbsp;&nbsp;
   <a href="https://compute.itomarkets.com" title="Itô Markets"><picture><source media="(prefers-color-scheme: light)" srcset="../../assets/images/sponsors/ito-transparent-light.png" /><img src="../../assets/images/sponsors/ito-transparent.png" width="96" alt="Itô Markets" /></picture></a>
 </p>
 
-<sub><strong>Спонсори спільноти:</strong> <a href="https://github.com/mikejmorgan-ai">Mike Morgan</a> · <a href="https://github.com/jasonwu513">@jasonwu513</a> · <a href="https://github.com/1anter">@1anter</a> · <a href="https://github.com/massimotodaro">@massimotodaro</a> · <a href="https://github.com/meadmccabe">@meadmccabe</a></sub>
+<sub><strong>Спонсори спільноти:</strong> <a href="https://github.com/mikejmorgan-ai">Mike Morgan (неактивний)</a> · <a href="https://github.com/jasonwu513">@jasonwu513</a> · <a href="https://github.com/1anter">@1anter</a> · <a href="https://github.com/massimotodaro">@massimotodaro</a> · <a href="https://github.com/meadmccabe">@meadmccabe</a></sub>
+<sub><strong>Минулі спонсори:</strong> <a href="https://www.atlascloud.ai/?utm_source=github&amp;utm_medium=link&amp;utm_campaign=ECC">Atlas Cloud</a></sub>
 
 <sub><a href="https://github.com/sponsors/affaan-m"><strong>Стати спонсором</strong></a> · <a href="../../SPONSORS.md">Рівні спонсорства</a> · <a href="../../SPONSORING.md">Програма спонсорства</a></sub>
 
@@ -735,6 +735,7 @@ ECC також постачає розширені керовані адапте
 - **Ціль встановлення Kimi Code** (`--target kimi`): ECC встановлюється нативно в Kimi Code CLI від [Moonshot AI](https://www.moonshot.ai)
 - **Самостійний хостинг на GPU**: перевірений шлях з [Itô](https://compute.itomarkets.com), бажаним обчислювальним спонсором ECC, включно з опційним мостом RFQ `ecc ito find` (деталі та розкриття вище в опціях встановлення)
 - **Moonshot AI (Kimi), Itô та Atlas Cloud** тепер публічні спонсори
+- **Історична примітка (2026-09-10):** Atlas Cloud був минулим спонсором у період випуску 2.1 і більше не є поточним спонсором. Інтеграція провайдера залишається чинною.
 - **Цілі встановлення Hermes + OpenClaw**, посібник з навігації Codex, консолідовані хуки PostToolUse та зміцнення ланцюжка поставок
 
 ### Поточна розробка: Уніфікованe сховище пам'яті

--- a/tests/scripts/ito-compute-sponsor.test.js
+++ b/tests/scripts/ito-compute-sponsor.test.js
@@ -372,8 +372,44 @@ function main() {
       assert.doesNotMatch(sponsors, /sixtytwo|sixty.?two/i);
       assertExactComputeRoute(sponsors);
     }],
+    ['sponsor cleanup separates current and past sponsors in both README locales', () => {
+      const readme = read('README.md');
+      const ukrainianReadme = read('docs/uk-UA/README.md');
+      const sponsors = read('SPONSORS.md');
+
+      const currentEnglish = readme.slice(
+        readme.indexOf('<sub><strong>Partners &amp; sponsors</strong></sub>'),
+        readme.indexOf('<sub><strong>Community sponsors:</strong>')
+      );
+      const currentUkrainian = ukrainianReadme.slice(
+        ukrainianReadme.indexOf('<sub><strong>Партнери та спонсори</strong></sub>'),
+        ukrainianReadme.indexOf('<sub><strong>Спонсори спільноти:</strong>')
+      );
+      const currentBusiness = sponsors.slice(
+        sponsors.indexOf('## Business Sponsors'),
+        sponsors.indexOf('## Team Sponsors')
+      );
+
+      assert.doesNotMatch(currentEnglish, /Atlas Cloud|atlascloud/i);
+      assert.doesNotMatch(currentUkrainian, /Atlas Cloud|atlascloud/i);
+      assert.doesNotMatch(currentBusiness, /Atlas Cloud|atlascloud/i);
+      assert.match(readme, /Past sponsors:.*Atlas Cloud/);
+      assert.match(sponsors, /## Past Sponsors/);
+      assert.match(sponsors, /Atlas Cloud/);
+      assert.match(sponsors, /Mike Morgan.*inactive/i);
+      assert.match(readme, /Historical note[^\n]*Atlas Cloud was a past sponsor/);
+      assert.match(
+        ukrainianReadme,
+        /Історична примітка[^\n]*Atlas Cloud був минулим спонсором/
+      );
+    }],
     ['inference guide distinguishes rental compute from managed serving', () => {
-      assertHonestComputeCopy(read('docs/ATLAS-CLOUD-GUIDE.md'));
+      const guide = read('docs/ATLAS-CLOUD-GUIDE.md');
+      assert.match(
+        guide,
+        /^# Atlas Cloud[\s\S]*> Historical sponsor note \(2026-09-10\): Atlas Cloud is a past sponsor\. The provider integration remains valid\./
+      );
+      assertHonestComputeCopy(guide);
     }],
     ['harness docs route generic open-source model intent without lock-in', () => {
       assertHonestComputeCopy(read('.claude-plugin/README.md'));


### PR DESCRIPTION
## Summary
- Move Atlas Cloud from current sponsor placement to a dated past-sponsor line in the English and Ukrainian READMEs.
- Move Atlas Cloud to `Past Sponsors` in `SPONSORS.md` and mark Mike Morgan inactive.
- Preserve the English 2.1 historical note and `docs/releases/2.1.0/release-notes.md`; add a dated historical clarification mirrored in Ukrainian.
- Add a first-line provider guide note that the past sponsorship does not invalidate the Atlas Cloud integration.
- Leave Atlas assets and provider implementation files unchanged.

## Audit coverage
- Current business sponsors remain CodeRabbit, Greptile, Moonshot AI (Kimi), and Itô.
- Checked `docs/ja-JP/README.md` and `docs/zh-CN/README.md`: no Atlas Cloud hits.
- Checked the listed historical worktrees: their root READMEs contain historical Atlas references, while their `docs/ja-JP/README.md` and `docs/zh-CN/README.md` copies have no Atlas hits. No unrelated worktree was edited.
- No asset or provider code changes.

## Rendered previews at exact head
- [English README](https://github.com/affaan-m/ECC/blob/7c1df74a/README.md)
- [Ukrainian README](https://github.com/affaan-m/ECC/blob/7c1df74a/docs/uk-UA/README.md)
- [Sponsor roster](https://github.com/affaan-m/ECC/blob/7c1df74a/SPONSORS.md)
- [Atlas Cloud provider guide](https://github.com/affaan-m/ECC/blob/7c1df74a/docs/ATLAS-CLOUD-GUIDE.md)
- [Sponsor test](https://github.com/affaan-m/ECC/blob/7c1df74a/tests/scripts/ito-compute-sponsor.test.js)

## Tests
- `node tests/scripts/ito-compute-sponsor.test.js` PASS, 14 passed, 0 failed
- `npm run lint` PASS
- `npm test` completed with 4,391 passed and 5 unrelated pre-existing failures in `lib/state-store.test.js` and `scripts/setup.test.js`; no sponsor test failure
- `git diff --check` PASS

## Rollback
Revert commit `7c1df74a` if the sponsor copy needs to be restored. This PR does not modify assets, provider code, deployment configuration, or release history.
