### PR TITLE
docs: synchronize README skill tree count

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,7 +794,7 @@ Stable graduation of the 2.0 line: control-pane substrate, worktree lifecycle se
 ```text
 ECC/
 |-- agents/           # 68 specialized subagents for delegation
-|-- skills/           # 284 reusable workflows loaded on demand
+|-- skills/           # 291 reusable workflows loaded on demand
 |-- commands/         # 94 maintained slash-command shims
 |-- rules/            # opt-in common and language standards
 |-- hooks/            # runtime automation and enforcement


### PR DESCRIPTION
Carries the still-current documentation defect identified in #2944 by @NICKSTER0506 onto exact current `main`.

The useful finding remains valid: the README component tree still says 284 skills while the live catalog and other authoritative README surfaces say 291. The original numeric patch to 286 is now stale, so this integration updates the tree to 291. It intentionally retains “94 legacy command shims” in the summary because commands are the compatibility layer during the skills-first transition; changing that term would create competing documentation authority.

Verification on integration head `1ab2132d268f61a5b0d3732db4e6bd9fb90c1d13`:
- `npm run catalog:check`: 68 agents, 94 commands, 291 skills; documentation matches
- `npx --no-install markdownlint-cli2 README.md`: 0 issues
- `git diff --check`: pass

Roadmap route: ECC 2.2 truthful multi-harness distribution documentation and catalog evidence. No context-profile, capability, sandbox, or execution contract changes.

Source credit and co-authorship: #2944.