### PR TITLE
fix(hooks): block-no-verify - stuck optional values and long-option prefixes

### DIFF
--- a/scripts/hooks/block-no-verify.js
+++ b/scripts/hooks/block-no-verify.js
@@ -78,6 +78,10 @@ const COMMIT_OPTIONS_WITH_INLINE_VALUE = [
 // must stop at this character — anything after it is the inline value,
 // not another flag.
 const COMMIT_SHORT_OPTIONS_WITH_VALUE = new Set(['m', 'F', 'C', 'c', 't']);
+// Short options whose value is OPTIONAL and must be stuck to the flag
+// (`-uno`, `-S<keyid>`). The rest of the cluster is that value, so an `n`
+// after them is not the -n flag: `git commit -uno` means --untracked-files=no.
+const COMMIT_SHORT_OPTIONS_WITH_OPTIONAL_VALUE = new Set(['u', 'S']);
 
 function tokenizeShellWords(input, start = 0, end = input.length) {
   const tokens = [];
@@ -264,6 +268,7 @@ function isCommitNoVerifyShortFlag(value) {
     const option = options.charAt(i);
     if (option === 'n') return true;
     if (COMMIT_SHORT_OPTIONS_WITH_VALUE.has(option)) return false;
+    if (COMMIT_SHORT_OPTIONS_WITH_OPTIONAL_VALUE.has(option)) return false;
   }
 
   return false;
@@ -389,6 +394,16 @@ function detectGitCommand(input, start = 0) {
 }
 
 /**
+ * git's option parser accepts any unambiguous prefix of a long option, so
+ * `--no-veri` and `--no-verif` run as --no-verify. Shorter prefixes such as
+ * `--no-ver` are ambiguous with --no-verbose and git rejects them itself, so
+ * refusing every prefix from `--no-v` up blocks nothing that would have run.
+ */
+function isNoVerifyLongFlag(value) {
+  return value.length >= '--no-v'.length && '--no-verify'.startsWith(value);
+}
+
+/**
  * Check if the input contains a --no-verify flag for a specific git command.
  * Only inspects the portion of the input starting at `offset` (the position
  * right after the detected subcommand keyword) so that flags belonging to
@@ -422,7 +437,7 @@ function hasNoVerifyFlag(input, command, offset) {
       }
     }
 
-    if (value === '--no-verify') return true;
+    if (isNoVerifyLongFlag(value)) return true;
 
     // For commit, -n is shorthand for --no-verify.
     if (command === 'commit' && isCommitNoVerifyShortFlag(value)) {

--- a/tests/hooks/block-no-verify.test.js
+++ b/tests/hooks/block-no-verify.test.js
@@ -219,6 +219,38 @@ if (test('still allows -tn (n is the -t template path, not a flag)', () => {
   assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
 })) passed++; else failed++;
 
+// --- Optional stuck values (-u, -S) and long-option prefixes ---
+
+if (test('allows -uno (n is the -u untracked-files mode, not a flag)', () => {
+  const r = runHook({ tool_input: { command: 'git commit -uno -m "msg"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('allows -Sn (n is the -S key id, not a flag)', () => {
+  const r = runHook({ tool_input: { command: 'git commit -Sn -m "msg"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
+if (test('still blocks -nu (n comes before the optional-value flag)', () => {
+  const r = runHook({ tool_input: { command: 'git commit -nu -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-veri (git accepts unambiguous long-option prefixes)', () => {
+  const r = runHook({ tool_input: { command: 'git commit --no-veri -m "msg"' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('blocks --no-verif on git push', () => {
+  const r = runHook({ tool_input: { command: 'git push --no-verif origin main' } });
+  assert.strictEqual(r.code, 2, `expected exit 2, got ${r.code}`);
+})) passed++; else failed++;
+
+if (test('allows --no-verbose (not a prefix of --no-verify)', () => {
+  const r = runHook({ tool_input: { command: 'git commit --no-verbose -m "msg"' } });
+  assert.strictEqual(r.code, 0, `expected exit 0, got ${r.code}: ${r.stderr}`);
+})) passed++; else failed++;
+
 console.log('─'.repeat(50));
 console.log(`Passed: ${passed}  Failed: ${failed}`);
 


### PR DESCRIPTION
## Summary

Two cases `block-no-verify` still gets wrong after the word-level rewrite (#2668 and the two before it):

| Command | Before | After | Why |
|---|---|---|---|
| `git commit -uno -m x` | blocked | allowed | `-u[<mode>]` takes an optional stuck value; `-uno` is `--untracked-files=no` |
| `git commit -Sn -m x` | blocked | allowed | `-S[<keyid>]`, same rule; `n` is the key id |
| `git commit -nu -m x` | blocked | blocked | `n` comes before the optional-value flag |
| `git commit --no-veri -m x` | allowed | blocked | git accepts any unambiguous long-option prefix |
| `git push --no-verif origin main` | allowed | blocked | same |
| `git commit --no-verbose -m x` | allowed | allowed | not a prefix of `--no-verify` |

Prefixes shorter than `--no-veri` (such as `--no-ver`) are ambiguous with `--no-verbose`, so git rejects them itself. Refusing every prefix from `--no-v` up therefore blocks nothing that would have run.

## Test plan

- `node tests/hooks/block-no-verify.test.js`: 35/35 pass, with 6 new cases.
- Red control: with the test file applied and the hook reverted, 4 of the new cases fail (`-uno`, `-Sn`, `--no-veri`, `--no-verif` on push).
- `node scripts/ci/check-unicode-safety.js`: exit 0.

We found these while vendoring the hook into our own dotfiles. We also block the environment spellings there: `HUSKY=0`, `GIT_CONFIG_KEY_<n>=core.hooksPath`, and a persistent `git config core.hooksPath`, all judged by value. Happy to send those as a follow-up if you want them here.
