### PR TITLE
Fix global dry run and enhance atomic install-state with LLM tools

### DIFF
--- a/scripts/hooks/bash-hook-dispatcher.js
+++ b/scripts/hooks/bash-hook-dispatcher.js
@@ -192,8 +192,23 @@ async function main() {
   if (result.stderr) {
     process.stderr.write(result.stderr);
   }
-  process.stdout.write(result.output);
-  process.exit(result.exitCode);
+  exitWithStdout(result.output, result.exitCode);
+}
+
+function exitWithStdout(text, exitCode) {
+  process.exitCode = exitCode;
+  let pendingWrites = 1;
+  const exitWhenFlushed = () => {
+    pendingWrites -= 1;
+    if (pendingWrites === 0) {
+      process.exit(exitCode);
+    }
+  };
+  if (typeof text === 'string' && text.length > 0) {
+    pendingWrites += 1;
+    process.stdout.write(text, exitWhenFlushed);
+  }
+  process.stderr.write('', exitWhenFlushed);
 }
 
 if (require.main === module) {

--- a/scripts/hooks/pre-bash-dispatcher.js
+++ b/scripts/hooks/pre-bash-dispatcher.js
@@ -19,6 +19,21 @@ process.stdin.on('end', () => {
   if (result.stderr) {
     process.stderr.write(result.stderr);
   }
-  process.stdout.write(result.output);
-  process.exitCode = result.exitCode;
+  exitWithStdout(result.output, result.exitCode);
 });
+
+function exitWithStdout(text, exitCode) {
+  process.exitCode = exitCode;
+  let pendingWrites = 1;
+  const exitWhenFlushed = () => {
+    pendingWrites -= 1;
+    if (pendingWrites === 0) {
+      process.exit(exitCode);
+    }
+  };
+  if (typeof text === 'string' && text.length > 0) {
+    pendingWrites += 1;
+    process.stdout.write(text, exitWhenFlushed);
+  }
+  process.stderr.write('', exitWhenFlushed);
+}

--- a/scripts/hooks/run-with-flags.js
+++ b/scripts/hooks/run-with-flags.js
@@ -207,7 +207,7 @@ async function main() {
   // which would interfere with the parent process or cause double execution.
   let hookModule;
   const src = fs.readFileSync(scriptPath, 'utf8');
-  const hasRunExport = /\bmodule\.exports\b/.test(src) && /\brun\b/.test(src);
+  const hasRunExport = /exports\.run\b/.test(src) || /module\.exports\.run\b/.test(src) || /module\.exports\s*=\s*\{[^}]*\brun\b/.test(src);
 
   if (hasRunExport) {
     try {

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -20,6 +20,7 @@ const {
 const { getComputeSponsorCopy } = require('./lib/compute-sponsor');
 const { stripAnsi } = require('./lib/utils');
 const { describeMissingDependencyError } = require('./lib/missing-dependency');
+const { isDryRun } = require('./lib/dry-run');
 
 function getHelpText() {
   const languages = listLegacyCompatibilityLanguages();
@@ -166,6 +167,7 @@ async function main() {
       ...options,
       config,
     });
+    const dryRun = isDryRun(options);
     const rawPlan = createInstallPlanFromRequest(request, {
       projectRoot: process.cwd(),
       homeDir: process.env.HOME || os.homedir(),
@@ -173,7 +175,7 @@ async function main() {
       claudeRulesDir: process.env.CLAUDE_RULES_DIR || null,
     });
 
-    if (options.dryRun) {
+    if (dryRun) {
       const plan = previewInstallPlan(rawPlan);
       if (options.json) {
         console.log(JSON.stringify({ dryRun: true, plan }, null, 2));

--- a/scripts/lib/dry-run.js
+++ b/scripts/lib/dry-run.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function isDryRun(options = {}, env = process.env) {
+  const dryRunEnv = env.ECC_DRY_RUN;
+  if (dryRunEnv !== undefined && dryRunEnv !== '0' && dryRunEnv !== '1') {
+    throw new Error('ECC_DRY_RUN must be "1" or "0" when set');
+  }
+  return Boolean(options.dryRun) || dryRunEnv === '1';
+}
+
+module.exports = {
+  isDryRun,
+};

--- a/scripts/lib/install-state.js
+++ b/scripts/lib/install-state.js
@@ -342,7 +342,16 @@ function readInstallState(filePath) {
 function writeInstallState(filePath, state) {
   assertValidInstallState(state, filePath);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`);
+  const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+  const payload = `${JSON.stringify(state, null, 2)}\n`;
+  const fd = fs.openSync(tmpPath, 'w');
+  try {
+    fs.writeFileSync(fd, payload);
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  fs.renameSync(tmpPath, filePath);
   return state;
 }
 

--- a/scripts/repair.js
+++ b/scripts/repair.js
@@ -4,6 +4,7 @@ const os = require('os');
 const { repairInstalledStates } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 const { problemReportLines } = require('./lib/feedback-links');
+const { isDryRun } = require('./lib/dry-run');
 
 function showHelp(exitCode = 0) {
   console.log(`
@@ -78,15 +79,16 @@ async function main() {
       showHelp(0);
     }
 
+    const dryRun = isDryRun(options);
     const result = repairInstalledStates({
       repoRoot: require('path').join(__dirname, '..'),
       homeDir: process.env.HOME || os.homedir(),
       env: process.env,
       projectRoot: process.cwd(),
       targets: options.targets,
-      dryRun: options.dryRun,
+      dryRun,
     });
-    if (!options.dryRun) {
+    if (!dryRun) {
       const { reconcileCanonicalInstallStates } = require('./lib/install-state-store-sync');
       result.installStateProjection = await reconcileCanonicalInstallStates({
         homeDir: process.env.HOME || os.homedir(),

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -9,6 +9,7 @@ const {
   legacyCodexSyncStateExists,
   uninstallLegacyCodexSync,
 } = require('./lib/codex-legacy-sync');
+const { isDryRun } = require('./lib/dry-run');
 
 function showHelp(exitCode = 0) {
   console.log(`
@@ -117,20 +118,6 @@ function printLegacy(result, dryRun) {
 
 function codexHomePath() {
   return process.env.CODEX_HOME || path.join(process.env.HOME || os.homedir(), '.codex');
-}
-
-/**
- * Dry-run is enabled either by the subcommand-level `--dry-run` flag or by the
- * global `ecc --dry-run <command>` prefix, which sets ECC_DRY_RUN=1 (#2952).
- * Destructive subcommands must honor both forms rather than silently ignoring
- * the global flag.
- */
-function isDryRun(options) {
-  const dryRunEnv = process.env.ECC_DRY_RUN;
-  if (dryRunEnv !== undefined && dryRunEnv !== '0' && dryRunEnv !== '1') {
-    throw new Error('ECC_DRY_RUN must be "1" or "0" when set');
-  }
-  return options.dryRun || dryRunEnv === '1';
 }
 
 function includesCodexTarget(targets) {

--- a/src/llm/providers/ollama.py
+++ b/src/llm/providers/ollama.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from typing import Any
 
@@ -18,6 +19,22 @@ from llm.core.types import (
     ProviderType,
     ToolCall,
 )
+
+
+def _parse_tool_arguments(raw_arguments: Any) -> dict[str, Any]:
+    if not raw_arguments:
+        return {}
+    if isinstance(raw_arguments, dict):
+        return raw_arguments
+    if isinstance(raw_arguments, str):
+        try:
+            parsed = json.loads(raw_arguments)
+        except json.JSONDecodeError:
+            return {"raw": raw_arguments}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"value": parsed}
+    return {"value": raw_arguments}
 
 
 class OllamaProvider(LLMProvider):
@@ -58,7 +75,6 @@ class OllamaProvider(LLMProvider):
         ]
 
     def generate(self, input: LLMInput) -> LLMOutput:
-        import json
         import urllib.request
 
         try:
@@ -87,7 +103,7 @@ class OllamaProvider(LLMProvider):
                     ToolCall(
                         id=tc.get("id", ""),
                         name=tc.get("function", {}).get("name", ""),
-                        arguments=tc.get("function", {}).get("arguments", {}),
+                        arguments=_parse_tool_arguments(tc.get("function", {}).get("arguments", {})),
                     )
                     for tc in result["message"]["tool_calls"]
                 ]
@@ -100,8 +116,9 @@ class OllamaProvider(LLMProvider):
             )
         except Exception as e:
             msg = str(e)
-            if "401" in msg or "connection" in msg.lower():
-                raise AuthenticationError(f"Ollama connection failed: {msg}", provider=ProviderType.OLLAMA) from e
+            lowered = msg.lower()
+            if "401" in msg or "unauthorized" in lowered or "authentication" in lowered:
+                raise AuthenticationError(f"Ollama authentication failed: {msg}", provider=ProviderType.OLLAMA) from e
             if "429" in msg or "rate_limit" in msg.lower():
                 raise RateLimitError(msg, provider=ProviderType.OLLAMA) from e
             if "context" in msg.lower() and "length" in msg.lower():

--- a/src/llm/providers/openai.py
+++ b/src/llm/providers/openai.py
@@ -24,6 +24,18 @@ from llm.core.types import (
 from llm.providers.constants import EMPTY_FILTERED_RESPONSE_ERROR
 
 
+def _parse_tool_arguments(raw_arguments: str | None) -> dict[str, Any]:
+    if not raw_arguments:
+        return {}
+    try:
+        parsed = json.loads(raw_arguments)
+    except json.JSONDecodeError:
+        return {"raw": raw_arguments}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"value": parsed}
+
+
 class OpenAIProvider(LLMProvider):
     provider_type = ProviderType.OPENAI
 
@@ -91,7 +103,7 @@ class OpenAIProvider(LLMProvider):
                     ToolCall(
                         id=tc.id or "",
                         name=tc.function.name,
-                        arguments={} if not tc.function.arguments else json.loads(tc.function.arguments),
+                        arguments=_parse_tool_arguments(tc.function.arguments),
                     )
                     for tc in choice.message.tool_calls
                 ]

--- a/src/llm/tools/executor.py
+++ b/src/llm/tools/executor.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any
+import inspect
 
+from llm.core.interface import LLMError
 from llm.core.types import (
     LLMInput,
     LLMOutput,
@@ -64,8 +66,35 @@ class ToolExecutor:
                 is_error=True,
             )
 
+    async def aexecute(self, tool_call: ToolCall) -> ToolResult:
+        func = self.registry.get(tool_call.name)
+        if not func:
+            return ToolResult(
+                tool_call_id=tool_call.id,
+                content=f"Error: Tool '{tool_call.name}' not found",
+                is_error=True,
+            )
+        try:
+            result = func(**tool_call.arguments)
+            if inspect.isawaitable(result):
+                result = await result
+            content = result if isinstance(result, str) else str(result)
+            return ToolResult(tool_call_id=tool_call.id, content=content)
+        except Exception as e:
+            return ToolResult(
+                tool_call_id=tool_call.id,
+                content=f"Error executing {tool_call.name}: {e}",
+                is_error=True,
+            )
+
     def execute_all(self, tool_calls: list[ToolCall]) -> list[ToolResult]:
         return [self.execute(tc) for tc in tool_calls]
+
+    async def aexecute_all(self, tool_calls: list[ToolCall]) -> list[ToolResult]:
+        results: list[ToolResult] = []
+        for tc in tool_calls:
+            results.append(await self.aexecute(tc))
+        return results
 
 
 class ReActAgent:
@@ -82,6 +111,7 @@ class ReActAgent:
     async def run(self, input: LLMInput) -> LLMOutput:
         messages = list(input.messages)
         tools = input.tools or []
+        last_output: LLMOutput | None = None
 
         for _ in range(self.max_iterations):
             input_copy = LLMInput(
@@ -92,7 +122,16 @@ class ReActAgent:
                 tools=tools,
             )
 
-            output: LLMOutput = self.provider.generate(input_copy)
+            try:
+                output: LLMOutput = self.provider.generate(input_copy)
+            except LLMError as e:
+                return LLMOutput(
+                    content=f"Error: {e.message}",
+                    model=input.model,
+                    stop_reason="error",
+                    metadata={"messages": [m.to_dict() for m in messages]},
+                )
+            last_output = output
 
             if not output.has_tool_calls:
                 return output
@@ -105,7 +144,7 @@ class ReActAgent:
                 )
             )
 
-            results = self.executor.execute_all(output.tool_calls or [])
+            results = await self.executor.aexecute_all(output.tool_calls or [])
 
             for result in results:
                 messages.append(
@@ -118,5 +157,8 @@ class ReActAgent:
 
         return LLMOutput(
             content="Max iterations reached",
+            model=last_output.model if last_output and last_output.model else input.model,
+            usage=last_output.usage if last_output and last_output.usage else None,
             stop_reason="max_iterations",
+            metadata={"messages": [m.to_dict() for m in messages]},
         )


### PR DESCRIPTION
## Summary

Fixes 7 bugs across dry-run handling, install state persistence, LLM providers, async tool execution, hook output handling, and module detection.

## Changes

* **Fix dry-run bypass:** Added a shared `isDryRun()` helper supporting both `--dry-run` and `ECC_DRY_RUN=1`. Updated `repair`, `install`, and `uninstall` to consistently honor dry-run mode.
* **Make install-state writes atomic:** `writeInstallState` now writes to a unique temporary file, calls `fsync`, and atomically renames it into place.
* **Prevent OpenAI tool-argument crashes:** Added parsing that safely handles malformed/truncated JSON and non-dictionary values instead of crashing the agent loop.
* **Fix Ollama argument handling and authentication errors:** Normalize tool arguments consistently, distinguish authentication failures from connection errors, and only raise `AuthenticationError` for actual auth failures.
* **Add async tool execution:** Added `aexecute` / `aexecute_all` with awaitable handling. Updated `ReActAgent.run` to use the async execution path while preserving partial output and execution metadata on error/max-iteration paths.
* **Prevent hook output truncation:** Replaced direct `write(); exit()` calls with drain-aware `exitWithStdout()` in the bash hook dispatchers.
* **Tighten the `require` heuristic:** Reduced false positives by matching supported `run` export patterns rather than a generic `module.exports && run` substring.

## Verification

* `validate-install-manifests` ✅
* `validate-hooks` ✅
* All touched JavaScript files pass `node --check` ✅
* Python files pass `py_compile` and AST validation ✅
* Atomic-write smoke test ✅
* Dry-run smoke test ✅
* Hook smoke tests ✅

No new comments were added.

