### PR TITLE
docs: add explicit hook consent to OpenCode install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ cd ECC
 | Harness | Install or setup | Notes |
 |---|---|---|
 | Cursor | `./install.sh --profile minimal --target cursor` | Project-local `.cursor/` adapter |
-| OpenCode | `npm install && npm run build:opencode && ./install.sh --profile full --target opencode` | Builds the plugin payload before the full install |
+| OpenCode | `npm install && npm run build:opencode && ./install.sh --profile full --target opencode --enable-hooks` | Builds the plugin payload before the full install |
 | Gemini CLI | `./install.sh --profile minimal --target gemini` | Project-local `.gemini/` config |
 | Zed | `./install.sh --profile minimal --target zed` | Project-local `.zed/` adapter |
 | Antigravity | `./install.sh --profile minimal --target antigravity` | See the [Antigravity guide](docs/ANTIGRAVITY-GUIDE.md) |


### PR DESCRIPTION
## What Changed
Update the OpenCode setup example to pass --enable-hooks for full-profile installations in other case installation wont end as success.

## Why This Change
Installation command from README now throws error

## Testing Done
Manual installation test