### PR TITLE
feat(vibe): add native skill target

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ npx ecc-universal@2.2.1 doctor --target kimi
 
 Do not use `npx ecc-install --profile minimal --target claude`: `ecc-install` is a binary name inside `ecc-universal`, not a separately published npm package.
 
-ECC also ships advanced managed adapters for `cursor`, `antigravity`, `gemini`, `opencode`, `codebuddy`, `joycode`, `qwen`, `zed`, `hermes`, and `openclaw`. Those targets still use their documented `ecc install --target ...` paths until each adapter has passed the guided collision, update, repair, and uninstall lifecycle matrix. Neither wizard silently installs into every detected harness.
+ECC also ships advanced managed adapters for `cursor`, `antigravity`, `gemini`, `opencode`, `codebuddy`, `joycode`, `qwen`, `zed`, `hermes`, `openclaw`, and `mistral-vibe`. Those targets still use their documented `ecc install --target ...` paths until each adapter has passed the guided collision, update, repair, and uninstall lifecycle matrix. Neither wizard silently installs into every detected harness.
 
 ### Pick one path only (per harness)
 
@@ -357,7 +357,7 @@ For repo navigation, surface ownership, and PR diff packet guidance, read the [C
 ### Other agents and editors
 
 <details>
-<summary><strong>Cursor, OpenCode, Gemini, Zed, Antigravity, Qwen, Hermes, OpenClaw, Kimi, CodeBuddy, JoyCode, Copilot</strong></summary>
+<summary><strong>Cursor, OpenCode, Gemini, Zed, Antigravity, Qwen, Hermes, OpenClaw, Kimi, Mistral Vibe, CodeBuddy, JoyCode, Copilot</strong></summary>
 
 Clone ECC once, then choose the target that matches your harness:
 
@@ -377,6 +377,7 @@ cd ECC
 | Hermes | `./install.sh --profile minimal --target hermes` | See the [Hermes setup guide](docs/HERMES-SETUP.md) |
 | OpenClaw | `./install.sh --profile minimal --target openclaw` | Managed home-directory install |
 | Kimi Code CLI | `./install.sh --profile minimal --target kimi` | Project-local `.kimi-code/` install · [Get Kimi Code](https://www.kimi.com/code?aff=ecc) |
+| Mistral Vibe | `./install.sh --target mistral-vibe --skills tdd-workflow` | Project-local `.vibe/skills/` install · [Mistral Vibe guide](docs/MISTRAL-VIBE-GUIDE.md) |
 | CodeBuddy | `./install.sh --profile minimal --target codebuddy` | Project-local `.codebuddy/` install |
 | JoyCode | `./install.sh --profile minimal --target joycode` | Project-local `.joycode/` install |
 
@@ -1260,7 +1261,7 @@ Treat `stable`, `beta`, `experimental`, and `instruction-only` below as capabili
 | Cursor | Beta project adapter | Selective installer into `.cursor/` | Agent discovery varies by Cursor build, and ECC's installer paths do not yet expose identical hook sets ([#2419](https://github.com/affaan-m/ECC/issues/2419)). |
 | OpenCode | Beta built plugin | Build plugin, then selective installer | ECC ships a subset of the catalog; connect a provider and select a model in OpenCode ([#2617](https://github.com/affaan-m/ECC/issues/2617)). |
 | GitHub Copilot | Instruction-only | Checked-in instructions and prompt files | No ECC hooks, runtime agents, delegation, or native skill discovery. |
-| Gemini, Zed, Antigravity, Qwen, Hermes, OpenClaw, Kimi, CodeBuddy, JoyCode | Experimental/minimal adapters | Harness-specific selective target | File placement and instruction portability are tested; full Claude feature parity is not claimed. |
+| Gemini, Zed, Antigravity, Qwen, Hermes, OpenClaw, Kimi, Mistral Vibe, CodeBuddy, JoyCode | Experimental/minimal adapters | Harness-specific selective target | File placement and instruction portability are tested; full Claude feature parity is not claimed. |
 
 <details>
 <summary><strong>Package manager detection</strong></summary>

--- a/docs/MISTRAL-VIBE-GUIDE.md
+++ b/docs/MISTRAL-VIBE-GUIDE.md
@@ -1,0 +1,64 @@
+# Mistral Vibe integration
+
+ECC provides a project-local, skills-first integration for Mistral Vibe. The
+contract in this guide is verified against **Mistral Vibe v2.25.3**.
+
+## Install a skill
+
+Run the installer from the project that Vibe will open. Keep the ECC source
+checkout separate so managed files are written to the target project:
+
+```bash
+ECC_ROOT="/absolute/path/to/ECC"
+"$ECC_ROOT/install.sh" --target mistral-vibe --skills tdd-workflow
+```
+
+After a release containing this target is published, verify the registry
+version and pin that released version:
+
+```bash
+npm view ecc-universal version
+npx ecc-universal@<released-version> install --target mistral-vibe --skills tdd-workflow
+```
+
+Install multiple skills with a comma-separated list:
+
+```bash
+"$ECC_ROOT/install.sh" --target mistral-vibe --skills tdd-workflow,security-review
+```
+
+ECC writes each selected skill to `.vibe/skills/<name>/`. Vibe discovers this
+directory natively for trusted projects and loads each `SKILL.md` through its
+Agent Skills implementation. ECC records only its managed files in
+`.vibe/ecc-install-state.json`; an existing user-owned skill file is preserved.
+
+## Verify and maintain the install
+
+```bash
+node "$ECC_ROOT/scripts/list-installed.js" --target mistral-vibe
+node "$ECC_ROOT/scripts/doctor.js" --target mistral-vibe
+node "$ECC_ROOT/scripts/repair.js" --target mistral-vibe
+node "$ECC_ROOT/scripts/uninstall.js" --target mistral-vibe
+```
+
+Use `--dry-run --json` with install, repair, or uninstall to inspect changes
+before writing them. Repair restores missing or drifted ECC-managed skill files.
+Uninstall removes unchanged managed files, but preserves modified files and the
+install-state so they can be reviewed.
+
+## Compatibility boundary
+
+This first integration deliberately installs Agent Skills only. It does not
+configure Vibe model/provider credentials, `.vibe/config.toml`, MCP servers, or
+`.vibe/hooks.toml`. It also does not translate ECC's Claude-oriented agent
+Markdown into `.vibe/agents/*.toml`, and it does not claim that ECC command or
+rule directories are native Vibe surfaces.
+
+Vibe also discovers project-level `.agents/skills/` and root `AGENTS.md`, but
+ECC uses `.vibe/skills/` so every managed write and lifecycle action stays
+inside one project-local ownership boundary.
+
+Official references:
+
+- [Mistral Vibe](https://github.com/mistralai/mistral-vibe)
+- [Agent Skills specification](https://agentskills.io/specification)

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "docs/CODEX-NAVIGATION-GUIDE.md",
     "docs/COMMAND-AGENT-MAP.md",
     "docs/ROADMAP.md",
+    "docs/MISTRAL-VIBE-GUIDE.md",
     "docs/design/ecc-memory-vault.md",
     "docs/ja-JP/",
     "docs/ko-KR/",

--- a/schemas/ecc-install-config.schema.json
+++ b/schemas/ecc-install-config.schema.json
@@ -32,7 +32,8 @@
         "hermes",
         "openclaw",
         "kimi",
-        "adal"
+        "adal",
+        "mistral-vibe"
       ]
     },
     "profile": {
@@ -50,14 +51,14 @@
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^(baseline|lang|framework|capability):[a-z0-9-]+$"
+        "pattern": "^(baseline|lang|framework|capability|skill):[a-z0-9-]+$"
       }
     },
     "exclude": {
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^(baseline|lang|framework|capability):[a-z0-9-]+$"
+        "pattern": "^(baseline|lang|framework|capability|skill):[a-z0-9-]+$"
       }
     },
     "options": {

--- a/schemas/install-modules.schema.json
+++ b/schemas/install-modules.schema.json
@@ -62,7 +62,8 @@
                 "hermes",
                 "openclaw",
                 "kimi",
-                "adal"
+                "adal",
+                "mistral-vibe"
               ]
             }
           },

