### PR TITLE
fix(cursor): make user-home hook installs path-safe

### DIFF
--- a/.cursor/hooks/adapter.js
+++ b/.cursor/hooks/adapter.js
@@ -6,6 +6,7 @@
  */
 
 const { execFileSync } = require('child_process');
+const fs = require('fs');
 const path = require('path');
 
 const MAX_STDIN = 1024 * 1024;
@@ -22,7 +23,18 @@ function readStdin() {
 }
 
 function getPluginRoot() {
-  return path.resolve(__dirname, '..', '..');
+  // User install: ~/.cursor/hooks → ~/.cursor (scripts live next to hooks/)
+  // Project/repo: <root>/.cursor/hooks → <root> (scripts live at repo root)
+  const candidates = [
+    path.resolve(__dirname, '..'),
+    path.resolve(__dirname, '..', '..'),
+  ];
+  for (const root of candidates) {
+    if (fs.existsSync(path.join(root, 'scripts', 'hooks'))) {
+      return root;
+    }
+  }
+  return candidates[candidates.length - 1];
 }
 
 function transformToClaude(cursorInput, overrides = {}) {

--- a/.cursor/hooks/before-shell-execution-block-no-verify.js
+++ b/.cursor/hooks/before-shell-execution-block-no-verify.js
@@ -20,8 +20,9 @@
 
 'use strict';
 
-const { readStdin, hookEnabled } = require('./adapter');
-const { run } = require('../../scripts/hooks/block-no-verify');
+const path = require('path');
+const { readStdin, hookEnabled, getPluginRoot } = require('./adapter');
+const { run } = require(path.join(getPluginRoot(), 'scripts', 'hooks', 'block-no-verify'));
 
 readStdin()
   .then(raw => {

--- a/.cursor/hooks/before-shell-execution.js
+++ b/.cursor/hooks/before-shell-execution.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-const { readStdin, hookEnabled } = require('./adapter');
-const { splitShellSegments } = require('../../scripts/lib/shell-split');
+const path = require('path');
+const { readStdin, hookEnabled, getPluginRoot } = require('./adapter');
+const { splitShellSegments } = require(path.join(getPluginRoot(), 'scripts', 'lib', 'shell-split'));
 
 readStdin()
   .then(raw => {

--- a/scripts/lib/install/apply.js
+++ b/scripts/lib/install/apply.js
@@ -36,19 +36,20 @@ const {
 const { cleanupLegacyOpencodeInstall } = require('./opencode-legacy-migration');
 const { buildInstallIndex, rewriteRelativeLinks } = require('./link-rewrite');
 const { adaptAntigravityAgent } = require('./antigravity-agent');
+const { rewriteCursorUserHooksJsonIfNeeded } = require('./cursor-hooks-json');
 
 function isMarkdownPath(filePath) {
   return /\.(md|mdx|markdown)$/i.test(String(filePath || ''));
 }
 
 function transformInstallContent(operation, content) {
-  if (!operation.contentTransform) {
-    return content;
-  }
+  let next = content;
   if (operation.contentTransform === 'antigravity-agent-frontmatter') {
-    return adaptAntigravityAgent(content, operation.sourceRelativePath);
+    next = adaptAntigravityAgent(content, operation.sourceRelativePath);
+  } else if (operation.contentTransform) {
+    throw new Error(`Unknown install content transform: ${operation.contentTransform}`);
   }
-  throw new Error(`Unknown install content transform: ${operation.contentTransform}`);
+  return rewriteCursorUserHooksJsonIfNeeded(operation, next);
 }
 
 // Map every copy-file operation to { sourceRel, destRel } so relative links in
@@ -562,12 +563,17 @@ function applyInstallPlanLocked(plan, dependencies = {}, settingsLockHeld = fals
 
       // Declared transforms are part of the install contract and always apply.
       // Markdown link rewriting is additive when the plan has a usable index.
+      // Cursor user-home hooks.json is always rewritten to ./hooks/ paths.
+      const needsCursorHooksRewrite = Boolean(
+        operation.kind === 'copy-file'
+        && /(?:^|[/\\])hooks\.json$/.test(String(operation.destinationPath || ''))
+      );
       const needsLinkRewrite = Boolean(
         linkIndex
         && operation.sourceRelativePath
         && isMarkdownPath(operation.destinationPath)
       );
-      if (operation.kind === 'copy-file' && (operation.contentTransform || needsLinkRewrite)) {
+      if (operation.kind === 'copy-file' && (operation.contentTransform || needsLinkRewrite || needsCursorHooksRewrite)) {
         const transformed = transformInstallContent(
           operation,
           fs.readFileSync(operation.sourcePath, 'utf8')

--- a/scripts/lib/install/cursor-hooks-json.js
+++ b/scripts/lib/install/cursor-hooks-json.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const os = require('os');
+const path = require('path');
+
+const PROJECT_HOOK_COMMAND_PREFIX = 'node .cursor/hooks/';
+const USER_HOOK_COMMAND_PREFIX = 'node ./hooks/';
+
+function resolveUserCursorHooksJsonPath(homeDir = os.homedir()) {
+  return path.resolve(homeDir, '.cursor', 'hooks.json');
+}
+
+function isUserCursorHooksJsonDestination(destinationPath, homeDir = os.homedir()) {
+  if (!destinationPath) {
+    return false;
+  }
+  return path.resolve(destinationPath) === resolveUserCursorHooksJsonPath(homeDir);
+}
+
+function rewriteCursorUserHooksJson(content) {
+  return String(content).split(PROJECT_HOOK_COMMAND_PREFIX).join(USER_HOOK_COMMAND_PREFIX);
+}
+
+function rewriteCursorUserHooksJsonIfNeeded(operation, content, homeDir = os.homedir()) {
+  if (!isUserCursorHooksJsonDestination(operation && operation.destinationPath, homeDir)) {
+    return content;
+  }
+  return rewriteCursorUserHooksJson(content);
+}
+
+module.exports = {
+  PROJECT_HOOK_COMMAND_PREFIX,
+  USER_HOOK_COMMAND_PREFIX,
+  resolveUserCursorHooksJsonPath,
+  isUserCursorHooksJsonDestination,
+  rewriteCursorUserHooksJson,
+  rewriteCursorUserHooksJsonIfNeeded,
+};

--- a/tests/scripts/cursor-hooks-json.test.js
+++ b/tests/scripts/cursor-hooks-json.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const assert = require('assert');
+const os = require('os');
+const path = require('path');
+
+const {
+  isUserCursorHooksJsonDestination,
+  rewriteCursorUserHooksJson,
+  rewriteCursorUserHooksJsonIfNeeded,
+} = require('../../scripts/lib/install/cursor-hooks-json');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    return false;
+  }
+}
+
+let passed = 0;
+let failed = 0;
+
+console.log('\ncursor user hooks.json rewrite tests');
+console.log('─'.repeat(50));
+
+if (test('rewrites project-style commands to user-style', () => {
+  const input = JSON.stringify({
+    hooks: {
+      sessionStart: [{ command: 'node .cursor/hooks/session-start.js' }],
+    },
+  }, null, 2);
+  const out = rewriteCursorUserHooksJson(input);
+  assert.ok(out.includes('node ./hooks/session-start.js'));
+  assert.ok(!out.includes('node .cursor/hooks/'));
+})) passed++; else failed++;
+
+if (test('only rewrites when destination is ~/.cursor/hooks.json', () => {
+  const home = '/tmp/ecc-home-test';
+  const content = 'node .cursor/hooks/session-start.js';
+  const projectDest = path.join(home, 'Workspace', 'app', '.cursor', 'hooks.json');
+  const userDest = path.join(home, '.cursor', 'hooks.json');
+
+  assert.strictEqual(
+    rewriteCursorUserHooksJsonIfNeeded({ destinationPath: projectDest }, content, home),
+    content
+  );
+  assert.strictEqual(
+    rewriteCursorUserHooksJsonIfNeeded({ destinationPath: userDest }, content, home),
+    'node ./hooks/session-start.js'
+  );
+  assert.strictEqual(isUserCursorHooksJsonDestination(userDest, home), true);
+  assert.strictEqual(isUserCursorHooksJsonDestination(projectDest, home), false);
+})) passed++; else failed++;
+
+if (test('detects real homedir destination', () => {
+  const dest = path.join(os.homedir(), '.cursor', 'hooks.json');
+  assert.strictEqual(isUserCursorHooksJsonDestination(dest), true);
+})) passed++; else failed++;
+
+console.log('─'.repeat(50));
+console.log(`passed=${passed} failed=${failed}`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary
- Make the Cursor hook adapter resolve `scripts/hooks` for both `~/.cursor` (user) and `<project>/.cursor` (project) layouts.
- Load shell-hook helpers via `getPluginRoot()` instead of hardcoded `../../scripts` paths.
- When installing into `~/.cursor/hooks.json`, rewrite `node .cursor/hooks/...` commands to `node ./hooks/...` so Cursor user hooks keep working after sync.

## Why
Installing ECC into `~/.cursor` flattens `.cursor/hooks` + `scripts` next to each other. Copying project-style paths unchanged makes every user hook fail with `MODULE_NOT_FOUND` / missing `.cursor/hooks/...`.

## Test plan
- [x] `node tests/hooks/cursor-block-no-verify.test.js`
- [x] `node tests/scripts/cursor-hooks-json.test.js`
- [ ] Install/sync into a temp `HOME/.cursor` and confirm `hooks.json` uses `node ./hooks/...`
- [ ] In Cursor Hooks output, confirm `beforeShellExecution` exits 0 (and blocks `--no-verify`)


Made with [Cursor](https://cursor.com)