### PR TITLE
feat(mcp): add serply-search server catalog entry

### DIFF
--- a/mcp-configs/mcp-servers.json
+++ b/mcp-configs/mcp-servers.json
@@ -213,6 +213,14 @@
       "command": "npx",
       "args": ["-y", "squish-memory"],
       "description": "Local-first persistent memory runtime for AI agents — MCP server for Claude Code, Cursor, OpenCode, Codex, Cline. Auto-captures context across sessions. 1-20ms recall, 283KB, no second LLM needed. Runs locally with SQLite. Supports cloud sync via Stripe checkout ($9-$99/mo). GitHub: https://github.com/michielhdoteth/squish | Docs: https://squishplugin.dev | (also available via local `squish run mcp`)"
+    },
+    "serply-search": {
+      "type": "http",
+      "url": "https://api.serply.io/mcp",
+      "headers": {
+        "X-Api-Key": "YOUR_SERPLY_API_KEY_HERE"
+      },
+      "description": "Serply hosted web search: Google, Bing, News, Scholar, Jobs, Maps, video and Amazon product search plus scrape_url. Search tools return a readable result list with structured content alongside, Maps returns structured JSON, and scrape_url returns Markdown or raw HTML. Complements exa-web-search and parallel-search with classic keyword SERP results and per-country/locale targeting. Requires an API key from serply.io (replace the header placeholder)."
     }
   },
   "_comments": {


### PR DESCRIPTION
## What Changed
Adds a `serply-search` entry to `mcp-configs/mcp-servers.json`. It is an opt-in HTTP entry pointing at Serply's hosted MCP endpoint (`https://api.serply.io/mcp`) with an `X-Api-Key` header placeholder, following the shape of the existing `parallel-search` (HTTP) and `browser-use` (header placeholder) entries. One file, 8 lines added, nothing enabled by default.

## Why This Change
The catalog already lists Exa and Parallel for web search. Serply covers a different slice: classic keyword SERP results from Google and Bing, plus News, Scholar, Jobs, Maps, video and Amazon product search and a `scrape_url` tool, with per-country and locale targeting. Users who already hold a Serply key can wire it in from the catalog instead of hand-writing the entry. Entirely optional, so anyone not using Serply is unaffected.

Endpoint verified live before opening this PR: the server answers MCP `initialize` over streamable HTTP and lists the tools named above; it returns 401 without a key, so the placeholder cannot leak anything.

## Testing Done
- [x] Manual testing completed (live `initialize` and `tools/list` against the endpoint with a real key held in the header only)
- [x] Automated tests pass locally (`npm test`: validators green, `node tests/run-all.js` 4615/4618; the 3 failures are `skill-stocktake` shell tests that need a local `jq` binary this machine lacks, unrelated to the catalog)
- [x] Edge cases considered and tested (`python3 -c "json.load"` on the catalog, `node scripts/ci/check-unicode-safety.js`, `node scripts/ci/catalog.js --check`, `node --test tests/plugin-manifest.test.js` 68/68, `node --test tests/ci/ito-compute-skill.test.js`)

## Type of Change
- [x] `feat:` New feature

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked; the header value is a `YOUR_..._HERE` placeholder like the neighbouring entries)
- [x] JSON files validate cleanly
- [x] Shell scripts pass shellcheck (not applicable, no scripts touched)
- [x] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## Documentation
- [x] Updated relevant documentation (the `description` field is the catalog's own documentation; no other doc lists catalog servers individually)

Disclosure: I work with Serply. Happy to trim the description or rename the key if you prefer a different convention.
