### PR TITLE
Fix/rails patterns followups

### DIFF
--- a/config/project-stack-mappings.json
+++ b/config/project-stack-mappings.json
@@ -359,6 +359,7 @@
       ],
       "rules": ["common"],
       "skills": [
+        "rails-patterns",
         "tdd-workflow",
         "verification-loop"
       ],

--- a/skills/rails-patterns/SKILL.md
+++ b/skills/rails-patterns/SKILL.md
@@ -163,8 +163,8 @@ module Invoices
 
     def build_invoice
       invoice = user.invoices.new(params.except(:line_items))
-      invoice.tax_total = TaxCalculator.call(invoice)
       invoice.line_items.build(params[:line_items])
+      invoice.tax_total = TaxCalculator.call(invoice)
       invoice.total = invoice.line_items.sum(&:amount) + invoice.tax_total
       invoice
     end
@@ -258,7 +258,7 @@ Query objects accept a scope, so they compose: `Invoices::Overdue.call(scope: cu
 @posts = Post.published.includes(:author)
 ```
 
-`includes` lets Rails choose preload vs eager_load. Force `preload` for separate queries, `eager_load` for a JOIN when filtering on the association. In Rails 7.1+, `strict_loading` raises on accidental lazy loads.
+`includes` lets Rails choose preload vs eager_load. Force `preload` for separate queries, `eager_load` for a JOIN when filtering on the association. Since Rails 6.1, `strict_loading` raises on accidental lazy loads.
 
 ### Counter cache
 
@@ -472,5 +472,4 @@ If the page is server-rendered with occasional interactivity, Hotwire ships fast
 ## Related Skills
 
 - `backend-patterns` — service boundaries and adapter patterns (referenced by the Ruby patterns rules)
-- `ruby-patterns` — language-level Ruby idioms (if present)
 - Ruby patterns rules (`rules/ruby/patterns.md`, installed as `rules/ecc/ruby/patterns.md`) — the decisions and when-to-use guidance this skill implements


### PR DESCRIPTION
## What Changed
- `config/project-stack-mappings.json`: added `rails-patterns` to the `ruby` stack's skills list
- `skills/rails-patterns/SKILL.md`: removed the Related Skills reference to the nonexistent `ruby-patterns` skill
- `skills/rails-patterns/SKILL.md`: moved `line_items.build` above `TaxCalculator.call` in `build_invoice`, and corrected `strict_loading` from Rails 7.1 to 6.1

## Why This Change
Follow-up to #3074, addressing the three items raised after merge. The `ruby` stack listed only `tdd-workflow` and `verification-loop`, so Gemfile-detected repos never had `rails-patterns` suggested, unlike the `php-laravel` and `django` stacks. The Related Skills entry pointed at a skill that does not exist. In `build_invoice`, tax was computed before line items were built, so the canonical example produced tax on an empty invoice.

## Testing Done
<!-- Describe the testing you performed to validate your changes -->
- [x] Manual testing completed
- [x] Automated tests pass locally (`node tests/run-all.js`)
- [ ] Edge cases considered and tested

## Type of Change
- [x] `fix:` Bug fix
- [ ] `feat:` New feature
- [ ] `refactor:` Code refactoring
- [ ] `docs:` Documentation
- [ ] `test:` Tests
- [ ] `chore:` Maintenance/tooling
- [ ] `ci:` CI/CD changes

## Security & Quality Checklist
- [x] No secrets or API keys committed (ghp_, sk-, AKIA, xoxb, xoxp patterns checked)
- [x] JSON files validate cleanly
- [ ] Shell scripts pass shellcheck (if applicable)
- [ ] Pre-commit hooks pass locally (if configured)
- [x] No sensitive data exposed in logs or output
- [x] Follows conventional commits format

## If you changed dependencies or `package.json` (`bin` / `files` / deps)
- [ ] Ran `yarn install --mode=update-lockfile` and committed the `yarn.lock` change. CI runs Yarn in hardened mode on public PRs and fails if the lockfile would be modified, so an out of date `yarn.lock` breaks the build even when nothing else is wrong.

## If you added a skill, command, agent, hook, or CLI tool
- [ ] Registered in `package.json` (`bin` and `files`), `manifests/install-components.json`, `manifests/install-modules.json`, and `agent.yaml`
- [ ] Regenerated the catalog (`npm run catalog:sync`) and command registry (`npm run command-registry:write`)
- [ ] Updated the docs tables it belongs in (`README.md`, `COMMANDS-QUICK-REF.md`, `docs/COMMAND-AGENT-MAP.md`)
- [ ] If it ships a new script path, added it to the publish surface allowlist (`tests/scripts/npm-publish-surface.test.js`)
- [ ] Cross-harness surfaces updated if applicable (for Codex, `.agents/skills/<name>/` plus `agents/openai.yaml`; the Codex frontmatter validator allows only `name`, `description`, `metadata`, `license`, `allowed-tools`, so drop keys like `version` from that copy)
- [x] Full gauntlet passes locally (`npm test`)

## Documentation
- [x] Updated relevant documentation
- [ ] Added comments for complex logic
- [ ] README updated (if needed)