--- a/scripts/consult.js
+++ b/scripts/consult.js
@@ -242,11 +242,17 @@ function commandFor(kind, id, target) {
   if (kind === 'profile') {
     return `npx ecc-universal install --profile ${id} --target ${target}`;
   }
+  if (target === 'mistral-vibe' && id.startsWith('skill:')) {
+    return `npx ecc-universal install --target mistral-vibe --skills ${id.slice('skill:'.length)}`;
+  }
 
   return `npx ecc-universal install --profile minimal --target ${target} --with ${id}`;
 }
 
 function planCommandFor(componentId, target) {
+  if (target === 'mistral-vibe' && componentId.startsWith('skill:')) {
+    return `npx ecc-universal plan --target mistral-vibe --skills ${componentId.slice('skill:'.length)}`;
+  }
   return `npx ecc-universal plan --profile minimal --target ${target} --with ${componentId}`;
 }
 
@@ -358,6 +364,7 @@ function rankComponents({ queryTokens, target, limit }) {
 }
 
 function rankProfiles({ queryTokens, target, limit }) {
+  if (target === 'mistral-vibe') return [];
   const manifests = loadInstallManifests();
   return listInstallProfiles()
     .map(profile => {

--- a/scripts/install-apply.js
+++ b/scripts/install-apply.js
@@ -49,6 +49,7 @@ Targets:
   kimi         - Install Kimi Code project instructions, skills, and MCP config into ./.kimi-code/ (ECC hooks not configured)
   openclaw     - Install shared rules/skills/commands into ~/.openclaw/
   adal         - Install shared rules/skills/commands into ./.adal/
+  mistral-vibe - Install selected skills into ./.vibe/skills/ (Vibe hooks and agents not configured)
 
 Options:
   --profile <name>    Resolve and install a manifest profile

--- a/scripts/install-plan.js
+++ b/scripts/install-plan.js
@@ -261,6 +261,7 @@ function main() {
       includeComponentIds: request.includeComponentIds,
       excludeComponentIds: request.excludeComponentIds,
       target: request.target,
+      projectRoot: process.cwd(),
     });
 
     if (options.json) {

--- a/scripts/lib/harness-capabilities.js
+++ b/scripts/lib/harness-capabilities.js
@@ -215,6 +215,23 @@ const HARNESS_CAPABILITIES = deepFreeze([
     aliases: ['adal-cli'],
   },
   {
+    id: 'mistral-vibe',
+    label: 'Mistral Vibe',
+    targetIds: ['mistral-vibe'],
+    channel: 'managed-project',
+    installMode: 'managed-project',
+    guidedReady: false,
+    availability: 'advanced',
+    destination: './.vibe',
+    scopes: [scope('project', 'mistral-vibe', './.vibe')],
+    hooks: hooks(
+      'not-configured',
+      false,
+      'ECC installs selected Agent Skills only; Vibe hooks, agents, and provider configuration are not configured.'
+    ),
+    aliases: ['vibe'],
+  },
+  {
     id: 'hermes',
     label: 'Hermes',
     targetIds: ['hermes'],

--- a/scripts/lib/install-executor.js
+++ b/scripts/lib/install-executor.js
@@ -47,6 +47,12 @@ function validateLegacyTarget(target) {
   // positional syntax (which is legacy-only). Guide the user to the right mode
   // instead of implying the target is unknown (#2282).
   if (SUPPORTED_INSTALL_TARGETS.includes(target)) {
+    if (target === 'mistral-vibe') {
+      throw new Error(
+        "Target 'mistral-vibe' supports explicit Agent Skill installs only. " +
+          "Use `install.sh --target mistral-vibe --skills <id,...>`."
+      );
+    }
     throw new Error(
       `Target '${target}' is supported, but the bare-language install syntax only accepts ${LEGACY_INSTALL_TARGETS.join(', ')}. ` +
         `Install '${target}' with a component selection instead, e.g. \`install.sh --target ${target} --profile full\` ` +

--- a/scripts/lib/install-manifests.js
+++ b/scripts/lib/install-manifests.js
@@ -5,7 +5,7 @@ const { getInstallTargetAdapter, planInstallTargetScaffold } = require('./instal
 const { resolveInvocationEnvironment } = require('./invocation-environment');
 
 const DEFAULT_REPO_ROOT = path.join(__dirname, '../..');
-const SUPPORTED_INSTALL_TARGETS = ['claude', 'claude-project', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'joycode', 'qwen', 'zed', 'hermes', 'openclaw', 'kimi', 'adal'];
+const SUPPORTED_INSTALL_TARGETS = ['claude', 'claude-project', 'cursor', 'antigravity', 'codex', 'gemini', 'opencode', 'codebuddy', 'joycode', 'qwen', 'zed', 'hermes', 'openclaw', 'kimi', 'adal', 'mistral-vibe'];
 const COMPONENT_FAMILY_PREFIXES = {
   baseline: 'baseline:',
   language: 'lang:',
@@ -189,42 +189,58 @@ function listSkillDirectoryIds(repoRoot) {
     .sort();
 }
 
-function addSyntheticSkillComponents({ repoRoot, modules, components }) {
-  const moduleIds = new Set(modules.map(module => module.id));
+function addSyntheticSkillComponents({ repoRoot, modules, components, target = null }) {
+  const originalModuleIds = new Set(modules.map(module => module.id));
   const componentIds = new Set(components.map(component => component.id));
+  const syntheticModules = [];
+  const syntheticComponents = [];
 
   for (const skillId of listSkillDirectoryIds(repoRoot)) {
     const componentId = `skill:${skillId}`;
+    const needsTargetSpecificModule = target === 'mistral-vibe';
+    if (componentIds.has(componentId) && !needsTargetSpecificModule) {
+      continue;
+    }
+    const moduleId = `skill-${skillId}`;
+    const exactSkillModule = {
+      id: moduleId,
+      kind: 'skills',
+      description: `Single-skill install surface for ${skillId}.`,
+      paths: [`skills/${skillId}`],
+      targets: needsTargetSpecificModule
+        ? ['mistral-vibe']
+        : SUPPORTED_INSTALL_TARGETS.slice(),
+      dependencies: [],
+      defaultInstall: false,
+      cost: 'light',
+      stability: 'stable',
+      synthetic: true,
+    };
+    if (needsTargetSpecificModule || !originalModuleIds.has(moduleId)) {
+      syntheticModules.push(exactSkillModule);
+    }
+
     if (componentIds.has(componentId)) {
       continue;
     }
 
-    const moduleId = `skill-${skillId}`;
-    if (!moduleIds.has(moduleId)) {
-      modules.push({
-        id: moduleId,
-        kind: 'skills',
-        description: `Single-skill install surface for ${skillId}.`,
-        paths: [`skills/${skillId}`],
-        targets: SUPPORTED_INSTALL_TARGETS.slice(),
-        dependencies: [],
-        defaultInstall: false,
-        cost: 'light',
-        stability: 'stable',
-        synthetic: true,
-      });
-      moduleIds.add(moduleId);
-    }
-
-    components.push({
+    syntheticComponents.push({
       id: componentId,
       family: 'skill',
       description: `Install only the ${skillId} skill directory.`,
       modules: [moduleId],
       synthetic: true,
     });
-    componentIds.add(componentId);
   }
+
+  const replacementModuleIds = new Set(syntheticModules.map(module => module.id));
+  return {
+    modules: [
+      ...modules.filter(module => !replacementModuleIds.has(module.id)),
+      ...syntheticModules,
+    ],
+    components: [...components, ...syntheticComponents],
+  };
 }
 
 function readOptionalStringOption(options, key) {
@@ -292,6 +308,21 @@ function intersectTargets(modules) {
   ));
 }
 
+function getComponentModuleIds(component, manifests, target = null) {
+  const skillId = component.id.startsWith(COMPONENT_FAMILY_PREFIXES.skill)
+    ? component.id.slice(COMPONENT_FAMILY_PREFIXES.skill.length)
+    : null;
+  const exactSkillModuleId = skillId ? `skill-${skillId}` : null;
+  if (
+    target === 'mistral-vibe'
+    && exactSkillModuleId
+    && manifests.modulesById.has(exactSkillModuleId)
+  ) {
+    return [exactSkillModuleId];
+  }
+  return dedupeStrings(component.modules);
+}
+
 function getManifestPaths(repoRoot = DEFAULT_REPO_ROOT) {
   return {
     modulesPath: path.join(repoRoot, 'manifests', 'install-modules.json'),
@@ -319,23 +350,30 @@ function loadInstallManifests(options = {}) {
     : {};
   const components = Array.isArray(componentsData.components) ? componentsData.components.slice() : [];
 
-  addSyntheticSkillComponents({ repoRoot, modules, components });
+  const withSyntheticSkills = addSyntheticSkillComponents({
+    repoRoot,
+    modules,
+    components,
+    target: options.target || null,
+  });
+  const resolvedModules = withSyntheticSkills.modules;
+  const resolvedComponents = withSyntheticSkills.components;
 
-  for (const module of modules) {
+  for (const module of resolvedModules) {
     readModuleTargetsOrThrow(module);
   }
 
-  const modulesById = new Map(modules.map(module => [module.id, module]));
-  const componentsById = new Map(components.map(component => [component.id, component]));
+  const modulesById = new Map(resolvedModules.map(module => [module.id, module]));
+  const componentsById = new Map(resolvedComponents.map(component => [component.id, component]));
 
   return {
     repoRoot,
     modulesPath,
     profilesPath,
     componentsPath,
-    modules,
+    modules: resolvedModules,
     profiles,
-    components,
+    components: resolvedComponents,
     modulesById,
     componentsById,
     modulesVersion: modulesData.version,
@@ -398,7 +436,7 @@ function listInstallComponents(options = {}) {
   return manifests.components
     .filter(component => !family || component.family === family)
     .map(component => {
-      const moduleIds = dedupeStrings(component.modules);
+      const moduleIds = getComponentModuleIds(component, manifests, target);
       const modules = moduleIds
         .map(moduleId => manifests.modulesById.get(moduleId))
         .filter(Boolean);
@@ -429,7 +467,7 @@ function getInstallComponent(componentId, options = {}) {
     throw new Error(`Unknown install component: ${normalizedComponentId}`);
   }
 
-  const moduleIds = dedupeStrings(component.modules);
+  const moduleIds = getComponentModuleIds(component, manifests, options.target || null);
   const modules = moduleIds
     .map(moduleId => manifests.modulesById.get(moduleId))
     .filter(Boolean)
@@ -455,7 +493,7 @@ function getInstallComponent(componentId, options = {}) {
   };
 }
 
-function expandComponentIdsToModuleIds(componentIds, manifests) {
+function expandComponentIdsToModuleIds(componentIds, manifests, options = {}) {
   const expandedModuleIds = [];
 
   for (const componentId of dedupeStrings(componentIds)) {
@@ -463,7 +501,11 @@ function expandComponentIdsToModuleIds(componentIds, manifests) {
     if (!component) {
       throw new Error(`Unknown install component: ${componentId}`);
     }
-    expandedModuleIds.push(...component.modules);
+    expandedModuleIds.push(...getComponentModuleIds(
+      component,
+      manifests,
+      options.target || null
+    ));
   }
 
   return dedupeStrings(expandedModuleIds);
@@ -543,13 +585,19 @@ function resolveLegacyCompatibilitySelection(options = {}) {
 }
 
 function resolveInstallPlan(options = {}) {
-  const manifests = loadInstallManifests(options);
+  const target = options.target || null;
+  const manifests = loadInstallManifests({ ...options, target });
   const requestedProfileId = options.profileId || null;
   const explicitModuleIds = dedupeStrings(options.moduleIds);
   const includedComponentIds = dedupeStrings(options.includeComponentIds);
   const excludedComponentIds = dedupeStrings(options.excludeComponentIds);
   const requestedModuleIds = [];
-  const target = options.target || null;
+
+  if (target === 'mistral-vibe' && requestedProfileId) {
+    throw new Error(
+      'Mistral Vibe currently supports explicit Agent Skill installs only; use --skills <id,...> instead of a profile.'
+    );
+  }
 
   if (target && !SUPPORTED_INSTALL_TARGETS.includes(target)) {
     throw new Error(
@@ -577,16 +625,24 @@ function resolveInstallPlan(options = {}) {
   }
 
   requestedModuleIds.push(...explicitModuleIds);
-  requestedModuleIds.push(...expandComponentIdsToModuleIds(includedComponentIds, manifests));
+  requestedModuleIds.push(...expandComponentIdsToModuleIds(
+    includedComponentIds,
+    manifests,
+    { target }
+  ));
 
-  const excludedModuleIds = expandComponentIdsToModuleIds(excludedComponentIds, manifests);
+  const excludedModuleIds = expandComponentIdsToModuleIds(
+    excludedComponentIds,
+    manifests,
+    { target }
+  );
   const excludedModuleOwners = new Map();
   for (const componentId of excludedComponentIds) {
     const component = manifests.componentsById.get(componentId);
     if (!component) {
       throw new Error(`Unknown install component: ${componentId}`);
     }
-    for (const moduleId of component.modules) {
+    for (const moduleId of getComponentModuleIds(component, manifests, target)) {
       const owners = excludedModuleOwners.get(moduleId) || [];
       owners.push(componentId);
       excludedModuleOwners.set(moduleId, owners);
@@ -615,6 +671,11 @@ function resolveInstallPlan(options = {}) {
   );
 
   if (requestedModuleIds.length === 0) {
+    if (target === 'mistral-vibe') {
+      throw new Error(
+        'Mistral Vibe currently supports explicit Agent Skill installs only; use --skills <id,...>.'
+      );
+    }
     throw new Error('No install profile, module IDs, or included component IDs were provided');
   }
 
@@ -698,6 +759,11 @@ function resolveInstallPlan(options = {}) {
   const selectedModules = manifests.modules.filter(module => selectedIds.has(module.id));
   const skippedModules = manifests.modules.filter(module => skippedTargetIds.has(module.id));
   const excludedModules = manifests.modules.filter(module => excludedIds.has(module.id));
+  if (target === 'mistral-vibe' && selectedModules.length === 0) {
+    throw new Error(
+      'Mistral Vibe currently supports explicit Agent Skill installs only; use --skills <id,...>.'
+    );
+  }
   const scaffoldPlan = target
     ? planInstallTargetScaffold({
       target,

--- a/scripts/lib/install-targets/helpers.js
+++ b/scripts/lib/install-targets/helpers.js
@@ -15,6 +15,7 @@ const PLATFORM_SOURCE_PATH_OWNERS = Object.freeze({
   '.hermes': 'hermes',
   '.kimi': 'kimi',
   '.kimi-code': 'kimi',
+  '.vibe': 'mistral-vibe',
   '.joycode': 'joycode',
   '.opencode': 'opencode',
   '.openclaw': 'openclaw',

--- a/scripts/lib/install-targets/mistral-vibe-project.js
+++ b/scripts/lib/install-targets/mistral-vibe-project.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const path = require('path');
+
+const {
+  createInstallTargetAdapter,
+  createManagedScaffoldOperation,
+} = require('./helpers');
+
+function parseSkillSourcePath(sourceRelativePath) {
+  if (typeof sourceRelativePath !== 'string' || sourceRelativePath.length === 0) {
+    throw new Error('Unsafe Mistral Vibe skill source path: expected skills/<name>');
+  }
+  if (path.isAbsolute(sourceRelativePath) || path.win32.isAbsolute(sourceRelativePath)) {
+    throw new Error(`Unsafe Mistral Vibe skill source path: ${sourceRelativePath}`);
+  }
+
+  const segments = sourceRelativePath.replace(/\\/g, '/').split('/');
+  if (
+    segments.length < 2
+    || segments[0] !== 'skills'
+    || segments.some(segment => !segment || segment === '.' || segment === '..' || segment.includes('\0'))
+  ) {
+    throw new Error(`Unsafe Mistral Vibe skill source path: ${sourceRelativePath}`);
+  }
+
+  return segments;
+}
+
+module.exports = createInstallTargetAdapter({
+  id: 'mistral-vibe-project',
+  target: 'mistral-vibe',
+  kind: 'project',
+  rootSegments: ['.vibe'],
+  installStatePathSegments: ['ecc-install-state.json'],
+  supportsModule(module) {
+    const paths = Array.isArray(module && module.paths) ? module.paths : [];
+    return module && module.kind === 'skills' && paths.length > 0;
+  },
+  planOperations(input, adapter) {
+    const modules = Array.isArray(input.modules)
+      ? input.modules
+      : (input.module ? [input.module] : []);
+    const targetRoot = adapter.resolveRoot(input);
+
+    return modules.flatMap(module => {
+      if (!adapter.supportsModule(module, input)) return [];
+
+      return module.paths.map(sourceRelativePath => {
+        const segments = parseSkillSourcePath(sourceRelativePath);
+        return createManagedScaffoldOperation(
+          module.id,
+          sourceRelativePath,
+          path.join(targetRoot, 'skills', ...segments.slice(1)),
+          'preserve-relative-path'
+        );
+      });
+    });
+  },
+});

--- a/scripts/lib/install-targets/registry.js
+++ b/scripts/lib/install-targets/registry.js
@@ -9,6 +9,7 @@ const geminiProject = require('./gemini-project');
 const hermesHome = require('./hermes-home');
 const joycodeProject = require('./joycode-project');
 const kimiProject = require('./kimi-project');
+const mistralVibeProject = require('./mistral-vibe-project');
 const openclawHome = require('./openclaw-home');
 const opencodeHome = require('./opencode-home');
 const qwenHome = require('./qwen-home');
@@ -28,6 +29,7 @@ const ADAPTERS = Object.freeze([
   codebuddyProject,
   joycodeProject,
   kimiProject,
+  mistralVibeProject,
   qwenHome,
   zedProject,
   adalProject,

--- a/tests/ci/packed-artifact-lifecycle.js
+++ b/tests/ci/packed-artifact-lifecycle.js
@@ -377,12 +377,14 @@ function findDriftCandidate(state, cursorRoot) {
 }
 
 function runTargetSmoke(options) {
+  const selectionArgs = Array.isArray(options.selectionArgs)
+    ? options.selectionArgs
+    : ['--modules', 'workflow-quality', '--enable-hooks'];
   parseJsonOutput(
     options.runCli([
       'install',
-      '--modules', 'workflow-quality',
+      ...selectionArgs,
       '--target', options.target,
-      '--enable-hooks',
       '--json',
     ]),
     `${options.target} packed install`
@@ -858,6 +860,14 @@ function runLifecycle(options) {
     });
     assert.ok(!fs.existsSync(path.join(homeDir, '.opencode')));
 
+    const mistralVibeRoot = path.join(projectDir, '.vibe');
+    runTargetSmoke({
+      runCli,
+      target: 'mistral-vibe',
+      targetRoot: mistralVibeRoot,
+      selectionArgs: ['--skills', 'skill-comply'],
+    });
+
     return {
       packageSha256: options.expectedSha256,
       platform: process.platform,
@@ -889,6 +899,7 @@ function runLifecycle(options) {
         'sentinel-preserved',
         'antigravity-install-doctor-uninstall',
         'opencode-install-doctor-uninstall',
+        'mistral-vibe-skill-install-doctor-uninstall',
       ],
     };
   } finally {

--- a/tests/ci/packed-artifact-lifecycle.test.js
+++ b/tests/ci/packed-artifact-lifecycle.test.js
@@ -155,6 +155,17 @@ test('workflow-quality target smoke explicitly opts into hooks', () => {
   );
 });
 
+test('packed lifecycle exercises the Mistral Vibe skills-only target', () => {
+  const source = fs.readFileSync(
+    path.join(__dirname, 'packed-artifact-lifecycle.js'),
+    'utf8'
+  );
+  assert.match(
+    source,
+    /target: 'mistral-vibe',[\s\S]*selectionArgs: \['--skills', 'skill-comply'\]/
+  );
+});
+
 test('lifecycle cleanup retries Windows file locks without masking results', () => {
   const source = fs.readFileSync(
     path.join(__dirname, 'packed-artifact-lifecycle.js'),

--- a/tests/docs/mistral-vibe-guide.test.js
+++ b/tests/docs/mistral-vibe-guide.test.js
@@ -1,0 +1,55 @@
+/** Contract tests for the Mistral Vibe installation guide. */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const guide = fs.readFileSync(path.join(repoRoot, 'docs', 'MISTRAL-VIBE-GUIDE.md'), 'utf8');
+const readme = fs.readFileSync(path.join(repoRoot, 'README.md'), 'utf8');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed += 1;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    failed += 1;
+  }
+}
+
+console.log('\n=== Testing Mistral Vibe guide ===\n');
+
+test('documents the native project skill install and lifecycle', () => {
+  assert.ok(guide.includes('"$ECC_ROOT/install.sh" --target mistral-vibe --skills tdd-workflow'));
+  assert.ok(guide.includes('node "$ECC_ROOT/scripts/doctor.js" --target mistral-vibe'));
+  assert.ok(guide.includes('node "$ECC_ROOT/scripts/repair.js" --target mistral-vibe'));
+  assert.ok(guide.includes('node "$ECC_ROOT/scripts/uninstall.js" --target mistral-vibe'));
+  assert.ok(guide.includes('.vibe/skills/'));
+  assert.ok(guide.includes('npm view ecc-universal version'));
+  assert.ok(!guide.includes('ecc-universal@2.2.1 install --target mistral-vibe'));
+});
+
+test('states the verified compatibility boundary without false parity claims', () => {
+  assert.match(guide, /Mistral Vibe v2.25.3/);
+  assert.match(guide, /\.vibe\/agents\/.*TOML/i);
+  assert.match(guide, /\.vibe\/hooks\.toml/);
+  assert.match(guide, /does not\s+configure/i);
+  assert.ok(!guide.includes('--profile minimal'));
+});
+
+test('links the Vibe target from the primary README', () => {
+  assert.ok(readme.includes('--target mistral-vibe --skills tdd-workflow'));
+  assert.ok(readme.includes('[Mistral Vibe guide](docs/MISTRAL-VIBE-GUIDE.md)'));
+});
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}`);
+process.exitCode = failed > 0 ? 1 : 0;

--- a/tests/lib/harness-capabilities.test.js
+++ b/tests/lib/harness-capabilities.test.js
@@ -33,12 +33,12 @@ function runTests() {
   let passed = 0;
   let failed = 0;
 
-  if (test('represents all 15 registered targets exactly once across 14 harnesses', () => {
+  if (test('represents all 16 registered targets exactly once across 15 harnesses', () => {
     const catalogTargetIds = HARNESS_CAPABILITIES.flatMap(harness => harness.targetIds);
     const adapterTargetIds = listInstallTargetAdapters().map(adapter => adapter.target);
 
-    assert.strictEqual(HARNESS_CAPABILITIES.length, 14);
-    assert.strictEqual(new Set(catalogTargetIds).size, 15);
+    assert.strictEqual(HARNESS_CAPABILITIES.length, 15);
+    assert.strictEqual(new Set(catalogTargetIds).size, 16);
     assert.deepStrictEqual([...catalogTargetIds].sort(), [...SUPPORTED_INSTALL_TARGETS].sort());
     assert.deepStrictEqual([...catalogTargetIds].sort(), [...adapterTargetIds].sort());
   })) passed++; else failed++;
@@ -103,6 +103,7 @@ function runTests() {
       adal: ['project', './.adal'],
       hermes: ['home', '~/.hermes'],
       openclaw: ['home', '~/.openclaw'],
+      'mistral-vibe': ['project', './.vibe'],
     };
 
     for (const [id, [scopeId, root]] of Object.entries(expected)) {
@@ -138,6 +139,16 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('describes Mistral Vibe as a skills-only managed project target', () => {
+    const vibe = getHarnessCapability('vibe');
+    assert.strictEqual(vibe.id, 'mistral-vibe');
+    assert.deepStrictEqual(vibe.targetIds, ['mistral-vibe']);
+    assert.strictEqual(vibe.destination, './.vibe');
+    assert.strictEqual(vibe.hooks.mode, 'not-configured');
+    assert.strictEqual(vibe.hooks.eccConfigured, false);
+    assert.match(vibe.hooks.note, /skills/i);
+  })) passed++; else failed++;
+
   if (test('normalizes wizard selections into canonical guided order', () => {
     assert.deepStrictEqual(
       normalizeHarnessSelection(' KIMI CODE, Claude Code, kimi '),
@@ -171,7 +182,7 @@ function runTests() {
 
     const first = listHarnessCapabilities();
     first.pop();
-    assert.strictEqual(listHarnessCapabilities().length, 14);
+    assert.strictEqual(listHarnessCapabilities().length, 15);
 
     const guided = listGuidedHarnesses();
     guided.reverse();

--- a/tests/lib/install-config.test.js
+++ b/tests/lib/install-config.test.js
@@ -106,6 +106,26 @@ function runTests() {
     }
   })) passed++; else failed++;
 
+  if (test('accepts a Mistral Vibe skills-only install config', () => {
+    const cwd = createTempDir('install-config-vibe-');
+    try {
+      const configPath = path.join(cwd, 'ecc-install.json');
+      writeJson(configPath, {
+        version: 1,
+        target: 'mistral-vibe',
+        include: ['skill:tdd-workflow'],
+        exclude: ['skill:security-review'],
+      });
+
+      const config = loadInstallConfig(configPath);
+      assert.strictEqual(config.target, 'mistral-vibe');
+      assert.deepStrictEqual(config.includeComponentIds, ['skill:tdd-workflow']);
+      assert.deepStrictEqual(config.excludeComponentIds, ['skill:security-review']);
+    } finally {
+      cleanup(cwd);
+    }
+  })) passed++; else failed++;
+
   if (test('rejects invalid config schema values', () => {
     const cwd = createTempDir('install-config-');
 

--- a/tests/lib/install-manifests.test.js
+++ b/tests/lib/install-manifests.test.js
@@ -192,6 +192,44 @@ function runTests() {
     );
   })) passed++; else failed++;
 
+  if (test('resolves existing skill components to exact modules for Mistral Vibe', () => {
+    const plan = resolveInstallPlan({
+      includeComponentIds: ['skill:tdd-workflow'],
+      target: 'mistral-vibe',
+      projectRoot: '/workspace/app',
+    });
+
+    assert.deepStrictEqual(plan.selectedModuleIds, ['skill-tdd-workflow']);
+    assert.deepStrictEqual(plan.skippedModuleIds, []);
+    assert.deepStrictEqual(
+      plan.operations.map(operation => operation.sourceRelativePath),
+      ['skills/tdd-workflow']
+    );
+  })) passed++; else failed++;
+
+  if (test('lists existing skill components as installable for Mistral Vibe', () => {
+    const components = listInstallComponents({ family: 'skill', target: 'mistral-vibe' });
+    const tdd = components.find(component => component.id === 'skill:tdd-workflow');
+    assert.ok(tdd, 'Should expose tdd-workflow to Mistral Vibe users');
+    assert.deepStrictEqual(tdd.moduleIds, ['skill-tdd-workflow']);
+    assert.deepStrictEqual(tdd.targets, ['mistral-vibe']);
+    const detail = getInstallComponent('skill:tdd-workflow', { target: 'mistral-vibe' });
+    assert.deepStrictEqual(detail.moduleIds, ['skill-tdd-workflow']);
+    assert.deepStrictEqual(detail.targets, ['mistral-vibe']);
+  })) passed++; else failed++;
+
+  if (test('applies Mistral Vibe exclusions to the exact selected skill module', () => {
+    assert.throws(
+      () => resolveInstallPlan({
+        target: 'mistral-vibe',
+        projectRoot: '/workspace/app',
+        includeComponentIds: ['skill:tdd-workflow'],
+        excludeComponentIds: ['skill:tdd-workflow'],
+      }),
+      /Selection excludes every requested install module/
+    );
+  })) passed++; else failed++;
+
   if (test('marks unified-memory install surfaces as requiring the separate ECC runtime', () => {
     const component = getInstallComponent('skill:unified-memory');
     assert.deepStrictEqual(component.moduleIds, ['skill-unified-memory']);

--- a/tests/lib/install-targets.test.js
+++ b/tests/lib/install-targets.test.js
@@ -51,6 +51,7 @@ function runTests() {
     assert.ok(targets.includes('joycode'), 'Should include joycode target');
     assert.ok(targets.includes('qwen'), 'Should include qwen target');
     assert.ok(targets.includes('zed'), 'Should include zed target');
+    assert.ok(targets.includes('mistral-vibe'), 'Should include mistral-vibe target');
   })) passed++; else failed++;
 
   if (test('resolves cursor adapter root and install-state path from project root', () => {

--- a/tests/lib/mistral-vibe-install-target.test.js
+++ b/tests/lib/mistral-vibe-install-target.test.js
@@ -1,0 +1,304 @@
+/**
+ * Contract and lifecycle tests for the Mistral Vibe project target.
+ */
+
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { createManifestInstallPlan } = require('../../scripts/lib/install/plan');
+const { applyInstallPlan } = require('../../scripts/lib/install/apply');
+const {
+  buildDoctorReport,
+  repairInstalledStates,
+  uninstallInstalledStates,
+} = require('../../scripts/lib/install-lifecycle');
+const { resolveInstallPlan } = require('../../scripts/lib/install-manifests');
+const {
+  getInstallTargetAdapter,
+  planInstallTargetScaffold,
+} = require('../../scripts/lib/install-targets/registry');
+const { createLegacyCompatInstallPlan } = require('../../scripts/lib/install-executor');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed += 1;
+  } catch (error) {
+    console.log(`  ✗ ${name}`);
+    console.log(`    Error: ${error.message}`);
+    failed += 1;
+  }
+}
+
+function createFixture() {
+  return {
+    homeDir: fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-vibe-home-')),
+    projectRoot: fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-vibe-project-')),
+  };
+}
+
+function cleanupFixture(fixture) {
+  fs.rmSync(fixture.homeDir, { recursive: true, force: true });
+  fs.rmSync(fixture.projectRoot, { recursive: true, force: true });
+}
+
+function createSkillPlan(fixture) {
+  return createManifestInstallPlan({
+    sourceRoot: REPO_ROOT,
+    target: 'mistral-vibe',
+    includeComponentIds: ['skill:tdd-workflow'],
+    projectRoot: fixture.projectRoot,
+    homeDir: fixture.homeDir,
+  });
+}
+
+console.log('\n=== Mistral Vibe install target tests ===\n');
+
+test('registers a project adapter rooted at .vibe', () => {
+  const adapter = getInstallTargetAdapter('mistral-vibe');
+  const projectRoot = path.resolve('/workspace/app');
+
+  assert.strictEqual(adapter.id, 'mistral-vibe-project');
+  assert.strictEqual(adapter.target, 'mistral-vibe');
+  assert.strictEqual(adapter.kind, 'project');
+  assert.strictEqual(adapter.resolveRoot({ projectRoot }), path.join(projectRoot, '.vibe'));
+  assert.strictEqual(
+    adapter.getInstallStatePath({ projectRoot }),
+    path.join(projectRoot, '.vibe', 'ecc-install-state.json')
+  );
+});
+
+test('maps only canonical skill sources into the native Vibe skills directory', () => {
+  const projectRoot = path.resolve('/workspace/app');
+  const plan = planInstallTargetScaffold({
+    target: 'mistral-vibe',
+    repoRoot: REPO_ROOT,
+    projectRoot,
+    modules: [
+      { id: 'skill-tdd-workflow', kind: 'skills', paths: ['skills/tdd-workflow'] },
+      { id: 'agents-core', kind: 'agents', paths: ['AGENTS.md', 'agents', '.agents'] },
+      { id: 'commands-core', kind: 'commands', paths: ['commands'] },
+      { id: 'rules-core', kind: 'rules', paths: ['rules'] },
+      { id: 'hooks-runtime', kind: 'hooks', paths: ['hooks'] },
+      { id: 'platform-configs', kind: 'platform', paths: ['.vibe', '.mcp.json'] },
+    ],
+  });
+
+  assert.deepStrictEqual(plan.operations, [{
+    kind: 'copy-path',
+    moduleId: 'skill-tdd-workflow',
+    sourceRelativePath: 'skills/tdd-workflow',
+    destinationPath: path.join(projectRoot, '.vibe', 'skills', 'tdd-workflow'),
+    strategy: 'preserve-relative-path',
+    ownership: 'managed',
+    scaffoldOnly: true,
+  }]);
+});
+
+test('rejects unsafe Vibe skill source paths before planning writes', () => {
+  for (const sourceRelativePath of [
+    'skills/../AGENTS.md',
+    'skills\\..\\AGENTS.md',
+    '/tmp/skills/escape',
+    'skills//escape',
+  ]) {
+    assert.throws(
+      () => planInstallTargetScaffold({
+        target: 'mistral-vibe',
+        repoRoot: REPO_ROOT,
+        projectRoot: '/workspace/app',
+        modules: [{ id: 'unsafe-skill', kind: 'skills', paths: [sourceRelativePath] }],
+      }),
+      /unsafe Mistral Vibe skill source path/i,
+      sourceRelativePath
+    );
+  }
+});
+
+test('resolves a single-skill install without claiming unsupported profiles', () => {
+  assert.throws(
+    () => resolveInstallPlan({
+      repoRoot: REPO_ROOT,
+      target: 'mistral-vibe',
+      projectRoot: '/workspace/app',
+    }),
+    /Mistral Vibe.*--skills/i
+  );
+  const plan = resolveInstallPlan({
+    repoRoot: REPO_ROOT,
+    target: 'mistral-vibe',
+    projectRoot: '/workspace/app',
+    includeComponentIds: ['skill:tdd-workflow'],
+  });
+
+  assert.deepStrictEqual(plan.selectedModuleIds, ['skill-tdd-workflow']);
+  assert.deepStrictEqual(plan.skippedModuleIds, []);
+  assert.strictEqual(plan.operations.length, 1);
+  const existingExactModulePlan = resolveInstallPlan({
+    repoRoot: REPO_ROOT,
+    target: 'mistral-vibe',
+    projectRoot: '/workspace/app',
+    includeComponentIds: ['skill:unified-memory'],
+  });
+  assert.deepStrictEqual(existingExactModulePlan.selectedModuleIds, ['skill-unified-memory']);
+  assert.deepStrictEqual(
+    existingExactModulePlan.operations.map(operation => operation.sourceRelativePath),
+    ['skills/unified-memory']
+  );
+  assert.throws(
+    () => resolveInstallPlan({
+      repoRoot: REPO_ROOT,
+      target: 'mistral-vibe',
+      projectRoot: '/workspace/app',
+      profileId: 'minimal',
+    }),
+    /Mistral Vibe.*--skills/i
+  );
+  assert.throws(
+    () => resolveInstallPlan({
+      repoRoot: REPO_ROOT,
+      target: 'mistral-vibe',
+      projectRoot: '/workspace/app',
+      moduleIds: ['workflow-quality'],
+    }),
+    /Mistral Vibe.*--skills/i
+  );
+});
+
+test('guides legacy language requests to the supported Vibe skill surface', () => {
+  assert.throws(
+    () => createLegacyCompatInstallPlan({
+      sourceRoot: REPO_ROOT,
+      target: 'mistral-vibe',
+      legacyLanguages: ['typescript'],
+      projectRoot: '/workspace/app',
+    }),
+    /--target mistral-vibe --skills <id,...>/
+  );
+});
+
+test('installs, diagnoses, repairs, and uninstalls a Vibe skill', () => {
+  const fixture = createFixture();
+  try {
+    const plan = createSkillPlan(fixture);
+    applyInstallPlan(plan);
+
+    const skillPath = path.join(fixture.projectRoot, '.vibe', 'skills', 'tdd-workflow', 'SKILL.md');
+    const statePath = path.join(fixture.projectRoot, '.vibe', 'ecc-install-state.json');
+    assert.ok(fs.existsSync(skillPath));
+    assert.ok(fs.existsSync(statePath));
+
+    const healthy = buildDoctorReport({
+      repoRoot: REPO_ROOT,
+      projectRoot: fixture.projectRoot,
+      homeDir: fixture.homeDir,
+      targets: ['mistral-vibe'],
+    });
+    assert.strictEqual(healthy.results[0].status, 'ok');
+
+    fs.unlinkSync(skillPath);
+    const broken = buildDoctorReport({
+      repoRoot: REPO_ROOT,
+      projectRoot: fixture.projectRoot,
+      homeDir: fixture.homeDir,
+      targets: ['mistral-vibe'],
+    });
+    assert.strictEqual(broken.results[0].status, 'error');
+
+    const repaired = repairInstalledStates({
+      repoRoot: REPO_ROOT,
+      projectRoot: fixture.projectRoot,
+      homeDir: fixture.homeDir,
+      targets: ['mistral-vibe'],
+    });
+    assert.strictEqual(repaired.results[0].status, 'repaired');
+    assert.ok(fs.existsSync(skillPath));
+
+    const uninstalled = uninstallInstalledStates({
+      repoRoot: REPO_ROOT,
+      projectRoot: fixture.projectRoot,
+      homeDir: fixture.homeDir,
+      targets: ['mistral-vibe'],
+    });
+    assert.strictEqual(uninstalled.results[0].status, 'uninstalled');
+    assert.ok(!fs.existsSync(skillPath));
+    assert.ok(!fs.existsSync(statePath));
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+test('never overwrites or claims a user-owned Vibe skill file', () => {
+  const fixture = createFixture();
+  const skillPath = path.join(fixture.projectRoot, '.vibe', 'skills', 'tdd-workflow', 'SKILL.md');
+  try {
+    fs.mkdirSync(path.dirname(skillPath), { recursive: true });
+    fs.writeFileSync(skillPath, '# User-owned Vibe skill\n', 'utf8');
+
+    const result = applyInstallPlan(createSkillPlan(fixture));
+    assert.strictEqual(fs.readFileSync(skillPath, 'utf8'), '# User-owned Vibe skill\n');
+    assert.ok(result.skippedOperations.some(operation => operation.destinationPath === skillPath));
+    assert.ok(!result.statePreview.operations.some(operation => operation.destinationPath === skillPath));
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+test('rejects a Vibe skill file created after preflight without overwriting it', () => {
+  const fixture = createFixture();
+  const skillPath = path.join(fixture.projectRoot, '.vibe', 'skills', 'tdd-workflow', 'SKILL.md');
+  try {
+    const plan = createSkillPlan(fixture);
+    assert.throws(
+      () => applyInstallPlan(plan, {
+        beforeOperationWrite({ operation }) {
+          if (operation.destinationPath === skillPath) {
+            fs.writeFileSync(skillPath, '# Concurrent user-owned Vibe skill\n', 'utf8');
+          }
+        },
+      }),
+      /user-owned file appeared.*after planning/i
+    );
+    assert.strictEqual(
+      fs.readFileSync(skillPath, 'utf8'),
+      '# Concurrent user-owned Vibe skill\n'
+    );
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+test('preserves a modified managed Vibe skill during uninstall', () => {
+  const fixture = createFixture();
+  const skillPath = path.join(fixture.projectRoot, '.vibe', 'skills', 'tdd-workflow', 'SKILL.md');
+  try {
+    applyInstallPlan(createSkillPlan(fixture));
+    fs.appendFileSync(skillPath, '\nUser change.\n', 'utf8');
+
+    const result = uninstallInstalledStates({
+      repoRoot: REPO_ROOT,
+      projectRoot: fixture.projectRoot,
+      homeDir: fixture.homeDir,
+      targets: ['mistral-vibe'],
+    });
+    assert.strictEqual(result.results[0].status, 'partial');
+    assert.ok(fs.existsSync(skillPath));
+    assert.ok(fs.existsSync(path.join(fixture.projectRoot, '.vibe', 'ecc-install-state.json')));
+  } finally {
+    cleanupFixture(fixture);
+  }
+});
+
+console.log(`\nPassed: ${passed}`);
+console.log(`Failed: ${failed}`);
+process.exit(failed > 0 ? 1 : 0);

--- a/tests/scripts/consult.test.js
+++ b/tests/scripts/consult.test.js
@@ -173,6 +173,23 @@ function runTests() {
     assert.ok(payload.matches[0].installCommand.includes('--target codex'));
   })) passed++; else failed++;
 
+  if (test('recommends only exact skill installs for Mistral Vibe', () => {
+    const result = run(['test-driven', 'development', '--target', 'mistral-vibe', '--json']);
+
+    assert.strictEqual(result.status, 0, result.stderr);
+    const payload = parseJson(result.stdout);
+    assert.strictEqual(payload.target, 'mistral-vibe');
+    assert.deepStrictEqual(payload.profiles, []);
+    assert.ok(payload.matches.length > 0);
+    assert.ok(payload.matches.every(match => match.family === 'skill'));
+    assert.ok(payload.matches.every(match => match.installCommand.startsWith(
+      'npx ecc-universal install --target mistral-vibe --skills '
+    )));
+    assert.ok(payload.matches.every(match => match.planCommand.startsWith(
+      'npx ecc-universal plan --target mistral-vibe --skills '
+    )));
+  })) passed++; else failed++;
+
   if (test('rejects unknown targets', () => {
     const result = run(['security', '--target', 'not-a-target']);
 

--- a/tests/scripts/install-apply.test.js
+++ b/tests/scripts/install-apply.test.js
@@ -113,6 +113,35 @@ function runTests() {
     assert.ok(result.stdout.includes('--dry-run'));
     assert.ok(result.stdout.includes('--profile <name>'));
     assert.ok(result.stdout.includes('--modules <id,id,...>'));
+    assert.ok(result.stdout.includes('mistral-vibe'));
+    assert.ok(result.stdout.includes('Install selected skills into ./.vibe/skills/'));
+  })) passed++; else failed++;
+
+  if (test('installs a selected skill into Mistral Vibe without unrelated surfaces', () => {
+    const homeDir = createTempDir('install-apply-vibe-home-');
+    const projectDir = createTempDir('install-apply-vibe-project-');
+    try {
+      const result = run(
+        ['--target', 'mistral-vibe', '--skills', 'tdd-workflow', '--json'],
+        { cwd: projectDir, homeDir }
+      );
+      assert.strictEqual(result.code, 0, result.stderr);
+      assert.ok(fs.existsSync(path.join(projectDir, '.vibe', 'skills', 'tdd-workflow', 'SKILL.md')));
+      assert.ok(!fs.existsSync(path.join(projectDir, '.vibe', 'agents')));
+      assert.ok(!fs.existsSync(path.join(projectDir, '.vibe', 'hooks.toml')));
+
+      const state = readJson(path.join(projectDir, '.vibe', 'ecc-install-state.json'));
+      assert.strictEqual(state.target.id, 'mistral-vibe-project');
+      assert.deepStrictEqual(state.resolution.selectedModules, ['skill-tdd-workflow']);
+      assert.ok(state.operations.every(operation => (
+        operation.destinationPath.startsWith(
+          `${path.join(fs.realpathSync(projectDir), '.vibe', 'skills')}${path.sep}`
+        )
+      )));
+    } finally {
+      cleanup(homeDir);
+      cleanup(projectDir);
+    }
   })) passed++; else failed++;
 
   if (test('Claude hook dry-run validates settings without mutating malformed input', () => {

--- a/tests/scripts/install-plan.test.js
+++ b/tests/scripts/install-plan.test.js
@@ -123,6 +123,34 @@ function runTests() {
     assert.ok(!parsed.operations.some(operation => operation.sourceRelativePath === 'skills/tdd-workflow'));
   })) passed++; else failed++;
 
+  if (test('resolves Mistral Vibe preview paths from the caller project', () => {
+    const projectDir = require('fs').mkdtempSync(
+      path.join(require('os').tmpdir(), 'ecc-vibe-plan-project-')
+    );
+    try {
+      const realProjectDir = require('fs').realpathSync(projectDir);
+      const result = run([
+        '--skills', 'tdd-workflow',
+        '--target', 'mistral-vibe',
+        '--json',
+      ], { cwd: projectDir });
+      assert.strictEqual(result.code, 0, result.stderr);
+      const parsed = JSON.parse(result.stdout);
+      assert.strictEqual(parsed.targetRoot, path.join(realProjectDir, '.vibe'));
+      assert.strictEqual(
+        parsed.installStatePath,
+        path.join(realProjectDir, '.vibe', 'ecc-install-state.json')
+      );
+      assert.ok(parsed.operations.every(operation => (
+        operation.destinationPath.startsWith(
+          `${path.join(realProjectDir, '.vibe', 'skills')}${path.sep}`
+        )
+      )));
+    } finally {
+      require('fs').rmSync(projectDir, { recursive: true, force: true });
+    }
+  })) passed++; else failed++;
+
   if (test('loads planning intent from ecc-install.json', () => {
     const configDir = path.join(__dirname, '..', 'fixtures', 'tmp-install-plan-config');
     const configPath = path.join(configDir, 'ecc-install.json');

--- a/tests/scripts/npm-publish-surface.test.js
+++ b/tests/scripts/npm-publish-surface.test.js
@@ -107,6 +107,7 @@ function buildExpectedPublishPaths(repoRoot) {
     "docs/CODEX-NAVIGATION-GUIDE.md",
     "docs/COMMAND-AGENT-MAP.md",
     "docs/ROADMAP.md",
+    "docs/MISTRAL-VIBE-GUIDE.md",
     "docs/design/ecc-memory-vault.md",
     "assets/images/sponsors",
   ]
@@ -223,6 +224,7 @@ function main() {
         "docs/CODEX-NAVIGATION-GUIDE.md",
         "docs/COMMAND-AGENT-MAP.md",
         "docs/ROADMAP.md",
+        "docs/MISTRAL-VIBE-GUIDE.md",
         "docs/design/ecc-memory-vault.md",
         "schemas/install-state.schema.json",
         "schemas/memory.schema.json",

--- a/tests/scripts/ownership-guard.test.js
+++ b/tests/scripts/ownership-guard.test.js
@@ -37,9 +37,12 @@ function readState(plan) {
 for (const adapter of listInstallTargetAdapters()) {
   test(`${adapter.target}: preserve user files through preview, install, reinstall and uninstall`, context => {
     const nativeTarget = ['codex', 'gemini', 'opencode'].includes(adapter.target);
+    const moduleId = adapter.target === 'mistral-vibe'
+      ? 'skill-tdd-workflow'
+      : (nativeTarget ? 'platform-configs' : 'rules-core');
     const resolved = createManifestInstallPlan({
       ...context, target: adapter.target,
-      moduleIds: [nativeTarget ? 'platform-configs' : 'rules-core'],
+      moduleIds: [moduleId],
       // This test exercises ownership of source files, not plugin compilation.
       exemptValidationCodes: ['opencode-plugin-not-built'],
     });


### PR DESCRIPTION
## Summary

- add a managed project target for Mistral Vibe using its native `.vibe/skills/<name>/SKILL.md` discovery surface
- keep the first integration skills-only: no synthetic Vibe agents, hooks, MCP, provider, or credential configuration
- resolve existing `skill:*` components to exact single-skill modules for this target, including include/exclude and `consult` recommendations
- align `install-plan` preview paths with the caller project and cover install-state, doctor, repair, uninstall, user-owned files, races, schemas, docs, and packed artifacts

## Compatibility boundary

This implementation is verified against the official Mistral Vibe v2.25.3 source contract. Vibe agents and hooks use native TOML formats that are not interchangeable with ECC's Claude-oriented surfaces, so this PR does not claim full feature parity.

## Verification

- Mistral Vibe target/lifecycle: 9/9
- install manifests: 44/44
- harness capabilities: 10/10
- install targets: 51/51
- consult: 13/13
- install config: 7/7
- install plan: 12/12
- install lifecycle: 66/66
- packed lifecycle runner: 10/10
- npm publish surface: 2/2
- selective install: 46/46
- install request: 15/15
- planning boundary: 3/3
- install executor: 20/20
- focused ESLint and Markdownlint
- Unicode, personal-path, and supply-chain IOC checks
- real prepack tarball lifecycle on macOS, including `mistral-vibe-skill-install-doctor-uninstall`
- independent code review: one P1 found and fixed (preview root mismatch); no remaining P0/P1/P2
- independent security review: PASS

Closes #3081
