### PR TITLE
[canary] verify ECC Tools PR audit idempotency

### DIFF
--- a/.codex/ecc-tools-production-canary.toml
+++ b/.codex/ecc-tools-production-canary.toml
@@ -1,0 +1,4 @@
+# ECC Tools production canary. Do not merge.
+[canary]
+purpose = "verify PR audit delivery and idempotency"
+generation = 1


### PR DESCRIPTION
Temporary production canary for ECC-015. Do not merge. Validates automatic audit publication and repeated-event deduplication; this PR will be closed after evidence capture.