### PR TITLE
fix(memory-mcp): accept reserved _meta on ping

### DIFF
--- a/scripts/memory-mcp.mjs
+++ b/scripts/memory-mcp.mjs
@@ -426,8 +426,18 @@ function createMemoryMcpService(options = {}) {
         return jsonRpcError(message.id, -32002, 'Server is not initialized.');
       }
       if (message.method === 'ping') {
-        if (message.params && Object.keys(message.params).length > 0) {
-          return jsonRpcError(message.id, -32602, 'ping does not accept parameters.');
+        const params = message.params ?? {};
+        // `_meta` is reserved by MCP for request metadata (e.g. progressToken) and
+        // may ride on any request, which is why `tools/list` and `tools/call` below
+        // both admit it. `ping` rejected every parameter, so a client that attaches
+        // `_meta` to everything — Codex does — got -32602 on its keepalive. Present
+        // means it must be a metadata object; nothing else is accepted. (#2810)
+        if (
+          !isRecord(params)
+          || (Object.prototype.hasOwnProperty.call(params, '_meta') && !isRecord(params._meta))
+          || Object.keys(params).some(key => key !== '_meta')
+        ) {
+          return jsonRpcError(message.id, -32602, 'ping accepts no parameters other than _meta.');
         }
         return jsonRpcResult(message.id, {});
       }

--- a/tests/scripts/memory-mcp.test.js
+++ b/tests/scripts/memory-mcp.test.js
@@ -260,6 +260,7 @@ async function withClient(fn, options = {}) {
         { name, arguments: toolArguments }
       ),
       callToolRaw: params => request('tools/call', params),
+      ping: params => request('ping', params),
     };
     phase = 'callback';
     await Promise.race([Promise.resolve().then(() => fn(client, fixture)), transportFailure]);
@@ -390,6 +391,25 @@ async function main() {
         client.listToolsRaw({ unexpected: true }),
         /-32602/
       );
+    });
+  });
+
+  await test('accepts the reserved _meta param on ping and rejects malformed values (#2810)', async () => {
+    await withClient(async client => {
+      assert.deepStrictEqual(await client.ping({ _meta: { progressToken: 'progress-1' } }), {});
+      assert.deepStrictEqual(await client.ping(), {});
+      assert.deepStrictEqual(await client.ping({}), {});
+
+      for (const badMeta of [null, ['not', 'an', 'object'], 'string', 42, true]) {
+        await assert.rejects(
+          client.ping({ _meta: badMeta }),
+          /-32602/,
+          `expected ping _meta=${JSON.stringify(badMeta)} to be rejected`
+        );
+      }
+
+      await assert.rejects(client.ping({ unexpected: true }), /-32602/);
+      await assert.rejects(client.ping({ _meta: {}, unexpected: true }), /-32602/);
     });
   });
 


### PR DESCRIPTION
Carries the useful core of #2880 from @ntdat812 onto exact current `main`, preserving the original author and commit message.

Current `main` already accepts object-valued `_meta` on `tools/list` and `tools/call`, but its `ping` handler still rejects every non-empty params object. This integration keeps #2880 as the canonical source because it is the older focused submission and covers accepted, malformed, and unrelated inputs. #2918 independently reports the same gap and remains open until the canonical behavior is verified on green `main`.

The source test file had changed substantially on current `main`, so the test hunk was adapted to the current bounded-transport harness without changing the requested protocol behavior.

Verification on integration commit `2cb1e29de379f1a346fba45c1ab5437fe9adb9a3`:
- `node tests/scripts/memory-mcp.test.js`: 14 passed, 0 failed
- `git diff --check origin/main...HEAD`: pass
- changed surface: `scripts/memory-mcp.mjs` and its focused test only

Roadmap route: ECC 2.2 trustworthy multi-harness substrate, MCP transport compatibility and evidence. This does not change context-profile, capability, sandbox, or canonical-state authority.

Source credit: #2880. Related duplicate signal: #2918.