### PR TITLE
fix(memory): classify directory traversal failures

### DIFF
--- a/scripts/lib/memory-vault.js
+++ b/scripts/lib/memory-vault.js
@@ -443,6 +443,12 @@ function publicMemoryFileError(error) {
   };
 }
 
+function incompleteMemoryLookupError() {
+  const error = new Error('Memory lookup is incomplete. Inspect the authorized vault before retrying.');
+  error.code = 'ECC_MEMORY_INCOMPLETE';
+  return error;
+}
+
 function readMemoryFiles(options = {}) {
   const roots = options.roots || resolveVaultRoots(options);
   const scopes = normalizeScopes(options.scopes || DEFAULT_RECALL_SCOPES);
@@ -461,7 +467,13 @@ function readMemoryFiles(options = {}) {
       break;
     }
     const root = assertMemoryRootSafe(roots, scope);
-    const walked = walkMemoryRoot(root, MAX_FILES - visitedCount);
+    let walked;
+    try {
+      walked = walkMemoryRoot(root, MAX_FILES - visitedCount);
+    } catch {
+      // Directory open/read/close failures cannot establish a complete lookup.
+      throw incompleteMemoryLookupError();
+    }
     visitedCount += walked.visitedCount;
     truncated = truncated || walked.truncated;
     skippedSymlinkCount += walked.skippedSymlinkCount;
@@ -660,9 +672,7 @@ function readMemoryById(id, options = {}) {
     : null;
   const loaded = readMemoryFiles(options);
   if (loaded.truncated || loaded.invalidFileCount > 0) {
-    const error = new Error('Memory lookup is incomplete. Inspect the authorized vault before retrying.');
-    error.code = 'ECC_MEMORY_INCOMPLETE';
-    throw error;
+    throw incompleteMemoryLookupError();
   }
   const matches = loaded.entries
     .filter(entry => entry.memory.id === memoryId)

--- a/tests/lib/memory-read-completeness.test.js
+++ b/tests/lib/memory-read-completeness.test.js
@@ -75,6 +75,50 @@ async function main() {
       fs.openSync = open;
     }
   });
+  function failTraversal(roots, phase, fn) {
+    const open = fs.opendirSync;
+    let closed = false;
+    fs.opendirSync = (directory, ...args) => {
+      if (directory !== roots.project) return open(directory, ...args);
+      const fail = () => {
+        const error = new Error('Synthetic private directory detail.');
+        error.code = 'EACCES';
+        throw error;
+      };
+      if (phase === 'open') return fail();
+      const handle = open(directory, ...args);
+      return {
+        readSync: () => phase === 'read' ? fail() : handle.readSync(),
+        closeSync: () => {
+          handle.closeSync(); closed = true;
+          if (phase === 'close') fail();
+        },
+      };
+    };
+    try { fn(); } finally {
+      fs.opendirSync = open;
+      if (phase !== 'open') assert.equal(closed, true);
+    }
+  }
+  for (const phase of ['open', 'read', 'close']) {
+    check(`direct read classifies directory ${phase} failure`, ({ roots, read }) => {
+      failTraversal(roots, phase, () => {
+        assert.throws(read, error => error.code === 'ECC_MEMORY_INCOMPLETE'
+          && !error.message.includes('Synthetic private directory detail.'));
+      });
+    });
+    check(`MCP read classifies directory ${phase} failure`, ({ roots, mcp }) => {
+      failTraversal(roots, phase, () => {
+        const result = mcp(); assert.equal(result.isError, true);
+        const error = JSON.parse(result.content[0].text).error;
+        assert.equal(error.code, 'MEMORY_READ_INCOMPLETE');
+        assert.equal(error.message.includes('Synthetic private directory detail.'), false);
+      });
+    });
+  }
+  check('unreadable traversal cannot establish missing memory', ({ roots, read }) => {
+    failTraversal(roots, 'open', () => incomplete(() => read('mem_synthetic_missing')));
+  });
   check('MCP incomplete lookup has a distinct bounded error', ({ mcp, truncate }) => {
     truncate(); const result = mcp(); assert.equal(result.isError, true);
     const error = JSON.parse(result.content[0].text).error;


### PR DESCRIPTION
An unreadable vault directory throws before the completeness check added in #3095. Direct reads then expose the filesystem error, while MCP reports a generic read failure instead of an incomplete lookup.

Classify directory open/read/close failures as `ECC_MEMORY_INCOMPLETE`, using the same safe message as other incomplete scans. MCP's existing mapping now returns `MEMORY_READ_INCOMPLETE`. Root/path-policy checks remain outside this catch, and no partial content is returned after a traversal failure. Search and doctor continue to fail on traversal errors, with sanitized details.

Validation on main `90ef62cb`:

- Seven new direct-core/MCP traversal regressions reproduced the failure; all 17 focused cases now pass.
- All 35 existing vault-core tests and affected-file ESLint pass.
- Independent code and security review bind the exact two-file patch.

Tests use disposable synthetic vaults and bounded filesystem fault injection, with restored handles and functions. No dependency, schema, authorization-policy, server or provider changes.
