### PR TITLE
fix(deps): patch lru RustSec advisory

### DIFF
--- a/ecc2/Cargo.lock
+++ b/ecc2/Cargo.lock
@@ -1231,9 +1231,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.18.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]


### PR DESCRIPTION
Carries forward #2926 from @aeonframework onto current `main`, preserving the original authored commit.

The useful core of #2926 is exact and bounded: `ecc2/Cargo.lock` moves `lru` from 0.18.0 to the RustSec-fixed 0.18.2 release for RUSTSEC-2026-0253. No manifest, source, workflow, generated-surface, or public-contract files change.

Verification before opening:
- current target: `928c1dea72f5c330442fc1f595563398b8f389f7`
- source head: `a37c1ace2ad0a027e7b12f2188feb25d34a4ca0c`
- integration commit: `94e8ca9ea6897b766dc3294afa7ae3f21fe5865d`
- `git diff --check`: pass
- official advisory: https://rustsec.org/advisories/RUSTSEC-2026-0253.html

Local Rust execution was unavailable in this environment, so this PR must remain gated on the repository CI and security checks for this exact integration head. It will not merge while the exact target-branch CI rerun is pending.

Source credit: #2926.