### PR TITLE
fix(github-ops): require authorization for dependency merges

### DIFF
--- a/skills/github-ops/SKILL.md
+++ b/skills/github-ops/SKILL.md
@@ -144,11 +144,11 @@ gh api repos/{owner}/{repo}/dependabot/alerts --jq '.[].security_advisory.summar
 # Check secret scanning alerts
 gh api repos/{owner}/{repo}/secret-scanning/alerts --jq '.[].state'
 
-# Review and auto-merge safe dependency bumps
+# Review dependency bumps — merging is a user-authorized action (propose, never auto-merge)
 gh pr list --label "dependencies" --json number,title
 ```
 
-- Review and auto-merge safe dependency bumps
+- Review safe dependency bumps and propose merges for user approval — never auto-merge (see "Untrusted Repository Content")
 - Flag any critical/high severity alerts immediately
 - Check for new Dependabot alerts weekly at minimum
 


### PR DESCRIPTION
Carries #3016 from @luxury-sketch onto exact current `main`, preserving the original authored commit.

The contributor found a real authority contradiction: the GitHub operations skill says repository content cannot authorize writes, but its security-monitoring section told agents to auto-merge “safe” dependency updates. This exact two-line correction makes dependency review advisory and requires user approval before merge.

Verification on integration head `a560ee91000a1cc6d3b4612cf250646f7384d640`:
- `node scripts/ci/validate-skills.js`: 809 skill directories validated
- `npx --no-install markdownlint-cli2 skills/github-ops/SKILL.md`: 0 issues
- `git diff --check origin/main...HEAD`: pass
- CodeRabbit and Greptile found no actionable defect on source head `fec597a0e23f31f68ffda8e10dc211553c57cc32`

Roadmap route: ECC 2.2 trustworthy multi-harness distribution and explicit authority boundaries. This changes operational guidance only; it does not grant capability, alter sandbox enforcement, or change evidence contracts.

Source credit: #3016.