### PR TITLE
fix: guided dry-run via env, atomic install-state writes, harden hook and provider parsing

### DIFF
--- a/scripts/hooks/bash-hook-dispatcher.js
+++ b/scripts/hooks/bash-hook-dispatcher.js
@@ -192,8 +192,23 @@ async function main() {
   if (result.stderr) {
     process.stderr.write(result.stderr);
   }
-  process.stdout.write(result.output);
-  process.exit(result.exitCode);
+  exitWithStdout(result.output, result.exitCode);
+}
+
+function exitWithStdout(text, exitCode) {
+  process.exitCode = exitCode;
+  let pendingWrites = 1;
+  const exitWhenFlushed = () => {
+    pendingWrites -= 1;
+    if (pendingWrites === 0) {
+      process.exit(exitCode);
+    }
+  };
+  if (typeof text === 'string' && text.length > 0) {
+    pendingWrites += 1;
+    process.stdout.write(text, exitWhenFlushed);
+  }
+  process.stderr.write('', exitWhenFlushed);
 }
 
 if (require.main === module) {

--- a/scripts/hooks/pre-bash-dispatcher.js
+++ b/scripts/hooks/pre-bash-dispatcher.js
@@ -19,6 +19,21 @@ process.stdin.on('end', () => {
   if (result.stderr) {
     process.stderr.write(result.stderr);
   }
-  process.stdout.write(result.output);
-  process.exitCode = result.exitCode;
+  exitWithStdout(result.output, result.exitCode);
 });
+
+function exitWithStdout(text, exitCode) {
+  process.exitCode = exitCode;
+  let pendingWrites = 1;
+  const exitWhenFlushed = () => {
+    pendingWrites -= 1;
+    if (pendingWrites === 0) {
+      process.exit(exitCode);
+    }
+  };
+  if (typeof text === 'string' && text.length > 0) {
+    pendingWrites += 1;
+    process.stdout.write(text, exitWhenFlushed);
+  }
+  process.stderr.write('', exitWhenFlushed);
+}

--- a/scripts/hooks/run-with-flags.js
+++ b/scripts/hooks/run-with-flags.js
@@ -207,7 +207,7 @@ async function main() {
   // which would interfere with the parent process or cause double execution.
   let hookModule;
   const src = fs.readFileSync(scriptPath, 'utf8');
-  const hasRunExport = /\bmodule\.exports\b/.test(src) && /\brun\b/.test(src);
+  const hasRunExport = /exports\.run\b/.test(src) || /module\.exports\.run\b/.test(src) || /module\.exports\s*=\s*\{[^}]*\brun\b/.test(src);
 
   if (hasRunExport) {
     try {

--- a/scripts/hooks/run-with-flags.js
+++ b/scripts/hooks/run-with-flags.js
@@ -109,70 +109,89 @@ function getPluginRoot() {
   return path.resolve(__dirname, '..', '..');
 }
 
-function stripJsNoise(source) {
-  let out = '';
-  let i = 0;
-  const n = source.length;
-  let state = 'code';
-  let quote = '';
-  while (i < n) {
-    const ch = source[i];
-    const next = i + 1 < n ? source[i + 1] : '';
-    if (state === 'code') {
-      if (ch === '/' && next === '/') {
-        state = 'line';
-        i += 2;
-        continue;
-      }
-      if (ch === '/' && next === '*') {
-        state = 'block';
-        i += 2;
-        continue;
-      }
-      if (ch === "'" || ch === '"' || ch === '`') {
-        state = 'string';
-        quote = ch;
-        out += ' ';
-        i += 1;
-        continue;
-      }
-      out += ch;
-      i += 1;
-      continue;
-    }
-    if (state === 'line') {
-      if (ch === '\n') {
-        state = 'code';
-        out += '\n';
-      }
-      i += 1;
-      continue;
-    }
-    if (state === 'block') {
-      if (ch === '*' && next === '/') {
-        state = 'code';
-        i += 2;
-        continue;
-      }
-      if (ch === '\n') {
-        out += '\n';
-      }
-      i += 1;
-      continue;
-    }
-    if (ch === '\\') {
-      i += 2;
-      continue;
-    }
-    if (ch === quote) {
-      state = 'code';
-      out += ' ';
-      i += 1;
-      continue;
-    }
-    i += 1;
+function makeJsScan(source) {
+  return { source, out: '', i: 0, n: source.length, state: 'code', quote: '' };
+}
+
+function scanCodeStep(scan) {
+  const ch = scan.source[scan.i];
+  const next = scan.i + 1 < scan.n ? scan.source[scan.i + 1] : '';
+  if (ch === '/' && next === '/') {
+    scan.state = 'line';
+    scan.i += 2;
+    return;
   }
-  return out;
+  if (ch === '/' && next === '*') {
+    scan.state = 'block';
+    scan.i += 2;
+    return;
+  }
+  if (ch === "'" || ch === '"' || ch === '`') {
+    scan.state = 'string';
+    scan.quote = ch;
+    scan.out += ' ';
+    scan.i += 1;
+    return;
+  }
+  scan.out += ch;
+  scan.i += 1;
+}
+
+function scanLineStep(scan) {
+  if (scan.source[scan.i] === '\n') {
+    scan.state = 'code';
+    scan.out += '\n';
+  }
+  scan.i += 1;
+}
+
+function scanBlockStep(scan) {
+  const ch = scan.source[scan.i];
+  const next = scan.i + 1 < scan.n ? scan.source[scan.i + 1] : '';
+  if (ch === '*' && next === '/') {
+    scan.state = 'code';
+    scan.i += 2;
+    return;
+  }
+  if (ch === '\n') {
+    scan.out += '\n';
+  }
+  scan.i += 1;
+}
+
+function scanStringStep(scan) {
+  const ch = scan.source[scan.i];
+  if (ch === '\\') {
+    scan.i += 2;
+    return;
+  }
+  if (ch === scan.quote) {
+    scan.state = 'code';
+    scan.out += ' ';
+    scan.i += 1;
+    return;
+  }
+  scan.i += 1;
+}
+
+function stripJsNoise(source) {
+  const scan = makeJsScan(source);
+  while (scan.i < scan.n) {
+    if (scan.state === 'code') {
+      scanCodeStep(scan);
+      continue;
+    }
+    if (scan.state === 'line') {
+      scanLineStep(scan);
+      continue;
+    }
+    if (scan.state === 'block') {
+      scanBlockStep(scan);
+      continue;
+    }
+    scanStringStep(scan);
+  }
+  return scan.out;
 }
 
 //Safely extract target context from hook stdin JSON for dry-run preview.

--- a/scripts/hooks/run-with-flags.js
+++ b/scripts/hooks/run-with-flags.js
@@ -109,6 +109,72 @@ function getPluginRoot() {
   return path.resolve(__dirname, '..', '..');
 }
 
+function stripJsNoise(source) {
+  let out = '';
+  let i = 0;
+  const n = source.length;
+  let state = 'code';
+  let quote = '';
+  while (i < n) {
+    const ch = source[i];
+    const next = i + 1 < n ? source[i + 1] : '';
+    if (state === 'code') {
+      if (ch === '/' && next === '/') {
+        state = 'line';
+        i += 2;
+        continue;
+      }
+      if (ch === '/' && next === '*') {
+        state = 'block';
+        i += 2;
+        continue;
+      }
+      if (ch === "'" || ch === '"' || ch === '`') {
+        state = 'string';
+        quote = ch;
+        out += ' ';
+        i += 1;
+        continue;
+      }
+      out += ch;
+      i += 1;
+      continue;
+    }
+    if (state === 'line') {
+      if (ch === '\n') {
+        state = 'code';
+        out += '\n';
+      }
+      i += 1;
+      continue;
+    }
+    if (state === 'block') {
+      if (ch === '*' && next === '/') {
+        state = 'code';
+        i += 2;
+        continue;
+      }
+      if (ch === '\n') {
+        out += '\n';
+      }
+      i += 1;
+      continue;
+    }
+    if (ch === '\\') {
+      i += 2;
+      continue;
+    }
+    if (ch === quote) {
+      state = 'code';
+      out += ' ';
+      i += 1;
+      continue;
+    }
+    i += 1;
+  }
+  return out;
+}
+
 //Safely extract target context from hook stdin JSON for dry-run preview.
 
 function extractTargetContext(raw) {
@@ -207,7 +273,8 @@ async function main() {
   // which would interfere with the parent process or cause double execution.
   let hookModule;
   const src = fs.readFileSync(scriptPath, 'utf8');
-  const hasRunExport = /exports\.run\b/.test(src) || /module\.exports\.run\b/.test(src) || /module\.exports\s*=\s*\{[^}]*\brun\b/.test(src);
+  const strippedSrc = stripJsNoise(src);
+  const hasRunExport = /exports\.run\b/.test(strippedSrc) || /module\.exports\.run\b/.test(strippedSrc) || /module\.exports\s*=\s*\{[^}]*\brun\b/.test(strippedSrc);
 
   if (hasRunExport) {
     try {

--- a/scripts/hooks/run-with-flags.js
+++ b/scripts/hooks/run-with-flags.js
@@ -117,79 +117,63 @@ function scanCodeStep(scan) {
   const ch = scan.source[scan.i];
   const next = scan.i + 1 < scan.n ? scan.source[scan.i + 1] : '';
   if (ch === '/' && next === '/') {
-    scan.state = 'line';
-    scan.i += 2;
-    return;
+    return { ...scan, state: 'line', i: scan.i + 2 };
   }
   if (ch === '/' && next === '*') {
-    scan.state = 'block';
-    scan.i += 2;
-    return;
+    return { ...scan, state: 'block', i: scan.i + 2 };
   }
   if (ch === "'" || ch === '"' || ch === '`') {
-    scan.state = 'string';
-    scan.quote = ch;
-    scan.out += ' ';
-    scan.i += 1;
-    return;
+    return { ...scan, state: 'string', quote: ch, out: `${scan.out} `, i: scan.i + 1 };
   }
-  scan.out += ch;
-  scan.i += 1;
+  return { ...scan, out: `${scan.out}${ch}`, i: scan.i + 1 };
 }
 
 function scanLineStep(scan) {
   if (scan.source[scan.i] === '\n') {
-    scan.state = 'code';
-    scan.out += '\n';
+    return { ...scan, state: 'code', out: `${scan.out}\n`, i: scan.i + 1 };
   }
-  scan.i += 1;
+  return { ...scan, i: scan.i + 1 };
 }
 
 function scanBlockStep(scan) {
   const ch = scan.source[scan.i];
   const next = scan.i + 1 < scan.n ? scan.source[scan.i + 1] : '';
   if (ch === '*' && next === '/') {
-    scan.state = 'code';
-    scan.i += 2;
-    return;
+    return { ...scan, state: 'code', i: scan.i + 2 };
   }
   if (ch === '\n') {
-    scan.out += '\n';
+    return { ...scan, out: `${scan.out}\n`, i: scan.i + 1 };
   }
-  scan.i += 1;
+  return { ...scan, i: scan.i + 1 };
 }
 
 function scanStringStep(scan) {
   const ch = scan.source[scan.i];
   if (ch === '\\') {
-    scan.i += 2;
-    return;
+    return { ...scan, i: scan.i + 2 };
   }
   if (ch === scan.quote) {
-    scan.state = 'code';
-    scan.out += ' ';
-    scan.i += 1;
-    return;
+    return { ...scan, state: 'code', out: `${scan.out} `, i: scan.i + 1 };
   }
-  scan.i += 1;
+  return { ...scan, i: scan.i + 1 };
 }
 
 function stripJsNoise(source) {
-  const scan = makeJsScan(source);
+  let scan = makeJsScan(source);
   while (scan.i < scan.n) {
     if (scan.state === 'code') {
-      scanCodeStep(scan);
+      scan = scanCodeStep(scan);
       continue;
     }
     if (scan.state === 'line') {
-      scanLineStep(scan);
+      scan = scanLineStep(scan);
       continue;
     }
     if (scan.state === 'block') {
-      scanBlockStep(scan);
+      scan = scanBlockStep(scan);
       continue;
     }
-    scanStringStep(scan);
+    scan = scanStringStep(scan);
   }
   return scan.out;
 }

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -232,6 +232,9 @@ function runGuidedMain(guidedArgs) {
 const cliArgs = process.argv.slice(2);
 if (cliArgs.includes('--guided')) {
   const guidedArgs = cliArgs.filter(argument => argument !== '--guided');
+  if (isDryRun({ dryRun: guidedArgs.includes('--dry-run') }) && !guidedArgs.includes('--dry-run')) {
+    guidedArgs.push('--dry-run');
+  }
   runGuidedMain(guidedArgs);
 } else {
   main();

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -20,6 +20,7 @@ const {
 const { getComputeSponsorCopy } = require('./lib/compute-sponsor');
 const { stripAnsi } = require('./lib/utils');
 const { describeMissingDependencyError } = require('./lib/missing-dependency');
+const { isDryRun } = require('./lib/dry-run');
 
 function getHelpText() {
   const languages = listLegacyCompatibilityLanguages();
@@ -166,6 +167,7 @@ async function main() {
       ...options,
       config,
     });
+    const dryRun = isDryRun(options);
     const rawPlan = createInstallPlanFromRequest(request, {
       projectRoot: process.cwd(),
       homeDir: process.env.HOME || os.homedir(),
@@ -173,7 +175,7 @@ async function main() {
       claudeRulesDir: process.env.CLAUDE_RULES_DIR || null,
     });
 
-    if (options.dryRun) {
+    if (dryRun) {
       const plan = previewInstallPlan(rawPlan);
       if (options.json) {
         console.log(JSON.stringify({ dryRun: true, plan }, null, 2));

--- a/scripts/install-guided.js
+++ b/scripts/install-guided.js
@@ -20,6 +20,7 @@ const { formatHookCapabilityDisclosure } = require('./lib/install/hook-consent')
 const { startTerminalSpinner } = require('./lib/terminal-spinner');
 const { showTerminalWelcome } = require('./lib/terminal-welcome');
 const { stripAnsi } = require('./lib/utils');
+const { isDryRun } = require('./lib/dry-run');
 
 const ADVANCED_HARNESSES = 'Cursor, Antigravity, Gemini CLI, OpenCode, CodeBuddy, JoyCode, Qwen Code, Zed, Hermes, and OpenClaw';
 
@@ -256,6 +257,7 @@ async function main(argv = process.argv.slice(2), injected = {}) {
 
   try {
     let options = parseArgs(argv);
+    options = { ...options, dryRun: isDryRun(options) };
     if (options.help) {
       showHelp(output);
       return 0;

--- a/scripts/lib/dry-run.js
+++ b/scripts/lib/dry-run.js
@@ -1,0 +1,13 @@
+'use strict';
+
+function isDryRun(options = {}, env = process.env) {
+  const dryRunEnv = env.ECC_DRY_RUN;
+  if (dryRunEnv !== undefined && dryRunEnv !== '0' && dryRunEnv !== '1') {
+    throw new Error('ECC_DRY_RUN must be "1" or "0" when set');
+  }
+  return Boolean(options.dryRun) || dryRunEnv === '1';
+}
+
+module.exports = {
+  isDryRun,
+};

--- a/scripts/lib/install-state.js
+++ b/scripts/lib/install-state.js
@@ -342,7 +342,16 @@ function readInstallState(filePath) {
 function writeInstallState(filePath, state) {
   assertValidInstallState(state, filePath);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`);
+  const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+  const payload = `${JSON.stringify(state, null, 2)}\n`;
+  const fd = fs.openSync(tmpPath, 'w');
+  try {
+    fs.writeFileSync(fd, payload);
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+  fs.renameSync(tmpPath, filePath);
   return state;
 }
 

--- a/scripts/lib/install-state.js
+++ b/scripts/lib/install-state.js
@@ -339,6 +339,27 @@ function readInstallState(filePath) {
   return state;
 }
 
+function syncParentDirectory(directoryPath) {
+  if (process.platform === 'win32') {
+    return;
+  }
+  let fd;
+  try {
+    fd = fs.openSync(directoryPath, fs.constants.O_RDONLY);
+    fs.fsyncSync(fd);
+  } catch (_syncError) {
+    void _syncError;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch (_closeError) {
+        void _closeError;
+      }
+    }
+  }
+}
+
 function writeInstallState(filePath, state) {
   assertValidInstallState(state, filePath);
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -348,10 +369,31 @@ function writeInstallState(filePath, state) {
   try {
     fs.writeFileSync(fd, payload);
     fs.fsyncSync(fd);
-  } finally {
-    fs.closeSync(fd);
+  } catch (error) {
+    try {
+      fs.closeSync(fd);
+    } catch (_closeError) {
+      void _closeError;
+    }
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch (_rmError) {
+      void _rmError;
+    }
+    throw error;
   }
-  fs.renameSync(tmpPath, filePath);
+  fs.closeSync(fd);
+  try {
+    fs.renameSync(tmpPath, filePath);
+  } catch (error) {
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch (_rmError) {
+      void _rmError;
+    }
+    throw error;
+  }
+  syncParentDirectory(path.dirname(filePath));
   return state;
 }
 

--- a/scripts/lib/install-state.js
+++ b/scripts/lib/install-state.js
@@ -339,6 +339,10 @@ function readInstallState(filePath) {
   return state;
 }
 
+function warnFilesystemIssue(message) {
+  process.stderr.write(`${message}\n`);
+}
+
 function syncParentDirectory(directoryPath) {
   if (process.platform === 'win32') {
     return;
@@ -347,14 +351,14 @@ function syncParentDirectory(directoryPath) {
   try {
     fd = fs.openSync(directoryPath, fs.constants.O_RDONLY);
     fs.fsyncSync(fd);
-  } catch (_syncError) {
-    void _syncError;
+  } catch (syncError) {
+    warnFilesystemIssue(`[install-state] directory sync skipped for ${directoryPath}: ${syncError.message}`);
   } finally {
     if (fd !== undefined) {
       try {
         fs.closeSync(fd);
-      } catch (_closeError) {
-        void _closeError;
+      } catch (closeError) {
+        warnFilesystemIssue(`[install-state] directory handle close failed for ${directoryPath}: ${closeError.message}`);
       }
     }
   }
@@ -372,24 +376,33 @@ function writeInstallState(filePath, state) {
   } catch (error) {
     try {
       fs.closeSync(fd);
-    } catch (_closeError) {
-      void _closeError;
+    } catch (closeError) {
+      warnFilesystemIssue(`[install-state] temp file handle close failed for ${tmpPath}: ${closeError.message}`);
     }
     try {
       fs.rmSync(tmpPath, { force: true });
-    } catch (_rmError) {
-      void _rmError;
+    } catch (rmError) {
+      warnFilesystemIssue(`[install-state] temp file cleanup failed for ${tmpPath}: ${rmError.message}`);
     }
     throw error;
   }
-  fs.closeSync(fd);
+  try {
+    fs.closeSync(fd);
+  } catch (closeError) {
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch (rmError) {
+      warnFilesystemIssue(`[install-state] temp file cleanup failed for ${tmpPath}: ${rmError.message}`);
+    }
+    throw closeError;
+  }
   try {
     fs.renameSync(tmpPath, filePath);
   } catch (error) {
     try {
       fs.rmSync(tmpPath, { force: true });
-    } catch (_rmError) {
-      void _rmError;
+    } catch (rmError) {
+      warnFilesystemIssue(`[install-state] temp file cleanup failed for ${tmpPath}: ${rmError.message}`);
     }
     throw error;
   }

--- a/scripts/repair.js
+++ b/scripts/repair.js
@@ -4,6 +4,7 @@ const os = require('os');
 const { repairInstalledStates } = require('./lib/install-lifecycle');
 const { SUPPORTED_INSTALL_TARGETS } = require('./lib/install-manifests');
 const { problemReportLines } = require('./lib/feedback-links');
+const { isDryRun } = require('./lib/dry-run');
 
 function showHelp(exitCode = 0) {
   console.log(`
@@ -78,15 +79,16 @@ async function main() {
       showHelp(0);
     }
 
+    const dryRun = isDryRun(options);
     const result = repairInstalledStates({
       repoRoot: require('path').join(__dirname, '..'),
       homeDir: process.env.HOME || os.homedir(),
       env: process.env,
       projectRoot: process.cwd(),
       targets: options.targets,
-      dryRun: options.dryRun,
+      dryRun,
     });
-    if (!options.dryRun) {
+    if (!dryRun) {
       const { reconcileCanonicalInstallStates } = require('./lib/install-state-store-sync');
       result.installStateProjection = await reconcileCanonicalInstallStates({
         homeDir: process.env.HOME || os.homedir(),

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -9,6 +9,7 @@ const {
   legacyCodexSyncStateExists,
   uninstallLegacyCodexSync,
 } = require('./lib/codex-legacy-sync');
+const { isDryRun } = require('./lib/dry-run');
 
 function showHelp(exitCode = 0) {
   console.log(`
@@ -117,20 +118,6 @@ function printLegacy(result, dryRun) {
 
 function codexHomePath() {
   return process.env.CODEX_HOME || path.join(process.env.HOME || os.homedir(), '.codex');
-}
-
-/**
- * Dry-run is enabled either by the subcommand-level `--dry-run` flag or by the
- * global `ecc --dry-run <command>` prefix, which sets ECC_DRY_RUN=1 (#2952).
- * Destructive subcommands must honor both forms rather than silently ignoring
- * the global flag.
- */
-function isDryRun(options) {
-  const dryRunEnv = process.env.ECC_DRY_RUN;
-  if (dryRunEnv !== undefined && dryRunEnv !== '0' && dryRunEnv !== '1') {
-    throw new Error('ECC_DRY_RUN must be "1" or "0" when set');
-  }
-  return options.dryRun || dryRunEnv === '1';
 }
 
 function includesCodexTarget(targets) {

--- a/src/llm/providers/ollama.py
+++ b/src/llm/providers/ollama.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from typing import Any
 
@@ -18,6 +19,22 @@ from llm.core.types import (
     ProviderType,
     ToolCall,
 )
+
+
+def _parse_tool_arguments(raw_arguments: Any) -> dict[str, Any]:
+    if not raw_arguments:
+        return {}
+    if isinstance(raw_arguments, dict):
+        return raw_arguments
+    if isinstance(raw_arguments, str):
+        try:
+            parsed = json.loads(raw_arguments)
+        except json.JSONDecodeError:
+            return {"raw": raw_arguments}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"value": parsed}
+    return {"value": raw_arguments}
 
 
 class OllamaProvider(LLMProvider):
@@ -58,7 +75,6 @@ class OllamaProvider(LLMProvider):
         ]
 
     def generate(self, input: LLMInput) -> LLMOutput:
-        import json
         import urllib.request
 
         try:
@@ -87,7 +103,7 @@ class OllamaProvider(LLMProvider):
                     ToolCall(
                         id=tc.get("id", ""),
                         name=tc.get("function", {}).get("name", ""),
-                        arguments=tc.get("function", {}).get("arguments", {}),
+                        arguments=_parse_tool_arguments(tc.get("function", {}).get("arguments", {})),
                     )
                     for tc in result["message"]["tool_calls"]
                 ]
@@ -100,8 +116,9 @@ class OllamaProvider(LLMProvider):
             )
         except Exception as e:
             msg = str(e)
-            if "401" in msg or "connection" in msg.lower():
-                raise AuthenticationError(f"Ollama connection failed: {msg}", provider=ProviderType.OLLAMA) from e
+            lowered = msg.lower()
+            if "401" in msg or "unauthorized" in lowered or "authentication" in lowered:
+                raise AuthenticationError(f"Ollama authentication failed: {msg}", provider=ProviderType.OLLAMA) from e
             if "429" in msg or "rate_limit" in msg.lower():
                 raise RateLimitError(msg, provider=ProviderType.OLLAMA) from e
             if "context" in msg.lower() and "length" in msg.lower():

--- a/src/llm/providers/ollama.py
+++ b/src/llm/providers/ollama.py
@@ -25,7 +25,7 @@ def _parse_tool_arguments(raw_arguments: Any) -> dict[str, Any]:
     if not raw_arguments:
         return {}
     if isinstance(raw_arguments, dict):
-        return raw_arguments
+        return {**raw_arguments}
     if isinstance(raw_arguments, str):
         try:
             parsed = json.loads(raw_arguments)

--- a/src/llm/providers/openai.py
+++ b/src/llm/providers/openai.py
@@ -24,6 +24,18 @@ from llm.core.types import (
 from llm.providers.constants import EMPTY_FILTERED_RESPONSE_ERROR
 
 
+def _parse_tool_arguments(raw_arguments: str | None) -> dict[str, Any]:
+    if not raw_arguments:
+        return {}
+    try:
+        parsed = json.loads(raw_arguments)
+    except json.JSONDecodeError:
+        return {"raw": raw_arguments}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"value": parsed}
+
+
 class OpenAIProvider(LLMProvider):
     provider_type = ProviderType.OPENAI
 
@@ -91,7 +103,7 @@ class OpenAIProvider(LLMProvider):
                     ToolCall(
                         id=tc.id or "",
                         name=tc.function.name,
-                        arguments={} if not tc.function.arguments else json.loads(tc.function.arguments),
+                        arguments=_parse_tool_arguments(tc.function.arguments),
                     )
                     for tc in choice.message.tool_calls
                 ]

--- a/src/llm/tools/executor.py
+++ b/src/llm/tools/executor.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any
+import inspect
 
+from llm.core.interface import LLMError
 from llm.core.types import (
     LLMInput,
     LLMOutput,
@@ -64,8 +66,35 @@ class ToolExecutor:
                 is_error=True,
             )
 
+    async def aexecute(self, tool_call: ToolCall) -> ToolResult:
+        func = self.registry.get(tool_call.name)
+        if not func:
+            return ToolResult(
+                tool_call_id=tool_call.id,
+                content=f"Error: Tool '{tool_call.name}' not found",
+                is_error=True,
+            )
+        try:
+            result = func(**tool_call.arguments)
+            if inspect.isawaitable(result):
+                result = await result
+            content = result if isinstance(result, str) else str(result)
+            return ToolResult(tool_call_id=tool_call.id, content=content)
+        except Exception as e:
+            return ToolResult(
+                tool_call_id=tool_call.id,
+                content=f"Error executing {tool_call.name}: {e}",
+                is_error=True,
+            )
+
     def execute_all(self, tool_calls: list[ToolCall]) -> list[ToolResult]:
         return [self.execute(tc) for tc in tool_calls]
+
+    async def aexecute_all(self, tool_calls: list[ToolCall]) -> list[ToolResult]:
+        results: list[ToolResult] = []
+        for tc in tool_calls:
+            results.append(await self.aexecute(tc))
+        return results
 
 
 class ReActAgent:
@@ -82,6 +111,7 @@ class ReActAgent:
     async def run(self, input: LLMInput) -> LLMOutput:
         messages = list(input.messages)
         tools = input.tools or []
+        last_output: LLMOutput | None = None
 
         for _ in range(self.max_iterations):
             input_copy = LLMInput(
@@ -92,7 +122,16 @@ class ReActAgent:
                 tools=tools,
             )
 
-            output: LLMOutput = self.provider.generate(input_copy)
+            try:
+                output: LLMOutput = self.provider.generate(input_copy)
+            except LLMError as e:
+                return LLMOutput(
+                    content=f"Error: {e.message}",
+                    model=input.model,
+                    stop_reason="error",
+                    metadata={"messages": [m.to_dict() for m in messages]},
+                )
+            last_output = output
 
             if not output.has_tool_calls:
                 return output
@@ -105,7 +144,7 @@ class ReActAgent:
                 )
             )
 
-            results = self.executor.execute_all(output.tool_calls or [])
+            results = await self.executor.aexecute_all(output.tool_calls or [])
 
             for result in results:
                 messages.append(
@@ -118,5 +157,8 @@ class ReActAgent:
 
         return LLMOutput(
             content="Max iterations reached",
+            model=last_output.model if last_output and last_output.model else input.model,
+            usage=last_output.usage if last_output and last_output.usage else None,
             stop_reason="max_iterations",
+            metadata={"messages": [m.to_dict() for m in messages]},
         )

--- a/src/llm/tools/executor.py
+++ b/src/llm/tools/executor.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable
 from typing import Any
-import inspect
 
 from llm.core.interface import LLMError
 from llm.core.types import (

--- a/tests/lib/install-state.test.js
+++ b/tests/lib/install-state.test.js
@@ -328,6 +328,68 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('rename failure preserves original and leaves no stale temp files', () => {
+    const testDir = createTestDir();
+    const statePath = path.join(testDir, 'ecc-install-state.json');
+    try {
+      const baseOptions = {
+        adapter: { id: 'claude-home' },
+        targetRoot: path.join(testDir, '.claude'),
+        installStatePath: statePath,
+        request: { profile: 'core', modules: [], legacyLanguages: [], legacyMode: false },
+        resolution: { selectedModules: ['rules-core'], skippedModules: [] },
+        operations: [],
+        source: { repoVersion: CURRENT_PACKAGE_VERSION, repoCommit: 'abc123', manifestVersion: 1 },
+      };
+      const original = createInstallState(baseOptions);
+      writeInstallState(statePath, original);
+      const beforeContent = fs.readFileSync(statePath, 'utf8');
+      const updated = createInstallState({ ...baseOptions, request: { profile: 'core', modules: ['extra'], legacyLanguages: [], legacyMode: false } });
+      const realRename = fs.renameSync;
+      fs.renameSync = () => { throw new Error('rename boom'); };
+      try {
+        assert.throws(() => writeInstallState(statePath, updated), /rename boom/);
+      } finally {
+        fs.renameSync = realRename;
+      }
+      assert.strictEqual(fs.readFileSync(statePath, 'utf8'), beforeContent);
+      assert.deepStrictEqual(fs.readdirSync(testDir).filter(name => name.includes('.tmp.')), []);
+    } finally {
+      cleanupTestDir(testDir);
+    }
+  })) passed++; else failed++;
+
+  if (test('write failure preserves original and leaves no stale temp files', () => {
+    const testDir = createTestDir();
+    const statePath = path.join(testDir, 'ecc-install-state.json');
+    try {
+      const baseOptions = {
+        adapter: { id: 'claude-home' },
+        targetRoot: path.join(testDir, '.claude'),
+        installStatePath: statePath,
+        request: { profile: 'core', modules: [], legacyLanguages: [], legacyMode: false },
+        resolution: { selectedModules: ['rules-core'], skippedModules: [] },
+        operations: [],
+        source: { repoVersion: CURRENT_PACKAGE_VERSION, repoCommit: 'abc123', manifestVersion: 1 },
+      };
+      const original = createInstallState(baseOptions);
+      writeInstallState(statePath, original);
+      const beforeContent = fs.readFileSync(statePath, 'utf8');
+      const updated = createInstallState({ ...baseOptions, request: { profile: 'core', modules: ['extra'], legacyLanguages: [], legacyMode: false } });
+      const realWrite = fs.writeFileSync;
+      fs.writeFileSync = () => { throw new Error('write boom'); };
+      try {
+        assert.throws(() => writeInstallState(statePath, updated), /write boom/);
+      } finally {
+        fs.writeFileSync = realWrite;
+      }
+      assert.strictEqual(fs.readFileSync(statePath, 'utf8'), beforeContent);
+      assert.deepStrictEqual(fs.readdirSync(testDir).filter(name => name.includes('.tmp.')), []);
+    } finally {
+      cleanupTestDir(testDir);
+    }
+  })) passed++; else failed++;
+
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
   process.exit(failed > 0 ? 1 : 0);
 }

--- a/tests/scripts/install-guided.test.js
+++ b/tests/scripts/install-guided.test.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
@@ -382,6 +384,35 @@ function runGuidedPtyFixture(answers) {
       request: { harnesses: ['claude'], claudeHooks: 'off' },
     }, output);
     assert.ok(!written.includes('enables automation'));
+  });
+
+  await test('ECC_DRY_RUN env forces guided dry-run with no apply or filesystem writes', async () => {
+    const previousDryRun = process.env.ECC_DRY_RUN;
+    process.env.ECC_DRY_RUN = '1';
+    const sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-guided-dryrun-'));
+    const sentinelPath = path.join(sandbox, 'sentinel.txt');
+    fs.writeFileSync(sentinelPath, 'sentinel');
+    const beforeEntries = fs.readdirSync(sandbox).sort();
+    const beforeContent = fs.readFileSync(sentinelPath, 'utf8');
+    try {
+      const output = capture(false);
+      let applyCalls = 0;
+      const code = await main(['--harness', 'codex', '--yes'], {
+        applyPlan: async () => { applyCalls += 1; return { status: 'complete', completed: [] }; },
+        createPlan: async request => ({ request, harnesses: [{ id: 'codex', channel: 'native-plugin', preview: {} }] }),
+        interactive: false,
+        output,
+      });
+      assert.strictEqual(code, 0);
+      assert.strictEqual(applyCalls, 0);
+      assert.deepStrictEqual(fs.readdirSync(sandbox).sort(), beforeEntries);
+      assert.strictEqual(fs.readFileSync(sentinelPath, 'utf8'), beforeContent);
+      assert.match(output.read(), /Dry run complete/);
+    } finally {
+      if (previousDryRun === undefined) delete process.env.ECC_DRY_RUN;
+      else process.env.ECC_DRY_RUN = previousDryRun;
+      fs.rmSync(sandbox, { recursive: true, force: true });
+    }
   });
 
   console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,5 +1,6 @@
-from llm.core.types import ToolCall, ToolDefinition
-from llm.tools import ToolExecutor, ToolRegistry
+from llm.core.interface import RateLimitError
+from llm.core.types import LLMInput, LLMOutput, Message, Role, ToolCall, ToolDefinition
+from llm.tools import ReActAgent, ToolExecutor, ToolRegistry
 
 
 class TestToolRegistry:
@@ -83,3 +84,53 @@ class TestToolExecutor:
         assert len(results) == 2
         assert results[0].content == "result1"
         assert results[1].content == "result2"
+
+    def test_aexecute_awaits_async_tools(self):
+        import asyncio
+
+        registry = ToolRegistry()
+
+        async def fetch(url: str) -> str:
+            return f"fetched:{url}"
+
+        registry.register(ToolDefinition(name="fetch", description="", parameters={}), fetch)
+        executor = ToolExecutor(registry)
+        result = asyncio.run(executor.aexecute(ToolCall(id="1", name="fetch", arguments={"url": "x"})))
+        assert result.is_error is False
+        assert result.content == "fetched:x"
+
+    def test_react_agent_returns_partial_output_on_provider_error(self):
+        import asyncio
+
+        from llm.core.types import ProviderType
+
+        class _FailingProvider:
+            def generate(self, _input):
+                raise RateLimitError("429 rate limited", provider=ProviderType.OPENAI)
+
+        registry = ToolRegistry()
+        agent = ReActAgent(provider=_FailingProvider(), executor=ToolExecutor(registry), max_iterations=3)
+        output = asyncio.run(agent.run(LLMInput(messages=[Message(role=Role.USER, content="hi")], model="m")))
+        assert output.stop_reason == "error"
+        assert output.model == "m"
+        assert len(output.metadata["messages"]) == 1
+
+    def test_react_agent_preserves_trajectory_on_max_iterations(self):
+        import asyncio
+
+        class _LoopProvider:
+            def __init__(self):
+                self.calls = 0
+
+            def generate(self, _input):
+                self.calls += 1
+                return LLMOutput(content="", tool_calls=[ToolCall(id=str(self.calls), name="noop", arguments={})], model="m", usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}, stop_reason="tool_calls")
+
+        registry = ToolRegistry()
+        registry.register(ToolDefinition(name="noop", description="", parameters={}), lambda: "ok")
+        agent = ReActAgent(provider=_LoopProvider(), executor=ToolExecutor(registry), max_iterations=2)
+        output = asyncio.run(agent.run(LLMInput(messages=[Message(role=Role.USER, content="hi")], model="m")))
+        assert output.stop_reason == "max_iterations"
+        assert output.model == "m"
+        assert output.usage == {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+        assert len(output.metadata["messages"]) == 5

--- a/tests/test_ollama_provider.py
+++ b/tests/test_ollama_provider.py
@@ -1,0 +1,69 @@
+import io
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from llm.core.interface import AuthenticationError
+from llm.core.types import LLMInput, Message, Role, ToolCall
+from llm.providers.ollama import OllamaProvider
+
+
+class _Response:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+def _run_generate(monkeypatch, payload):
+    provider = OllamaProvider(base_url="http://localhost:11434", default_model="llama3.2")
+    monkeypatch.setattr("urllib.request.urlopen", lambda req, timeout=60: _Response(payload))
+    return provider.generate(LLMInput(messages=[Message(role=Role.USER, content="hi")]))
+
+
+def test_ollama_provider_parses_string_tool_arguments(monkeypatch):
+    payload = {"message": {"content": "", "tool_calls": [{"id": "1", "function": {"name": "search", "arguments": '{"q":"x"}'}}]}, "done_reason": "stop"}
+    output = _run_generate(monkeypatch, payload)
+    assert output.tool_calls == [ToolCall(id="1", name="search", arguments={"q": "x"})]
+
+
+def test_ollama_provider_parses_dict_tool_arguments(monkeypatch):
+    payload = {"message": {"content": "", "tool_calls": [{"id": "1", "function": {"name": "search", "arguments": {"q": "x"}}}]}, "done_reason": "stop"}
+    output = _run_generate(monkeypatch, payload)
+    assert output.tool_calls == [ToolCall(id="1", name="search", arguments={"q": "x"})]
+
+
+def test_ollama_provider_preserves_malformed_tool_arguments(monkeypatch):
+    payload = {"message": {"content": "", "tool_calls": [{"id": "1", "function": {"name": "search", "arguments": "{bad"}}]}, "done_reason": "stop"}
+    output = _run_generate(monkeypatch, payload)
+    assert output.tool_calls == [ToolCall(id="1", name="search", arguments={"raw": "{bad"})]
+
+
+def test_ollama_connection_error_is_not_authentication_error(monkeypatch):
+    provider = OllamaProvider(base_url="http://localhost:11434", default_model="llama3.2")
+
+    def _boom(req, timeout=60):
+        raise ConnectionError("connection refused")
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+    with pytest.raises(ConnectionError):
+        provider.generate(LLMInput(messages=[Message(role=Role.USER, content="hi")]))
+
+
+def test_ollama_auth_error_maps_to_authentication_error(monkeypatch):
+    provider = OllamaProvider(base_url="http://localhost:11434", default_model="llama3.2")
+
+    def _boom(req, timeout=60):
+        raise Exception("401 unauthorized")
+
+    monkeypatch.setattr("urllib.request.urlopen", _boom)
+    with pytest.raises(AuthenticationError):
+        provider.generate(LLMInput(messages=[Message(role=Role.USER, content="hi")]))

--- a/tests/test_ollama_provider.py
+++ b/tests/test_ollama_provider.py
@@ -1,6 +1,4 @@
-import io
 import json
-from types import SimpleNamespace
 
 import pytest
 

--- a/tests/test_provider_tools.py
+++ b/tests/test_provider_tools.py
@@ -114,6 +114,38 @@ def test_openai_provider_allows_missing_usage():
     assert output.usage is None
 
 
+def test_openai_provider_preserves_malformed_tool_arguments():
+    from llm.core.types import ToolCall
+
+    provider = OpenAIProvider(api_key="test")
+    tool_call = SimpleNamespace(
+        id="call_1",
+        function=SimpleNamespace(name="search", arguments="{not-json"),
+    )
+    message = SimpleNamespace(content="", tool_calls=[tool_call])
+    provider.client = _OpenAIClient(response=_openai_response(choices=[SimpleNamespace(message=message, finish_reason="tool_calls")]))
+
+    output = provider.generate(LLMInput(messages=[Message(role=Role.USER, content="hi")]))
+
+    assert output.tool_calls == [ToolCall(id="call_1", name="search", arguments={"raw": "{not-json"})]
+
+
+def test_openai_provider_wraps_non_dict_tool_arguments():
+    from llm.core.types import ToolCall
+
+    provider = OpenAIProvider(api_key="test")
+    tool_call = SimpleNamespace(
+        id="call_2",
+        function=SimpleNamespace(name="search", arguments="[1,2]"),
+    )
+    message = SimpleNamespace(content="", tool_calls=[tool_call])
+    provider.client = _OpenAIClient(response=_openai_response(choices=[SimpleNamespace(message=message, finish_reason="tool_calls")]))
+
+    output = provider.generate(LLMInput(messages=[Message(role=Role.USER, content="hi")]))
+
+    assert output.tool_calls == [ToolCall(id="call_2", name="search", arguments={"value": [1, 2]})]
+
+
 def test_claude_provider_serializes_tools_for_messages_api():
     provider = ClaudeProvider(api_key="test")
     client = _AnthropicClient()


### PR DESCRIPTION
## Summary

- Guided install now honors the global dry-run state (`ECC_DRY_RUN=1`) in addition to `--dry-run`: `install-guided.js` resolves dry-run from env, and `install-apply.js` forwards it on the `--guided` dispatch path so a prefixed `ecc --dry-run install --guided...` can no longer perform real writes.
- `writeInstallState` is atomic (tmp + fsync + rename) with temp cleanup on write/rename failure and a best-effort parent-directory fsync after rename.
- Hook dispatcher `hasRunExport` check strips comments/strings before matching, so `require()` is only attempted for real `run` exports; spawn fallback preserved.
- Ollama `_parse_tool_arguments` returns a copy instead of aliasing the provider-response dict; OpenAI gains the same malformed/non-dict fallback already used by Atlas.

## Tests

- `tests/scripts/install-guided.test.js`: new case proves `ECC_DRY_RUN=1` without a flag performs no apply and leaves the filesystem unchanged (15/15 pass).
- `tests/lib/install-state.test.js`: rename-failure and write-failure boundary cases preserve the original file with no stale temps (8/8 pass).
- Python: OpenAI malformed/non-dict args, new Ollama provider cases (string/dict/malformed args, connection-vs-auth mapping), async `aexecute` and ReActAgent partial-output/trajectory cases; JS syntax checks and manual harnesses verified.

## Verification

- `ECC_DRY_RUN=1 node scripts/install-apply.js --guided --harness codex --yes --json` emits a `dryRun: true` preview instead of applying.