### PR TITLE
perf(metrics): cache cumulative session costs

### DIFF
--- a/scripts/hooks/cost-tracker.js
+++ b/scripts/hooks/cost-tracker.js
@@ -4,7 +4,9 @@
  *
  * Reads transcript_path from Stop hook stdin, sums usage across all
  * assistant turns in the session JSONL, and appends one row to
- * ~/.claude/metrics/costs.jsonl.
+ * ~/.claude/metrics/costs.jsonl. It also atomically publishes the latest
+ * cumulative row under metrics/cost-snapshots/ so frequent PostToolUse
+ * hooks do not need to rescan the unbounded history.
  *
  * Stop hook stdin payload: { session_id, transcript_path, cwd, hook_event_name, ... }
  * The Stop payload does NOT include `usage` or `model` directly. The previous
@@ -42,6 +44,7 @@ const os = require('os');
 const path = require('path');
 const { ensureDir, appendFile, getClaudeDir } = require('../lib/utils');
 const { sanitizeSessionId } = require('../lib/session-bridge');
+const { publishAppendedSessionCostSnapshot } = require('../lib/session-cost-snapshot');
 
 const HARNESS_COST_MAX_AGE_SECONDS = 300;
 
@@ -243,6 +246,12 @@ process.stdin.on('end', () => {
     };
 
     appendFile(path.join(metricsDir, 'costs.jsonl'), `${JSON.stringify(row)}\n`);
+    try {
+      publishAppendedSessionCostSnapshot(metricsDir, sessionId, row);
+    } catch {
+      // The append-only log remains authoritative. A later bridge read falls
+      // back to it when an atomic snapshot cannot be published.
+    }
   } catch {
     // Non-blocking — never fail the Stop hook.
   }

--- a/scripts/hooks/cost-tracker.js
+++ b/scripts/hooks/cost-tracker.js
@@ -109,7 +109,17 @@ function isSonnet5(model) {
 
 function toNumber(v) {
   const n = Number(v);
-  return Number.isFinite(n) ? n : 0;
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+function normalizeUsageTotals(totals) {
+  return {
+    inputTokens: toNumber(totals.inputTokens),
+    outputTokens: toNumber(totals.outputTokens),
+    cacheWriteTokens: toNumber(totals.cacheWriteTokens),
+    cacheReadTokens: toNumber(totals.cacheReadTokens),
+    model: totals.model
+  };
 }
 
 /**
@@ -167,7 +177,9 @@ function sumUsageFromTranscript(transcriptPath) {
     cacheReadTokens  += toNumber(u.cache_read_input_tokens);
   }
 
-  return { inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens, model };
+  return normalizeUsageTotals({
+    inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens, model
+  });
 }
 
 // 1MB, matching the other Stop hooks. The Stop payload carries

--- a/scripts/hooks/cost-tracker.js
+++ b/scripts/hooks/cost-tracker.js
@@ -42,9 +42,12 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { ensureDir, appendFile, getClaudeDir } = require('../lib/utils');
+const { ensureDir, getClaudeDir } = require('../lib/utils');
 const { sanitizeSessionId } = require('../lib/session-bridge');
-const { publishAppendedSessionCostSnapshot } = require('../lib/session-cost-snapshot');
+const {
+  appendSessionCostRow,
+  warnSessionCostSnapshotFailure
+} = require('../lib/session-cost-snapshot');
 
 const HARNESS_COST_MAX_AGE_SECONDS = 300;
 
@@ -245,12 +248,10 @@ process.stdin.on('end', () => {
       estimated_cost_usd: estimatedCostUsd
     };
 
-    appendFile(path.join(metricsDir, 'costs.jsonl'), `${JSON.stringify(row)}\n`);
     try {
-      publishAppendedSessionCostSnapshot(metricsDir, sessionId, row);
-    } catch {
-      // The append-only log remains authoritative. A later bridge read falls
-      // back to it when an atomic snapshot cannot be published.
+      appendSessionCostRow(metricsDir, sessionId, row);
+    } catch (error) {
+      warnSessionCostSnapshotFailure('publication', metricsDir, sessionId, error);
     }
   } catch {
     // Non-blocking — never fail the Stop hook.

--- a/scripts/hooks/ecc-metrics-bridge.js
+++ b/scripts/hooks/ecc-metrics-bridge.js
@@ -155,7 +155,7 @@ function readSessionCost(sessionId) {
         'malformed',
         costsPath,
         `${snapshotResult.malformed}:${snapshotResult.malformedSignature}`,
-        `[ecc-metrics-bridge] skipped ${snapshotResult.malformed} malformed line(s) in ${costsPath}\n`
+        `[ecc-metrics-bridge] skipped ${snapshotResult.malformed} malformed line(s) during the snapshot scan of ${costsPath}\n`
       );
     }
     if (snapshotResult.invalid > 0) {
@@ -163,7 +163,7 @@ function readSessionCost(sessionId) {
         'invalid-row',
         costsPath,
         `${snapshotResult.invalid}:${snapshotResult.invalidSignature}`,
-        `[ecc-metrics-bridge] skipped ${snapshotResult.invalid} invalid cumulative row(s) for ${sessionId} in ${costsPath}\n`
+        `[ecc-metrics-bridge] skipped ${snapshotResult.invalid} invalid cumulative row(s) for ${sessionId} during the snapshot scan of ${costsPath}\n`
       );
     }
     if (snapshotResult.snapshotError) {

--- a/scripts/hooks/ecc-metrics-bridge.js
+++ b/scripts/hooks/ecc-metrics-bridge.js
@@ -15,11 +15,8 @@ const os = require('os');
 const path = require('path');
 const { sanitizeSessionId, readBridge, writeBridgeAtomic } = require('../lib/session-bridge');
 const {
-  getCostLogSignature,
-  isValidCostRow,
   readSessionCostSnapshot,
-  repairSessionCostSnapshot,
-  signaturesMatch,
+  warnSessionCostSnapshotFailure
 } = require('../lib/session-cost-snapshot');
 const { getClaudeDir } = require('../lib/utils');
 
@@ -28,11 +25,6 @@ const MAX_FILES_TRACKED = 200;
 const RECENT_TOOLS_SIZE = 5;
 const HASH_INPUT_LIMIT = 2048;
 const WARNING_CACHE_PREFIX = 'ecc-metrics-cost-warnings-';
-
-function toNumber(value) {
-  const n = Number(value);
-  return Number.isFinite(n) ? n : 0;
-}
 
 function stableStringify(value, depth = 0) {
   if (depth > 4) return '[depth-limit]';
@@ -143,8 +135,9 @@ function writeCostWarningIfChanged(kind, costsPath, signature, message) {
 /**
  * Read cumulative cost for a session.
  *
- * The Stop hook publishes an atomic per-session snapshot, so the normal
- * PostToolUse path reads O(1) data instead of reparsing unbounded history.
+ * The Stop hook publishes an atomic per-session cursor snapshot, so a stable
+ * PostToolUse path reads O(1) metadata and newly appended data is O(delta)
+ * instead of reparsing unbounded history.
  * Older ECC installations and damaged/missing snapshots remain compatible:
  * they fall back to scanning costs.jsonl for the last cumulative row.
  *
@@ -155,77 +148,36 @@ function readSessionCost(sessionId) {
   let costsPath = path.join('metrics', 'costs.jsonl');
   try {
     const metricsDir = path.join(getClaudeDir(), 'metrics');
-    const snapshot = readSessionCostSnapshot(metricsDir, sessionId);
-    if (snapshot) {
-      return {
-        totalCost: toNumber(snapshot.estimated_cost_usd),
-        totalIn: toNumber(snapshot.input_tokens),
-        totalOut: toNumber(snapshot.output_tokens)
-      };
-    }
-
     costsPath = path.join(metricsDir, 'costs.jsonl');
-    const sourceBefore = getCostLogSignature(metricsDir);
-    const content = fs.readFileSync(costsPath, 'utf8');
-    const lines = content.split('\n').filter(Boolean);
-
-    let totalCost = 0;
-    let totalIn = 0;
-    let totalOut = 0;
-    let latestRow = null;
-    let malformed = 0;
-    let invalid = 0;
-    const malformedHasher = crypto.createHash('sha256');
-    const invalidHasher = crypto.createHash('sha256');
-    for (const line of lines) {
-      try {
-        const row = JSON.parse(line);
-        if (row.session_id === sessionId) {
-          if (isValidCostRow(row, sessionId)) {
-            latestRow = row;
-            totalCost = row.estimated_cost_usd;
-            totalIn = row.input_tokens;
-            totalOut = row.output_tokens;
-          } else {
-            invalid += 1;
-            invalidHasher.update(line).update('\0');
-          }
-        }
-      } catch {
-        malformed += 1;
-        malformedHasher.update(line).update('\0');
-      }
-    }
-    // One aggregated breadcrumb per call rather than one per bad row, so a
-    // log-flooded costs.jsonl stays diagnosable without overwhelming stderr.
-    // Suppress repeats for the same malformed-line signature across hook
-    // subprocesses, so a persistent bad row should not spam stderr.
-    if (malformed > 0) {
+    const snapshotResult = readSessionCostSnapshot(metricsDir, sessionId);
+    if (snapshotResult.malformed > 0) {
       writeCostWarningIfChanged(
         'malformed',
         costsPath,
-        `${malformed}:${malformedHasher.digest('hex').slice(0, 16)}`,
-        `[ecc-metrics-bridge] skipped ${malformed} malformed line(s) in ${costsPath}\n`
+        `${snapshotResult.malformed}:${snapshotResult.malformedSignature}`,
+        `[ecc-metrics-bridge] skipped ${snapshotResult.malformed} malformed line(s) in ${costsPath}\n`
       );
     }
-    if (invalid > 0) {
+    if (snapshotResult.invalid > 0) {
       writeCostWarningIfChanged(
         'invalid-row',
         costsPath,
-        `${invalid}:${invalidHasher.digest('hex').slice(0, 16)}`,
-        `[ecc-metrics-bridge] skipped ${invalid} invalid cumulative row(s) for ${sessionId} in ${costsPath}\n`
+        `${snapshotResult.invalid}:${snapshotResult.invalidSignature}`,
+        `[ecc-metrics-bridge] skipped ${snapshotResult.invalid} invalid cumulative row(s) for ${sessionId} in ${costsPath}\n`
       );
     }
-
-    const sourceAfter = getCostLogSignature(metricsDir);
-    if (latestRow && signaturesMatch(sourceBefore, sourceAfter)) {
-      try {
-        repairSessionCostSnapshot(metricsDir, sessionId, latestRow, sourceAfter);
-      } catch {
-        // Snapshot repair is best effort; the JSONL result remains valid.
-      }
+    if (snapshotResult.snapshotError) {
+      warnSessionCostSnapshotFailure(
+        'repair',
+        metricsDir,
+        sessionId,
+        snapshotResult.snapshotError
+      );
     }
-    return { totalCost, totalIn, totalOut };
+    const row = snapshotResult.row;
+    return row
+      ? { totalCost: row.estimated_cost_usd, totalIn: row.input_tokens, totalOut: row.output_tokens }
+      : { totalCost: 0, totalIn: 0, totalOut: 0 };
   } catch (err) {
     // ENOENT is the common case (no Stop event has fired yet this session)
     // and is not actually a failure — stay silent on it. Anything else

--- a/scripts/hooks/ecc-metrics-bridge.js
+++ b/scripts/hooks/ecc-metrics-bridge.js
@@ -14,6 +14,13 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { sanitizeSessionId, readBridge, writeBridgeAtomic } = require('../lib/session-bridge');
+const {
+  getCostLogSignature,
+  isValidCostRow,
+  readSessionCostSnapshot,
+  repairSessionCostSnapshot,
+  signaturesMatch,
+} = require('../lib/session-cost-snapshot');
 const { getClaudeDir } = require('../lib/utils');
 
 const MAX_STDIN = 1024 * 1024;
@@ -134,41 +141,55 @@ function writeCostWarningIfChanged(kind, costsPath, signature, message) {
 }
 
 /**
- * Read cumulative cost for a session from costs.jsonl.
+ * Read cumulative cost for a session.
  *
- * Scans the full file because each row is a cumulative session total
- * (see cost-tracker.js docblock) and the row we need is the last one
- * matching `sessionId`. The previous implementation read only the
- * trailing 8 KiB; any session whose latest cumulative row was pushed
- * past that window by newer rows from other sessions silently dropped
- * to zero — the opposite sign of the double-count bug fixed in the
- * previous commit.
+ * The Stop hook publishes an atomic per-session snapshot, so the normal
+ * PostToolUse path reads O(1) data instead of reparsing unbounded history.
+ * Older ECC installations and damaged/missing snapshots remain compatible:
+ * they fall back to scanning costs.jsonl for the last cumulative row.
  *
- * costs.jsonl is append-only and unbounded today (no rotation in
- * cost-tracker.js). At a typical ~150 bytes per row, even 100k rows
- * is ~15 MB and a single sync read on every PostToolUse hook is in
- * the low milliseconds. If rotation lands later, this scan becomes
- * even cheaper.
+ * The fallback deliberately scans the whole file. A fixed tail window loses
+ * sessions whose newest row has been pushed back by other sessions.
  */
 function readSessionCost(sessionId) {
   let costsPath = path.join('metrics', 'costs.jsonl');
   try {
-    costsPath = path.join(getClaudeDir(), 'metrics', 'costs.jsonl');
+    const metricsDir = path.join(getClaudeDir(), 'metrics');
+    const snapshot = readSessionCostSnapshot(metricsDir, sessionId);
+    if (snapshot) {
+      return {
+        totalCost: toNumber(snapshot.estimated_cost_usd),
+        totalIn: toNumber(snapshot.input_tokens),
+        totalOut: toNumber(snapshot.output_tokens)
+      };
+    }
+
+    costsPath = path.join(metricsDir, 'costs.jsonl');
+    const sourceBefore = getCostLogSignature(metricsDir);
     const content = fs.readFileSync(costsPath, 'utf8');
     const lines = content.split('\n').filter(Boolean);
 
     let totalCost = 0;
     let totalIn = 0;
     let totalOut = 0;
+    let latestRow = null;
     let malformed = 0;
+    let invalid = 0;
     const malformedHasher = crypto.createHash('sha256');
+    const invalidHasher = crypto.createHash('sha256');
     for (const line of lines) {
       try {
         const row = JSON.parse(line);
         if (row.session_id === sessionId) {
-          totalCost = toNumber(row.estimated_cost_usd);
-          totalIn = toNumber(row.input_tokens);
-          totalOut = toNumber(row.output_tokens);
+          if (isValidCostRow(row, sessionId)) {
+            latestRow = row;
+            totalCost = row.estimated_cost_usd;
+            totalIn = row.input_tokens;
+            totalOut = row.output_tokens;
+          } else {
+            invalid += 1;
+            invalidHasher.update(line).update('\0');
+          }
         }
       } catch {
         malformed += 1;
@@ -186,6 +207,23 @@ function readSessionCost(sessionId) {
         `${malformed}:${malformedHasher.digest('hex').slice(0, 16)}`,
         `[ecc-metrics-bridge] skipped ${malformed} malformed line(s) in ${costsPath}\n`
       );
+    }
+    if (invalid > 0) {
+      writeCostWarningIfChanged(
+        'invalid-row',
+        costsPath,
+        `${invalid}:${invalidHasher.digest('hex').slice(0, 16)}`,
+        `[ecc-metrics-bridge] skipped ${invalid} invalid cumulative row(s) for ${sessionId} in ${costsPath}\n`
+      );
+    }
+
+    const sourceAfter = getCostLogSignature(metricsDir);
+    if (latestRow && signaturesMatch(sourceBefore, sourceAfter)) {
+      try {
+        repairSessionCostSnapshot(metricsDir, sessionId, latestRow, sourceAfter);
+      } catch {
+        // Snapshot repair is best effort; the JSONL result remains valid.
+      }
     }
     return { totalCost, totalIn, totalOut };
   } catch (err) {
@@ -259,7 +297,7 @@ function run(rawInput) {
     if (recent.length > RECENT_TOOLS_SIZE) recent.shift();
     bridge.recent_tools = recent;
 
-    // Update cost from costs.jsonl tail
+    // Use the O(1) session snapshot, with JSONL compatibility fallback.
     const costs = readSessionCost(sessionId);
     bridge.total_cost_usd = Math.round(costs.totalCost * 1e6) / 1e6;
     bridge.total_input_tokens = costs.totalIn;

--- a/scripts/lib/session-cost-snapshot.js
+++ b/scripts/lib/session-cost-snapshot.js
@@ -1,0 +1,147 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { writeFileAtomic } = require('./atomic-write');
+const { sanitizeSessionId } = require('./session-bridge');
+
+const COST_SNAPSHOT_SCHEMA_VERSION = 'ecc.cost-snapshot.v1';
+const COST_SNAPSHOT_DIRECTORY = 'cost-snapshots';
+const COST_LOG_FILENAME = 'costs.jsonl';
+
+function assertSafeSessionId(sessionId) {
+  if (sanitizeSessionId(sessionId) !== sessionId) {
+    throw new Error('Cost snapshot requires a safe session ID');
+  }
+}
+
+function getCostSnapshotPath(metricsDir, sessionId) {
+  assertSafeSessionId(sessionId);
+  // Prefix the filename so Windows device names such as CON/NUL/COM1 never
+  // become the basename, even when they are otherwise valid session IDs.
+  return path.join(metricsDir, COST_SNAPSHOT_DIRECTORY, `session-${sessionId}.json`);
+}
+
+function getCostLogSignature(metricsDir) {
+  const stat = fs.statSync(path.join(metricsDir, COST_LOG_FILENAME));
+  return {
+    size_bytes: stat.size,
+    mtime_ms: stat.mtimeMs
+  };
+}
+
+function signaturesMatch(left, right) {
+  return left?.size_bytes === right?.size_bytes
+    && left?.mtime_ms === right?.mtime_ms;
+}
+
+function isValidCostRow(row, sessionId) {
+  return row?.session_id === sessionId
+    && typeof row.estimated_cost_usd === 'number'
+    && Number.isFinite(row.estimated_cost_usd)
+    && row.estimated_cost_usd >= 0
+    && typeof row.input_tokens === 'number'
+    && Number.isFinite(row.input_tokens)
+    && row.input_tokens >= 0
+    && typeof row.output_tokens === 'number'
+    && Number.isFinite(row.output_tokens)
+    && row.output_tokens >= 0;
+}
+
+function assertCostLogSignature(source) {
+  if (!Number.isSafeInteger(source?.size_bytes) || source.size_bytes < 0) {
+    throw new Error('Cost snapshot requires a valid source size');
+  }
+  if (!Number.isFinite(source?.mtime_ms) || source.mtime_ms < 0) {
+    throw new Error('Cost snapshot requires a valid source mtime');
+  }
+}
+
+function writeSnapshotForSource(metricsDir, sessionId, row, source) {
+  assertSafeSessionId(sessionId);
+  if (!isValidCostRow(row, sessionId)) {
+    throw new Error('Cost snapshot requires valid non-negative numeric totals for its session');
+  }
+
+  const snapshotPath = getCostSnapshotPath(metricsDir, sessionId);
+  assertCostLogSignature(source);
+  return writeFileAtomic(
+    snapshotPath,
+    JSON.stringify({
+      schema_version: COST_SNAPSHOT_SCHEMA_VERSION,
+      source,
+      row
+    }),
+    {
+      beforeRename() {
+        if (!signaturesMatch(source, getCostLogSignature(metricsDir))) {
+          throw new Error('Cost log changed while publishing its session snapshot');
+        }
+      }
+    }
+  );
+}
+
+function costLogEndsWithRow(metricsDir, row) {
+  const expected = Buffer.from(`${JSON.stringify(row)}\n`, 'utf8');
+  const descriptor = fs.openSync(path.join(metricsDir, COST_LOG_FILENAME), 'r');
+  try {
+    const stat = fs.fstatSync(descriptor);
+    if (stat.size < expected.length) return false;
+    const actual = Buffer.allocUnsafe(expected.length);
+    const bytesRead = fs.readSync(
+      descriptor,
+      actual,
+      0,
+      expected.length,
+      stat.size - expected.length
+    );
+    return bytesRead === expected.length && actual.equals(expected);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function publishAppendedSessionCostSnapshot(metricsDir, sessionId, row) {
+  assertSafeSessionId(sessionId);
+  if (!isValidCostRow(row, sessionId)) {
+    throw new Error('Cost snapshot requires valid non-negative numeric totals for its session');
+  }
+  const sourceBefore = getCostLogSignature(metricsDir);
+  if (!costLogEndsWithRow(metricsDir, row)) return false;
+  const sourceAfter = getCostLogSignature(metricsDir);
+  if (!signaturesMatch(sourceBefore, sourceAfter)) return false;
+  writeSnapshotForSource(metricsDir, sessionId, row, sourceAfter);
+  return true;
+}
+
+function repairSessionCostSnapshot(metricsDir, sessionId, row, source) {
+  writeSnapshotForSource(metricsDir, sessionId, row, source);
+}
+
+function readSessionCostSnapshot(metricsDir, sessionId) {
+  try {
+    const snapshot = JSON.parse(
+      fs.readFileSync(getCostSnapshotPath(metricsDir, sessionId), 'utf8')
+    );
+    if (snapshot?.schema_version !== COST_SNAPSHOT_SCHEMA_VERSION) return null;
+    if (!isValidCostRow(snapshot.row, sessionId)) return null;
+    if (!signaturesMatch(snapshot.source, getCostLogSignature(metricsDir))) return null;
+    return snapshot.row;
+  } catch {
+    return null;
+  }
+}
+
+module.exports = {
+  COST_SNAPSHOT_SCHEMA_VERSION,
+  COST_SNAPSHOT_DIRECTORY,
+  COST_LOG_FILENAME,
+  getCostSnapshotPath,
+  getCostLogSignature,
+  signaturesMatch,
+  isValidCostRow,
+  publishAppendedSessionCostSnapshot,
+  repairSessionCostSnapshot,
+  readSessionCostSnapshot
+};

--- a/scripts/lib/session-cost-snapshot.js
+++ b/scripts/lib/session-cost-snapshot.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const crypto = require('crypto');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { writeFileAtomic } = require('./atomic-write');
 const { sanitizeSessionId } = require('./session-bridge');
@@ -8,6 +10,12 @@ const { sanitizeSessionId } = require('./session-bridge');
 const COST_SNAPSHOT_SCHEMA_VERSION = 'ecc.cost-snapshot.v1';
 const COST_SNAPSHOT_DIRECTORY = 'cost-snapshots';
 const COST_LOG_FILENAME = 'costs.jsonl';
+const READ_CHUNK_BYTES = 64 * 1024;
+const FINGERPRINT_WINDOW_BYTES = 256;
+const PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const SNAPSHOT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_SNAPSHOTS = 512;
+const WARNING_CACHE_PREFIX = 'ecc-cost-snapshot-warnings-';
 
 function assertSafeSessionId(sessionId) {
   if (sanitizeSessionId(sessionId) !== sessionId) {
@@ -15,24 +23,13 @@ function assertSafeSessionId(sessionId) {
   }
 }
 
+function getSnapshotDirectory(metricsDir) {
+  return path.join(metricsDir, COST_SNAPSHOT_DIRECTORY);
+}
+
 function getCostSnapshotPath(metricsDir, sessionId) {
   assertSafeSessionId(sessionId);
-  // Prefix the filename so Windows device names such as CON/NUL/COM1 never
-  // become the basename, even when they are otherwise valid session IDs.
-  return path.join(metricsDir, COST_SNAPSHOT_DIRECTORY, `session-${sessionId}.json`);
-}
-
-function getCostLogSignature(metricsDir) {
-  const stat = fs.statSync(path.join(metricsDir, COST_LOG_FILENAME));
-  return {
-    size_bytes: stat.size,
-    mtime_ms: stat.mtimeMs
-  };
-}
-
-function signaturesMatch(left, right) {
-  return left?.size_bytes === right?.size_bytes
-    && left?.mtime_ms === right?.mtime_ms;
+  return path.join(getSnapshotDirectory(metricsDir), `session-${sessionId}.json`);
 }
 
 function isValidCostRow(row, sessionId) {
@@ -48,89 +45,354 @@ function isValidCostRow(row, sessionId) {
     && row.output_tokens >= 0;
 }
 
-function assertCostLogSignature(source) {
-  if (!Number.isSafeInteger(source?.size_bytes) || source.size_bytes < 0) {
-    throw new Error('Cost snapshot requires a valid source size');
-  }
-  if (!Number.isFinite(source?.mtime_ms) || source.mtime_ms < 0) {
-    throw new Error('Cost snapshot requires a valid source mtime');
+function readJsonFile(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
   }
 }
 
-function writeSnapshotForSource(metricsDir, sessionId, row, source) {
-  assertSafeSessionId(sessionId);
-  if (!isValidCostRow(row, sessionId)) {
-    throw new Error('Cost snapshot requires valid non-negative numeric totals for its session');
+function chooseNewerCumulativeRow(currentRow, nextRow) {
+  if (!currentRow) return nextRow;
+  const nextDominates = nextRow.input_tokens >= currentRow.input_tokens
+    && nextRow.output_tokens >= currentRow.output_tokens
+    && nextRow.estimated_cost_usd >= currentRow.estimated_cost_usd;
+  const currentDominates = currentRow.input_tokens >= nextRow.input_tokens
+    && currentRow.output_tokens >= nextRow.output_tokens
+    && currentRow.estimated_cost_usd >= nextRow.estimated_cost_usd;
+  if (nextDominates && !currentDominates) return nextRow;
+  if (currentDominates && !nextDominates) return currentRow;
+  const nextTimestamp = Date.parse(nextRow.timestamp);
+  const currentTimestamp = Date.parse(currentRow.timestamp);
+  if (Number.isFinite(nextTimestamp) && Number.isFinite(currentTimestamp)) {
+    return nextTimestamp >= currentTimestamp ? nextRow : currentRow;
   }
+  return nextRow;
+}
 
-  const snapshotPath = getCostSnapshotPath(metricsDir, sessionId);
-  assertCostLogSignature(source);
-  return writeFileAtomic(
-    snapshotPath,
-    JSON.stringify({
-      schema_version: COST_SNAPSHOT_SCHEMA_VERSION,
-      source,
-      row
-    }),
+function sourceIdentity(stat) {
+  return `${stat.dev}:${stat.ino}`;
+}
+
+function hashWindow(descriptor, position, length) {
+  const buffer = Buffer.alloc(length);
+  if (length > 0) fs.readSync(descriptor, buffer, 0, length, position);
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+function fingerprintProcessedPrefix(descriptor, offset) {
+  const windowLength = Math.min(FINGERPRINT_WINDOW_BYTES, offset);
+  const middleStart = Math.max(0, Math.floor((offset - windowLength) / 2));
+  return {
+    start: hashWindow(descriptor, 0, windowLength),
+    middle: hashWindow(descriptor, middleStart, windowLength),
+    end: hashWindow(descriptor, offset - windowLength, windowLength)
+  };
+}
+
+function fingerprintsMatch(left, right) {
+  return left?.start === right?.start
+    && left?.middle === right?.middle
+    && left?.end === right?.end;
+}
+
+function validSnapshotBase(snapshot, descriptor, stat, sessionId) {
+  if (snapshot?.schema_version !== COST_SNAPSHOT_SCHEMA_VERSION) return null;
+  if (snapshot.row !== null && !isValidCostRow(snapshot.row, sessionId)) return null;
+  const source = snapshot.source;
+  if (source?.identity !== sourceIdentity(stat)) return null;
+  if (!Number.isSafeInteger(source.offset_bytes) || source.offset_bytes < 0) return null;
+  if (source.offset_bytes > stat.size) return null;
+  if (source.offset_bytes === stat.size && source.mtime_ms !== stat.mtimeMs) return null;
+  if (!fingerprintsMatch(
+    source.fingerprint,
+    fingerprintProcessedPrefix(descriptor, source.offset_bytes)
+  )) return null;
+  return { row: snapshot.row, offset: source.offset_bytes };
+}
+
+function scanJsonlRange(descriptor, start, end, sessionId, initialRow) {
+  const buffer = Buffer.allocUnsafe(READ_CHUNK_BYTES);
+  let position = start;
+  let processedOffset = start;
+  let pending = Buffer.alloc(0);
+  let latestRow = initialRow;
+  let committedRow = initialRow;
+  let malformed = 0;
+  let invalid = 0;
+  const malformedHasher = crypto.createHash('sha256');
+  const invalidHasher = crypto.createHash('sha256');
+
+  const processLine = (line, committed = true) => {
+    if (!line.trim()) return;
+    try {
+      const row = JSON.parse(line);
+      if (row.session_id !== sessionId) return;
+      if (!isValidCostRow(row, sessionId)) {
+        if (committed) {
+          invalid += 1;
+          invalidHasher.update(line).update('\0');
+        }
+        return;
+      }
+      latestRow = chooseNewerCumulativeRow(latestRow, row);
+      if (committed) committedRow = chooseNewerCumulativeRow(committedRow, row);
+    } catch {
+      if (committed) {
+        malformed += 1;
+        malformedHasher.update(line).update('\0');
+      }
+    }
+  };
+
+  while (position < end) {
+    const bytesRead = fs.readSync(
+      descriptor,
+      buffer,
+      0,
+      Math.min(buffer.length, end - position),
+      position
+    );
+    if (bytesRead === 0) break;
+    const combined = pending.length > 0
+      ? Buffer.concat([pending, buffer.subarray(0, bytesRead)])
+      : buffer.subarray(0, bytesRead);
+    let lineStart = 0;
+    for (;;) {
+      const newlineIndex = combined.indexOf(0x0a, lineStart);
+      if (newlineIndex < 0) break;
+      processLine(combined.subarray(lineStart, newlineIndex).toString('utf8'));
+      lineStart = newlineIndex + 1;
+    }
+    pending = Buffer.from(combined.subarray(lineStart));
+    position += bytesRead;
+    processedOffset = position - pending.length;
+  }
+  if (pending.toString('utf8').trim()) processLine(pending.toString('utf8'), false);
+  return {
+    row: latestRow,
+    committedRow,
+    processedOffset,
+    malformed,
+    invalid,
+    malformedSignature: malformed > 0 ? malformedHasher.digest('hex').slice(0, 16) : null,
+    invalidSignature: invalid > 0 ? invalidHasher.digest('hex').slice(0, 16) : null
+  };
+}
+
+function writeSnapshotAtOffset(metricsDir, sessionId, row, descriptor, stat, offset) {
+  if (row !== null && !isValidCostRow(row, sessionId)) return false;
+  const snapshot = {
+    schema_version: COST_SNAPSHOT_SCHEMA_VERSION,
+    source: {
+      identity: sourceIdentity(stat),
+      offset_bytes: offset,
+      mtime_ms: stat.mtimeMs,
+      fingerprint: fingerprintProcessedPrefix(descriptor, offset)
+    },
+    row
+  };
+  writeFileAtomic(
+    getCostSnapshotPath(metricsDir, sessionId),
+    JSON.stringify(snapshot),
     {
       beforeRename() {
-        if (!signaturesMatch(source, getCostLogSignature(metricsDir))) {
-          throw new Error('Cost log changed while publishing its session snapshot');
+        const current = fs.fstatSync(descriptor);
+        if (sourceIdentity(current) !== snapshot.source.identity) {
+          throw new Error('Cost log identity changed during snapshot publication');
+        }
+        if (current.size < offset) {
+          throw new Error('Cost log was truncated during snapshot publication');
+        }
+        if (current.size === offset && current.mtimeMs !== snapshot.source.mtime_ms) {
+          throw new Error('Cost log changed during snapshot publication');
+        }
+        if (!fingerprintsMatch(
+          fingerprintProcessedPrefix(descriptor, offset),
+          snapshot.source.fingerprint
+        )) {
+          throw new Error('Cost log prefix changed during snapshot publication');
         }
       }
     }
   );
+  return true;
 }
 
-function costLogEndsWithRow(metricsDir, row) {
-  const expected = Buffer.from(`${JSON.stringify(row)}\n`, 'utf8');
-  const descriptor = fs.openSync(path.join(metricsDir, COST_LOG_FILENAME), 'r');
+function refreshSessionCostSnapshot(metricsDir, sessionId) {
+  assertSafeSessionId(sessionId);
+  const costsPath = path.join(metricsDir, COST_LOG_FILENAME);
+  const descriptor = fs.openSync(costsPath, 'r');
   try {
     const stat = fs.fstatSync(descriptor);
-    if (stat.size < expected.length) return false;
-    const actual = Buffer.allocUnsafe(expected.length);
-    const bytesRead = fs.readSync(
+    const snapshot = readJsonFile(getCostSnapshotPath(metricsDir, sessionId));
+    const base = validSnapshotBase(snapshot, descriptor, stat, sessionId);
+    if (base?.offset === stat.size) {
+      return {
+        row: base.row,
+        scannedBytes: 0,
+        malformed: 0,
+        invalid: 0,
+        malformedSignature: null,
+        invalidSignature: null,
+        snapshotError: null
+      };
+    }
+    const scan = scanJsonlRange(
       descriptor,
-      actual,
-      0,
-      expected.length,
-      stat.size - expected.length
+      base?.offset || 0,
+      stat.size,
+      sessionId,
+      base?.row || null
     );
-    return bytesRead === expected.length && actual.equals(expected);
+    let snapshotError = null;
+    if (scan.committedRow || scan.processedOffset > 0) {
+      try {
+        writeSnapshotAtOffset(
+          metricsDir,
+          sessionId,
+          scan.committedRow,
+          descriptor,
+          stat,
+          scan.processedOffset
+        );
+      } catch (error) {
+        snapshotError = error;
+      }
+    }
+    return {
+      row: scan.row,
+      scannedBytes: scan.processedOffset - (base?.offset || 0),
+      malformed: scan.malformed,
+      invalid: scan.invalid,
+      malformedSignature: scan.malformedSignature,
+      invalidSignature: scan.invalidSignature,
+      snapshotError
+    };
   } finally {
     fs.closeSync(descriptor);
   }
 }
 
-function publishAppendedSessionCostSnapshot(metricsDir, sessionId, row) {
+function costLogNeedsSeparator(metricsDir) {
+  const costsPath = path.join(metricsDir, COST_LOG_FILENAME);
+  let descriptor;
+  try {
+    descriptor = fs.openSync(costsPath, 'r');
+    const stat = fs.fstatSync(descriptor);
+    if (stat.size === 0) return false;
+    const lastByte = Buffer.alloc(1);
+    return fs.readSync(descriptor, lastByte, 0, 1, stat.size - 1) === 1
+      && lastByte[0] !== 0x0a;
+  } catch (error) {
+    if (error.code === 'ENOENT') return false;
+    throw error;
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+  }
+}
+
+function appendSessionCostRow(metricsDir, sessionId, row) {
   assertSafeSessionId(sessionId);
   if (!isValidCostRow(row, sessionId)) {
     throw new Error('Cost snapshot requires valid non-negative numeric totals for its session');
   }
-  const sourceBefore = getCostLogSignature(metricsDir);
-  if (!costLogEndsWithRow(metricsDir, row)) return false;
-  const sourceAfter = getCostLogSignature(metricsDir);
-  if (!signaturesMatch(sourceBefore, sourceAfter)) return false;
-  writeSnapshotForSource(metricsDir, sessionId, row, sourceAfter);
-  return true;
-}
-
-function repairSessionCostSnapshot(metricsDir, sessionId, row, source) {
-  writeSnapshotForSource(metricsDir, sessionId, row, source);
+  const prefix = costLogNeedsSeparator(metricsDir) ? '\n' : '';
+  fs.appendFileSync(
+    path.join(metricsDir, COST_LOG_FILENAME),
+    `${prefix}${JSON.stringify(row)}\n`,
+    'utf8'
+  );
+  const result = refreshSessionCostSnapshot(metricsDir, sessionId);
+  if (result.snapshotError) throw result.snapshotError;
+  try {
+    maybePruneSessionCostSnapshots(metricsDir);
+  } catch {
+    // Retention is opportunistic and retried by a later update.
+  }
+  return JSON.stringify(result.row) === JSON.stringify(row);
 }
 
 function readSessionCostSnapshot(metricsDir, sessionId) {
   try {
-    const snapshot = JSON.parse(
-      fs.readFileSync(getCostSnapshotPath(metricsDir, sessionId), 'utf8')
-    );
-    if (snapshot?.schema_version !== COST_SNAPSHOT_SCHEMA_VERSION) return null;
-    if (!isValidCostRow(snapshot.row, sessionId)) return null;
-    if (!signaturesMatch(snapshot.source, getCostLogSignature(metricsDir))) return null;
-    return snapshot.row;
-  } catch {
-    return null;
+    return refreshSessionCostSnapshot(metricsDir, sessionId);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return { row: null, scannedBytes: 0, malformed: 0, invalid: 0, snapshotError: null };
+    }
+    throw error;
   }
+}
+
+function maybePruneSessionCostSnapshots(metricsDir, options = {}) {
+  const snapshotDir = getSnapshotDirectory(metricsDir);
+  const now = Number.isFinite(options.now) ? options.now : Date.now();
+  const maxAgeMs = Number.isFinite(options.maxAgeMs) ? options.maxAgeMs : SNAPSHOT_MAX_AGE_MS;
+  const maxSnapshots = Number.isSafeInteger(options.maxSnapshots)
+    ? Math.max(0, options.maxSnapshots)
+    : MAX_SNAPSHOTS;
+  const markerPath = path.join(snapshotDir, '.last-prune');
+
+  fs.mkdirSync(snapshotDir, { recursive: true });
+  const snapshotEntries = fs.readdirSync(snapshotDir, { withFileTypes: true })
+    .filter(entry => entry.isFile() && /^session-.+\.json$/.test(entry.name));
+  if (!options.force) {
+    try {
+      const intervalIsFresh = now - fs.statSync(markerPath).mtimeMs < PRUNE_INTERVAL_MS;
+      if (intervalIsFresh && snapshotEntries.length <= maxSnapshots) return 0;
+    } catch { /* missing marker */ }
+  }
+  fs.writeFileSync(markerPath, String(now), { encoding: 'utf8', mode: 0o600 });
+
+  const snapshots = snapshotEntries
+    .map(entry => {
+      const filePath = path.join(snapshotDir, entry.name);
+      return { filePath, mtimeMs: fs.statSync(filePath).mtimeMs };
+    })
+    .sort((left, right) => right.mtimeMs - left.mtimeMs);
+  const removals = snapshots.filter((entry, index) => (
+    index >= maxSnapshots || now - entry.mtimeMs > maxAgeMs
+  ));
+  let removed = 0;
+  for (const entry of removals) {
+    try {
+      if (fs.statSync(entry.filePath).mtimeMs <= entry.mtimeMs) {
+        fs.rmSync(entry.filePath, { force: true });
+        removed += 1;
+      }
+    } catch { /* already replaced or removed */ }
+  }
+  return removed;
+}
+
+function warningClaimPath(kind, metricsDir, sessionId, signature) {
+  const key = crypto.createHash('sha256')
+    .update(`${path.resolve(metricsDir)}\0${sessionId}\0${kind}\0${signature}`)
+    .digest('hex')
+    .slice(0, 16);
+  return path.join(os.tmpdir(), `${WARNING_CACHE_PREFIX}${key}.claim`);
+}
+
+function warnSessionCostSnapshotFailure(kind, metricsDir, sessionId, error) {
+  const targetPath = getCostSnapshotPath(metricsDir, sessionId);
+  const errorCode = error?.code || error?.name || 'error';
+  const signature = `${kind}:${targetPath}:${errorCode}`;
+  const claimPath = warningClaimPath(kind, metricsDir, sessionId, signature);
+  let claimDescriptor;
+  try {
+    claimDescriptor = fs.openSync(claimPath, 'wx', 0o600);
+    fs.closeSync(claimDescriptor);
+    claimDescriptor = undefined;
+  } catch (claimError) {
+    if (claimDescriptor !== undefined) fs.closeSync(claimDescriptor);
+    if (claimError.code === 'EEXIST') return;
+    // Warning persistence is best effort. If the claim cannot be created,
+    // still surface the underlying snapshot failure.
+  }
+  process.stderr.write(
+    `[cost-snapshot] ${kind} failed for session ${sessionId}: ${error?.message || String(error)}\n`
+  );
 }
 
 module.exports = {
@@ -138,10 +400,12 @@ module.exports = {
   COST_SNAPSHOT_DIRECTORY,
   COST_LOG_FILENAME,
   getCostSnapshotPath,
-  getCostLogSignature,
-  signaturesMatch,
   isValidCostRow,
-  publishAppendedSessionCostSnapshot,
-  repairSessionCostSnapshot,
-  readSessionCostSnapshot
+  chooseNewerCumulativeRow,
+  appendSessionCostRow,
+  readSessionCostSnapshot,
+  refreshSessionCostSnapshot,
+  costLogNeedsSeparator,
+  maybePruneSessionCostSnapshots,
+  warnSessionCostSnapshotFailure
 };

--- a/scripts/lib/session-cost-snapshot.js
+++ b/scripts/lib/session-cost-snapshot.js
@@ -500,6 +500,7 @@ module.exports = {
   COST_SNAPSHOT_SCHEMA_VERSION,
   COST_SNAPSHOT_DIRECTORY,
   COST_LOG_FILENAME,
+  MAX_SCAN_BYTES,
   getCostSnapshotPath,
   isValidCostRow,
   chooseNewerCumulativeRow,

--- a/scripts/lib/session-cost-snapshot.js
+++ b/scripts/lib/session-cost-snapshot.js
@@ -11,6 +11,8 @@ const COST_SNAPSHOT_SCHEMA_VERSION = 'ecc.cost-snapshot.v1';
 const COST_SNAPSHOT_DIRECTORY = 'cost-snapshots';
 const COST_LOG_FILENAME = 'costs.jsonl';
 const READ_CHUNK_BYTES = 64 * 1024;
+const MAX_JSONL_LINE_BYTES = 1024 * 1024;
+const MAX_SCAN_BYTES = 16 * 1024 * 1024;
 const FINGERPRINT_WINDOW_BYTES = 256;
 const PRUNE_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const SNAPSHOT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
@@ -109,42 +111,121 @@ function validSnapshotBase(snapshot, descriptor, stat, sessionId) {
     source.fingerprint,
     fingerprintProcessedPrefix(descriptor, source.offset_bytes)
   )) return null;
-  return { row: snapshot.row, offset: source.offset_bytes };
+  return {
+    row: snapshot.row,
+    offset: source.offset_bytes,
+    discardingLine: source.discarding_line === true
+  };
 }
 
-function scanJsonlRange(descriptor, start, end, sessionId, initialRow) {
+function createScanState(initialRow) {
+  return {
+    latestRow: initialRow,
+    committedRow: initialRow,
+    malformed: 0,
+    invalid: 0,
+    malformedHasher: crypto.createHash('sha256'),
+    invalidHasher: crypto.createHash('sha256')
+  };
+}
+
+function processCostLine(state, line, sessionId, committed = true) {
+  if (!line.trim()) return state;
+  try {
+    const row = JSON.parse(line);
+    if (row.session_id !== sessionId) return state;
+    if (!isValidCostRow(row, sessionId)) {
+      if (!committed) return state;
+      return {
+        ...state,
+        invalid: state.invalid + 1,
+        invalidHasher: state.invalidHasher.copy().update(line).update('\0')
+      };
+    }
+    return {
+      ...state,
+      latestRow: chooseNewerCumulativeRow(state.latestRow, row),
+      committedRow: committed
+        ? chooseNewerCumulativeRow(state.committedRow, row)
+        : state.committedRow
+    };
+  } catch {
+    if (!committed) return state;
+    return {
+      ...state,
+      malformed: state.malformed + 1,
+      malformedHasher: state.malformedHasher.copy().update(line).update('\0')
+    };
+  }
+}
+
+function markOversizedLine(state, pendingChunks, segment) {
+  const hasher = state.malformedHasher.copy();
+  for (const chunk of pendingChunks) hasher.update(chunk);
+  const remaining = Math.max(0, MAX_JSONL_LINE_BYTES - pendingChunks.reduce(
+    (total, chunk) => total + chunk.length,
+    0
+  ));
+  hasher.update(segment.subarray(0, remaining)).update('\0<oversized>');
+  return { ...state, malformed: state.malformed + 1, malformedHasher: hasher };
+}
+
+function consumeLineSegment(scan, segment, terminated, sessionId) {
+  if (scan.discardingLine) {
+    return { ...scan, discardingLine: !terminated };
+  }
+  if (scan.pendingBytes + segment.length > MAX_JSONL_LINE_BYTES) {
+    return {
+      state: markOversizedLine(scan.state, scan.pendingChunks, segment),
+      pendingChunks: [],
+      pendingBytes: 0,
+      discardingLine: !terminated
+    };
+  }
+  const pendingChunks = segment.length > 0
+    ? [...scan.pendingChunks, Buffer.from(segment)]
+    : scan.pendingChunks;
+  const pendingBytes = scan.pendingBytes + segment.length;
+  if (!terminated) return { ...scan, pendingChunks, pendingBytes };
+  const line = Buffer.concat(pendingChunks, pendingBytes).toString('utf8');
+  return {
+    state: processCostLine(scan.state, line, sessionId),
+    pendingChunks: [],
+    pendingBytes: 0,
+    discardingLine: false
+  };
+}
+
+function consumeJsonlChunk(scan, chunk, sessionId, absoluteStart, processedOffset) {
+  let nextScan = scan;
+  let nextOffset = processedOffset;
+  let segmentStart = 0;
+  for (;;) {
+    const newlineIndex = chunk.indexOf(0x0a, segmentStart);
+    if (newlineIndex < 0) break;
+    nextScan = consumeLineSegment(
+      nextScan, chunk.subarray(segmentStart, newlineIndex), true, sessionId
+    );
+    nextOffset = absoluteStart + newlineIndex + 1;
+    segmentStart = newlineIndex + 1;
+  }
+  nextScan = consumeLineSegment(
+    nextScan, chunk.subarray(segmentStart), false, sessionId
+  );
+  if (nextScan.discardingLine) nextOffset = absoluteStart + chunk.length;
+  return { scan: nextScan, processedOffset: nextOffset };
+}
+
+function scanJsonlRange(descriptor, start, end, sessionId, initialRow, initialDiscard = false) {
   const buffer = Buffer.allocUnsafe(READ_CHUNK_BYTES);
+  let lineScan = {
+    state: createScanState(initialRow),
+    pendingChunks: [],
+    pendingBytes: 0,
+    discardingLine: initialDiscard
+  };
   let position = start;
   let processedOffset = start;
-  let pending = Buffer.alloc(0);
-  let latestRow = initialRow;
-  let committedRow = initialRow;
-  let malformed = 0;
-  let invalid = 0;
-  const malformedHasher = crypto.createHash('sha256');
-  const invalidHasher = crypto.createHash('sha256');
-
-  const processLine = (line, committed = true) => {
-    if (!line.trim()) return;
-    try {
-      const row = JSON.parse(line);
-      if (row.session_id !== sessionId) return;
-      if (!isValidCostRow(row, sessionId)) {
-        if (committed) {
-          invalid += 1;
-          invalidHasher.update(line).update('\0');
-        }
-        return;
-      }
-      latestRow = chooseNewerCumulativeRow(latestRow, row);
-      if (committed) committedRow = chooseNewerCumulativeRow(committedRow, row);
-    } catch {
-      if (committed) {
-        malformed += 1;
-        malformedHasher.update(line).update('\0');
-      }
-    }
-  };
 
   while (position < end) {
     const bytesRead = fs.readSync(
@@ -155,33 +236,40 @@ function scanJsonlRange(descriptor, start, end, sessionId, initialRow) {
       position
     );
     if (bytesRead === 0) break;
-    const combined = pending.length > 0
-      ? Buffer.concat([pending, buffer.subarray(0, bytesRead)])
-      : buffer.subarray(0, bytesRead);
-    let lineStart = 0;
-    for (;;) {
-      const newlineIndex = combined.indexOf(0x0a, lineStart);
-      if (newlineIndex < 0) break;
-      processLine(combined.subarray(lineStart, newlineIndex).toString('utf8'));
-      lineStart = newlineIndex + 1;
-    }
-    pending = Buffer.from(combined.subarray(lineStart));
+    const consumed = consumeJsonlChunk(
+      lineScan, buffer.subarray(0, bytesRead), sessionId, position, processedOffset
+    );
+    lineScan = consumed.scan;
+    processedOffset = consumed.processedOffset;
     position += bytesRead;
-    processedOffset = position - pending.length;
   }
-  if (pending.toString('utf8').trim()) processLine(pending.toString('utf8'), false);
+  if (lineScan.pendingBytes > 0) {
+    const line = Buffer.concat(lineScan.pendingChunks, lineScan.pendingBytes).toString('utf8');
+    lineScan = {
+      ...lineScan,
+      state: processCostLine(lineScan.state, line, sessionId, false)
+    };
+  }
+  const { state } = lineScan;
   return {
-    row: latestRow,
-    committedRow,
+    row: state.latestRow,
+    committedRow: state.committedRow,
     processedOffset,
-    malformed,
-    invalid,
-    malformedSignature: malformed > 0 ? malformedHasher.digest('hex').slice(0, 16) : null,
-    invalidSignature: invalid > 0 ? invalidHasher.digest('hex').slice(0, 16) : null
+    malformed: state.malformed,
+    invalid: state.invalid,
+    malformedSignature: state.malformed > 0
+      ? state.malformedHasher.digest('hex').slice(0, 16)
+      : null,
+    invalidSignature: state.invalid > 0
+      ? state.invalidHasher.digest('hex').slice(0, 16)
+      : null,
+    discardingLine: lineScan.discardingLine
   };
 }
 
-function writeSnapshotAtOffset(metricsDir, sessionId, row, descriptor, stat, offset) {
+function writeSnapshotAtOffset(
+  metricsDir, sessionId, row, descriptor, stat, offset, discardingLine = false
+) {
   if (row !== null && !isValidCostRow(row, sessionId)) return false;
   const snapshot = {
     schema_version: COST_SNAPSHOT_SCHEMA_VERSION,
@@ -189,6 +277,7 @@ function writeSnapshotAtOffset(metricsDir, sessionId, row, descriptor, stat, off
       identity: sourceIdentity(stat),
       offset_bytes: offset,
       mtime_ms: stat.mtimeMs,
+      discarding_line: discardingLine,
       fingerprint: fingerprintProcessedPrefix(descriptor, offset)
     },
     row
@@ -199,9 +288,6 @@ function writeSnapshotAtOffset(metricsDir, sessionId, row, descriptor, stat, off
     {
       beforeRename() {
         const current = fs.fstatSync(descriptor);
-        if (sourceIdentity(current) !== snapshot.source.identity) {
-          throw new Error('Cost log identity changed during snapshot publication');
-        }
         if (current.size < offset) {
           throw new Error('Cost log was truncated during snapshot publication');
         }
@@ -220,6 +306,36 @@ function writeSnapshotAtOffset(metricsDir, sessionId, row, descriptor, stat, off
   return true;
 }
 
+function emptySnapshotResult(row) {
+  return {
+    row,
+    scannedBytes: 0,
+    malformed: 0,
+    invalid: 0,
+    malformedSignature: null,
+    invalidSignature: null,
+    snapshotError: null
+  };
+}
+
+function publishScanSnapshot(metricsDir, sessionId, scan, descriptor, stat) {
+  if (!scan.committedRow && scan.processedOffset === 0) return null;
+  try {
+    writeSnapshotAtOffset(
+      metricsDir,
+      sessionId,
+      scan.committedRow,
+      descriptor,
+      stat,
+      scan.processedOffset,
+      scan.discardingLine
+    );
+    return null;
+  } catch (error) {
+    return error;
+  }
+}
+
 function refreshSessionCostSnapshot(metricsDir, sessionId) {
   assertSafeSessionId(sessionId);
   const costsPath = path.join(metricsDir, COST_LOG_FILENAME);
@@ -228,39 +344,19 @@ function refreshSessionCostSnapshot(metricsDir, sessionId) {
     const stat = fs.fstatSync(descriptor);
     const snapshot = readJsonFile(getCostSnapshotPath(metricsDir, sessionId));
     const base = validSnapshotBase(snapshot, descriptor, stat, sessionId);
-    if (base?.offset === stat.size) {
-      return {
-        row: base.row,
-        scannedBytes: 0,
-        malformed: 0,
-        invalid: 0,
-        malformedSignature: null,
-        invalidSignature: null,
-        snapshotError: null
-      };
-    }
+    if (base?.offset === stat.size) return emptySnapshotResult(base.row);
+    const scanEnd = Math.min(stat.size, (base?.offset || 0) + MAX_SCAN_BYTES);
     const scan = scanJsonlRange(
       descriptor,
       base?.offset || 0,
-      stat.size,
+      scanEnd,
       sessionId,
-      base?.row || null
+      base?.row || null,
+      base?.discardingLine || false
     );
-    let snapshotError = null;
-    if (scan.committedRow || scan.processedOffset > 0) {
-      try {
-        writeSnapshotAtOffset(
-          metricsDir,
-          sessionId,
-          scan.committedRow,
-          descriptor,
-          stat,
-          scan.processedOffset
-        );
-      } catch (error) {
-        snapshotError = error;
-      }
-    }
+    const snapshotError = publishScanSnapshot(
+      metricsDir, sessionId, scan, descriptor, stat
+    );
     return {
       row: scan.row,
       scannedBytes: scan.processedOffset - (base?.offset || 0),
@@ -308,8 +404,10 @@ function appendSessionCostRow(metricsDir, sessionId, row) {
   if (result.snapshotError) throw result.snapshotError;
   try {
     maybePruneSessionCostSnapshots(metricsDir);
-  } catch {
-    // Retention is opportunistic and retried by a later update.
+  } catch (error) {
+    // Retention is opportunistic and retried by a later update, but a
+    // persistent failure remains visible without rolling back the log append.
+    warnSessionCostSnapshotFailure('retention', metricsDir, sessionId, error);
   }
   return JSON.stringify(result.row) === JSON.stringify(row);
 }
@@ -341,10 +439,10 @@ function maybePruneSessionCostSnapshots(metricsDir, options = {}) {
     try {
       const intervalIsFresh = now - fs.statSync(markerPath).mtimeMs < PRUNE_INTERVAL_MS;
       if (intervalIsFresh && snapshotEntries.length <= maxSnapshots) return 0;
-    } catch { /* missing marker */ }
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
   }
-  fs.writeFileSync(markerPath, String(now), { encoding: 'utf8', mode: 0o600 });
-
   const snapshots = snapshotEntries
     .map(entry => {
       const filePath = path.join(snapshotDir, entry.name);
@@ -361,8 +459,11 @@ function maybePruneSessionCostSnapshots(metricsDir, options = {}) {
         fs.rmSync(entry.filePath, { force: true });
         removed += 1;
       }
-    } catch { /* already replaced or removed */ }
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+    }
   }
+  fs.writeFileSync(markerPath, String(now), { encoding: 'utf8', mode: 0o600 });
   return removed;
 }
 

--- a/skills/cost-tracking/SKILL.md
+++ b/skills/cost-tracking/SKILL.md
@@ -17,6 +17,11 @@ The tracker appends one JSON object per session-stop to
 session**, so to total spend you take the **latest row per `session_id`** and
 sum across sessions — summing every row multiply-counts.
 
+ECC also maintains internal per-session files under
+`~/.claude/metrics/cost-snapshots/` so runtime hooks can read the current
+session total without rescanning all history. Treat those files as a
+rebuildable cache; reports and exports should continue to use `costs.jsonl`.
+
 Row schema:
 
 | Field | Meaning |

--- a/skills/cost-tracking/SKILL.md
+++ b/skills/cost-tracking/SKILL.md
@@ -20,7 +20,10 @@ sum across sessions — summing every row multiply-counts.
 ECC also maintains internal per-session files under
 `~/.claude/metrics/cost-snapshots/` so runtime hooks can read the current
 session total without rescanning all history. Treat those files as a
-rebuildable cache; reports and exports should continue to use `costs.jsonl`.
+rebuildable cache; each snapshot stores a byte cursor so only newly appended
+rows are scanned. Stable reads are O(1), while updates are O(new bytes). Stale
+entries are pruned after 30 days or when the directory exceeds 512 sessions.
+Reports and exports should continue to use `costs.jsonl`.
 
 Row schema:
 

--- a/skills/cost-tracking/SKILL.md
+++ b/skills/cost-tracking/SKILL.md
@@ -23,6 +23,8 @@ session total without rescanning all history. Treat those files as a
 rebuildable cache; each snapshot stores a byte cursor so only newly appended
 rows are scanned. Stable reads are O(1), while updates are O(new bytes). Stale
 entries are pruned after 30 days or when the directory exceeds 512 sessions.
+Cold catch-up work is limited to 16 MiB per hook invocation, and malformed
+unterminated rows larger than 1 MiB are discarded with a resumable cursor.
 Reports and exports should continue to use `costs.jsonl`.
 
 Row schema:

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -249,6 +249,57 @@ function runTests() {
     fs.rmSync(tmpHome, { recursive: true, force: true });
   }) ? passed++ : failed++);
 
+  (test('normalizes malformed negative and non-finite transcript usage', () => {
+    const tmpHome = makeTempDir();
+    const transcriptPath = path.join(tmpHome, 'session.jsonl');
+    writeTranscript(transcriptPath, [{
+      type: 'assistant',
+      message: {
+        id: 'msg_invalid_usage',
+        model: 'claude-sonnet-4-20250514',
+        usage: {
+          input_tokens: -100,
+          output_tokens: 'Infinity',
+          cache_creation_input_tokens: -20,
+          cache_read_input_tokens: 'not-a-number',
+        },
+      },
+    }, {
+      type: 'assistant',
+      message: {
+        id: 'msg_overflow_1',
+        model: 'claude-sonnet-4-20250514',
+        usage: { input_tokens: 1e308, output_tokens: 0 },
+      },
+    }, {
+      type: 'assistant',
+      message: {
+        id: 'msg_overflow_2',
+        model: 'claude-sonnet-4-20250514',
+        usage: { input_tokens: 1e308, output_tokens: 0 },
+      },
+    }]);
+
+    const result = runScript(
+      { session_id: 'invalid-usage', transcript_path: transcriptPath },
+      withTempHome(tmpHome)
+    );
+    assert.strictEqual(result.code, 0, result.stderr);
+    const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+    const recorded = JSON.parse(fs.readFileSync(metricsFile, 'utf8').trim());
+    assert.deepStrictEqual(
+      {
+        input: recorded.input_tokens,
+        output: recorded.output_tokens,
+        cacheWrite: recorded.cache_write_tokens,
+        cacheRead: recorded.cache_read_tokens,
+        cost: recorded.estimated_cost_usd,
+      },
+      { input: 0, output: 0, cacheWrite: 0, cacheRead: 0, cost: 0 }
+    );
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }) ? passed++ : failed++);
+
   // 3. Handles empty input gracefully
   (test('handles empty input gracefully', () => {
     const tmpHome = makeTempDir();

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -9,6 +9,7 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const { spawnSync } = require('child_process');
+const { getCostSnapshotPath } = require('../../scripts/lib/session-cost-snapshot');
 
 const script = path.join(__dirname, '..', '..', 'scripts', 'hooks', 'cost-tracker.js');
 
@@ -115,6 +116,32 @@ function runTests() {
     assert.strictEqual(result.stdout, inputStr, 'Expected stdout to match original input');
   }) ? passed++ : failed++);
 
+  (test('keeps JSONL authoritative when the snapshot path cannot be published', () => {
+    const tmpHome = makeTempDir();
+    const metricsDir = path.join(tmpHome, '.claude', 'metrics');
+    const blockedSnapshotPath = path.join(
+      metricsDir,
+      'cost-snapshots',
+      'snapshot-failure.json'
+    );
+    fs.mkdirSync(blockedSnapshotPath, { recursive: true });
+
+    try {
+      const result = runScript(
+        { session_id: 'snapshot-failure' },
+        withTempHome(tmpHome)
+      );
+      assert.strictEqual(result.code, 0, result.stderr);
+      const rows = fs.readFileSync(path.join(metricsDir, 'costs.jsonl'), 'utf8')
+        .trim()
+        .split('\n')
+        .map(line => JSON.parse(line));
+      assert.strictEqual(rows.at(-1).session_id, 'snapshot-failure');
+    } finally {
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  }) ? passed++ : failed++);
+
   // 2. Creates metrics file when given transcript usage data
   (test('creates metrics file when given transcript usage data', () => {
     const tmpHome = makeTempDir();
@@ -154,6 +181,7 @@ function runTests() {
     assert.strictEqual(result.code, 0, `Expected exit code 0, got ${result.code}`);
 
     const metricsFile = path.join(tmpHome, '.claude', 'metrics', 'costs.jsonl');
+    const metricsDir = path.dirname(metricsFile);
     assert.ok(fs.existsSync(metricsFile), `Expected metrics file to exist at ${metricsFile}`);
 
     const content = fs.readFileSync(metricsFile, 'utf8').trim();
@@ -168,6 +196,12 @@ function runTests() {
     assert.ok(row.timestamp, 'Expected timestamp to be present');
     assert.ok(typeof row.estimated_cost_usd === 'number', 'Expected estimated_cost_usd to be a number');
     assert.ok(row.estimated_cost_usd > 0, 'Expected estimated_cost_usd to be positive');
+
+    const snapshotFile = getCostSnapshotPath(metricsDir, 'session-from-hook');
+    assert.ok(fs.existsSync(snapshotFile), 'Expected an O(1) per-session cost snapshot');
+    const snapshot = JSON.parse(fs.readFileSync(snapshotFile, 'utf8'));
+    assert.strictEqual(snapshot.schema_version, 'ecc.cost-snapshot.v1');
+    assert.deepStrictEqual(snapshot.row, row, 'Snapshot must mirror the appended cumulative row');
 
     fs.rmSync(tmpHome, { recursive: true, force: true });
   }) ? passed++ : failed++);

--- a/tests/hooks/cost-tracker.test.js
+++ b/tests/hooks/cost-tracker.test.js
@@ -119,10 +119,9 @@ function runTests() {
   (test('keeps JSONL authoritative when the snapshot path cannot be published', () => {
     const tmpHome = makeTempDir();
     const metricsDir = path.join(tmpHome, '.claude', 'metrics');
-    const blockedSnapshotPath = path.join(
+    const blockedSnapshotPath = getCostSnapshotPath(
       metricsDir,
-      'cost-snapshots',
-      'snapshot-failure.json'
+      'snapshot-failure'
     );
     fs.mkdirSync(blockedSnapshotPath, { recursive: true });
 
@@ -137,6 +136,14 @@ function runTests() {
         .split('\n')
         .map(line => JSON.parse(line));
       assert.strictEqual(rows.at(-1).session_id, 'snapshot-failure');
+      assert.match(result.stderr, /cost-snapshot.*publication failed/);
+
+      const second = runScript(
+        { session_id: 'snapshot-failure' },
+        withTempHome(tmpHome)
+      );
+      assert.strictEqual(second.code, 0, second.stderr);
+      assert.strictEqual(second.stderr, '', 'identical persistent failure should warn only once');
     } finally {
       fs.rmSync(tmpHome, { recursive: true, force: true });
     }

--- a/tests/hooks/ecc-metrics-bridge.test.js
+++ b/tests/hooks/ecc-metrics-bridge.test.js
@@ -271,8 +271,11 @@ function runTests() {
         appendSessionCostRow(metricsDir, 'S1', snapshotRow);
 
         fs.readSync = function measuredRead(descriptor, buffer, offset, length, position) {
-          bytesReadFromCostLog += length;
-          return originalReadSync.call(this, descriptor, buffer, offset, length, position);
+          const bytesRead = originalReadSync.call(
+            this, descriptor, buffer, offset, length, position
+          );
+          if (Number.isSafeInteger(position)) bytesReadFromCostLog += bytesRead;
+          return bytesRead;
         };
 
         const result = readSessionCost('S1');
@@ -329,8 +332,11 @@ function runTests() {
         const originalReadSync = fs.readSync;
         let bytesReadFromCostLog = 0;
         fs.readSync = function measuredRead(descriptor, buffer, offset, length, position) {
-          bytesReadFromCostLog += length;
-          return originalReadSync.call(this, descriptor, buffer, offset, length, position);
+          const bytesRead = originalReadSync.call(
+            this, descriptor, buffer, offset, length, position
+          );
+          if (Number.isSafeInteger(position)) bytesReadFromCostLog += bytesRead;
+          return bytesRead;
         };
         try {
           assert.deepStrictEqual(readSessionCost('S1'), { totalCost: 1, totalIn: 100, totalOut: 50 });

--- a/tests/hooks/ecc-metrics-bridge.test.js
+++ b/tests/hooks/ecc-metrics-bridge.test.js
@@ -256,6 +256,18 @@ function runTests() {
           input_tokens: 750,
           output_tokens: 375
         };
+        const historicalRow = JSON.stringify({
+          session_id: 'HISTORY',
+          estimated_cost_usd: 0,
+          input_tokens: 0,
+          output_tokens: 0
+        });
+        fs.writeFileSync(
+          path.join(metricsDir, 'costs.jsonl'),
+          `${historicalRow}\n`.repeat(100),
+          'utf8'
+        );
+        assert.ok(fs.statSync(path.join(metricsDir, 'costs.jsonl')).size > 3 * 256);
         appendSessionCostRow(metricsDir, 'S1', snapshotRow);
 
         fs.readSync = function measuredRead(descriptor, buffer, offset, length, position) {
@@ -295,6 +307,18 @@ function runTests() {
           input_tokens: 100,
           output_tokens: 50
         };
+        const historicalRow = JSON.stringify({
+          session_id: 'HISTORY',
+          estimated_cost_usd: 0,
+          input_tokens: 0,
+          output_tokens: 0
+        });
+        fs.writeFileSync(
+          path.join(metricsDir, 'costs.jsonl'),
+          `${historicalRow}\n`.repeat(200),
+          'utf8'
+        );
+        assert.ok(fs.statSync(path.join(metricsDir, 'costs.jsonl')).size > 3 * 1024);
         appendSessionCostRow(metricsDir, 'S1', first);
         appendSessionCostRow(metricsDir, 'S2', {
           session_id: 'S2',
@@ -310,7 +334,7 @@ function runTests() {
         };
         try {
           assert.deepStrictEqual(readSessionCost('S1'), { totalCost: 1, totalIn: 100, totalOut: 50 });
-          assert.ok(bytesReadFromCostLog <= 2 * 1024);
+          assert.ok(bytesReadFromCostLog <= 3 * 1024);
         } finally {
           fs.readSync = originalReadSync;
         }
@@ -448,6 +472,7 @@ function runTests() {
           totalOut: 100
         });
         assert.match(captured, /skipped 3 invalid cumulative row\(s\) for S1/);
+        assert.match(captured, /during the snapshot scan of/);
       } finally {
         process.stderr.write = originalStderrWrite;
         if (originalHome === undefined) delete process.env.HOME;
@@ -541,6 +566,7 @@ function runTests() {
         const matches = captured.match(/skipped 2 malformed line\(s\)/g) || [];
         assert.strictEqual(matches.length, 1,
           `expected one aggregated malformed-line breadcrumb on stderr, got: ${captured}`);
+        assert.match(captured, /during the snapshot scan of/);
       } finally {
         process.stderr.write = originalStderrWrite;
         if (originalHome === undefined) delete process.env.HOME;

--- a/tests/hooks/ecc-metrics-bridge.test.js
+++ b/tests/hooks/ecc-metrics-bridge.test.js
@@ -11,6 +11,10 @@ const os = require('os');
 const path = require('path');
 
 const { run, hashToolCall, extractFilePaths, readSessionCost } = require('../../scripts/hooks/ecc-metrics-bridge');
+const {
+  getCostSnapshotPath,
+  publishAppendedSessionCostSnapshot
+} = require('../../scripts/lib/session-cost-snapshot');
 
 // Test helper
 function test(name, fn) {
@@ -222,6 +226,252 @@ function runTests() {
         assert.strictEqual(result.totalIn, 1000);
         assert.strictEqual(result.totalOut, 500);
       } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = originalUserProfile;
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('readSessionCost uses the per-session snapshot without scanning historical JSONL', () => {
+      const tmpHome = makeTempHome();
+      const originalHome = process.env.HOME;
+      const originalUserProfile = process.env.USERPROFILE;
+      const originalReadFileSync = fs.readFileSync;
+      try {
+        process.env.HOME = tmpHome;
+        process.env.USERPROFILE = tmpHome;
+        const metricsDir = path.join(tmpHome, '.claude', 'metrics');
+        const snapshotsDir = path.join(metricsDir, 'cost-snapshots');
+        fs.mkdirSync(snapshotsDir, { recursive: true });
+        const snapshotRow = {
+          session_id: 'S1',
+          estimated_cost_usd: 0.75,
+          input_tokens: 750,
+          output_tokens: 375
+        };
+        fs.writeFileSync(
+          path.join(metricsDir, 'costs.jsonl'),
+          `${JSON.stringify(snapshotRow)}\n`,
+          'utf8'
+        );
+        assert.strictEqual(
+          publishAppendedSessionCostSnapshot(metricsDir, 'S1', snapshotRow),
+          true
+        );
+
+        fs.readFileSync = function guardedRead(filePath, ...args) {
+          if (path.basename(String(filePath)) === 'costs.jsonl') {
+            throw new Error('historical JSONL scan should be bypassed on a snapshot hit');
+          }
+          return originalReadFileSync.call(this, filePath, ...args);
+        };
+
+        const result = readSessionCost('S1');
+        assert.deepStrictEqual(result, { totalCost: 0.75, totalIn: 750, totalOut: 375 });
+      } finally {
+        fs.readFileSync = originalReadFileSync;
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = originalUserProfile;
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('readSessionCost ignores a stale snapshot after costs.jsonl advances', () => {
+      const tmpHome = makeTempHome();
+      const originalHome = process.env.HOME;
+      const originalUserProfile = process.env.USERPROFILE;
+      try {
+        process.env.HOME = tmpHome;
+        process.env.USERPROFILE = tmpHome;
+        const metricsDir = path.join(tmpHome, '.claude', 'metrics');
+        fs.mkdirSync(metricsDir, { recursive: true });
+        const first = {
+          session_id: 'S1',
+          estimated_cost_usd: 1,
+          input_tokens: 100,
+          output_tokens: 50
+        };
+        const latest = {
+          session_id: 'S1',
+          estimated_cost_usd: 2,
+          input_tokens: 200,
+          output_tokens: 100
+        };
+        const costsPath = path.join(metricsDir, 'costs.jsonl');
+        fs.writeFileSync(costsPath, `${JSON.stringify(first)}\n`, 'utf8');
+        publishAppendedSessionCostSnapshot(metricsDir, 'S1', first);
+        fs.appendFileSync(costsPath, `${JSON.stringify(latest)}\n`, 'utf8');
+
+        assert.deepStrictEqual(readSessionCost('S1'), {
+          totalCost: 2,
+          totalIn: 200,
+          totalOut: 100
+        });
+
+        const originalReadFileSync = fs.readFileSync;
+        fs.readFileSync = function guardedRead(filePath, ...args) {
+          if (path.basename(String(filePath)) === 'costs.jsonl') {
+            throw new Error('fallback should repair the session snapshot');
+          }
+          return originalReadFileSync.call(this, filePath, ...args);
+        };
+        try {
+          assert.deepStrictEqual(readSessionCost('S1'), {
+            totalCost: 2,
+            totalIn: 200,
+            totalOut: 100
+          });
+        } finally {
+          fs.readFileSync = originalReadFileSync;
+        }
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = originalUserProfile;
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('readSessionCost falls back to JSONL when the session snapshot is malformed', () => {
+      const tmpHome = makeTempHome();
+      const originalHome = process.env.HOME;
+      const originalUserProfile = process.env.USERPROFILE;
+      try {
+        process.env.HOME = tmpHome;
+        process.env.USERPROFILE = tmpHome;
+        const metricsDir = path.join(tmpHome, '.claude', 'metrics');
+        const snapshotsDir = path.join(metricsDir, 'cost-snapshots');
+        fs.mkdirSync(snapshotsDir, { recursive: true });
+        fs.writeFileSync(getCostSnapshotPath(metricsDir, 'S1'), '{broken', 'utf8');
+        fs.writeFileSync(
+          path.join(metricsDir, 'costs.jsonl'),
+          `${JSON.stringify({
+            session_id: 'S1',
+            estimated_cost_usd: 1.5,
+            input_tokens: 1500,
+            output_tokens: 750
+          })}\n`,
+          'utf8'
+        );
+
+        assert.deepStrictEqual(readSessionCost('S1'), {
+          totalCost: 1.5,
+          totalIn: 1500,
+          totalOut: 750
+        });
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = originalUserProfile;
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('readSessionCost falls back when a snapshot row has invalid numeric totals', () => {
+      const tmpHome = makeTempHome();
+      const originalHome = process.env.HOME;
+      const originalUserProfile = process.env.USERPROFILE;
+      try {
+        process.env.HOME = tmpHome;
+        process.env.USERPROFILE = tmpHome;
+        const metricsDir = path.join(tmpHome, '.claude', 'metrics');
+        const snapshotsDir = path.join(metricsDir, 'cost-snapshots');
+        fs.mkdirSync(snapshotsDir, { recursive: true });
+        const valid = {
+          session_id: 'S1',
+          estimated_cost_usd: 2,
+          input_tokens: 200,
+          output_tokens: 100
+        };
+        const costsPath = path.join(metricsDir, 'costs.jsonl');
+        fs.writeFileSync(costsPath, `${JSON.stringify(valid)}\n`, 'utf8');
+        const stat = fs.statSync(costsPath);
+        fs.writeFileSync(
+          getCostSnapshotPath(metricsDir, 'S1'),
+          JSON.stringify({
+            schema_version: 'ecc.cost-snapshot.v1',
+            source: { size_bytes: stat.size, mtime_ms: stat.mtimeMs },
+            row: { session_id: 'S1' }
+          }),
+          'utf8'
+        );
+
+        assert.deepStrictEqual(readSessionCost('S1'), {
+          totalCost: 2,
+          totalIn: 200,
+          totalOut: 100
+        });
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+        if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+        else process.env.USERPROFILE = originalUserProfile;
+        fs.rmSync(tmpHome, { recursive: true, force: true });
+      }
+    })
+  )
+    passed++;
+  else failed++;
+
+  if (
+    test('readSessionCost skips invalid cumulative JSONL rows after the last valid total', () => {
+      const tmpHome = makeTempHome();
+      const originalHome = process.env.HOME;
+      const originalUserProfile = process.env.USERPROFILE;
+      const originalStderrWrite = process.stderr.write.bind(process.stderr);
+      let captured = '';
+      process.stderr.write = chunk => {
+        captured += String(chunk);
+        return true;
+      };
+      try {
+        process.env.HOME = tmpHome;
+        process.env.USERPROFILE = tmpHome;
+        const metricsDir = path.join(tmpHome, '.claude', 'metrics');
+        fs.mkdirSync(metricsDir, { recursive: true });
+        const rows = [
+          { session_id: 'S1', estimated_cost_usd: 2, input_tokens: 200, output_tokens: 100 },
+          { session_id: 'S1', estimated_cost_usd: -999, input_tokens: 'invalid', output_tokens: -5 },
+          { session_id: 'S1', input_tokens: 300, output_tokens: 150 },
+          { session_id: 'S1', estimated_cost_usd: null, input_tokens: 400, output_tokens: 200 },
+          { session_id: 'OTHER', estimated_cost_usd: -1, input_tokens: -1, output_tokens: -1 }
+        ];
+        fs.writeFileSync(
+          path.join(metricsDir, 'costs.jsonl'),
+          `${rows.map(row => JSON.stringify(row)).join('\n')}\n`,
+          'utf8'
+        );
+
+        assert.deepStrictEqual(readSessionCost('S1'), {
+          totalCost: 2,
+          totalIn: 200,
+          totalOut: 100
+        });
+        assert.match(captured, /skipped 3 invalid cumulative row\(s\) for S1/);
+      } finally {
+        process.stderr.write = originalStderrWrite;
         if (originalHome === undefined) delete process.env.HOME;
         else process.env.HOME = originalHome;
         if (originalUserProfile === undefined) delete process.env.USERPROFILE;

--- a/tests/hooks/ecc-metrics-bridge.test.js
+++ b/tests/hooks/ecc-metrics-bridge.test.js
@@ -12,8 +12,8 @@ const path = require('path');
 
 const { run, hashToolCall, extractFilePaths, readSessionCost } = require('../../scripts/hooks/ecc-metrics-bridge');
 const {
-  getCostSnapshotPath,
-  publishAppendedSessionCostSnapshot
+  appendSessionCostRow,
+  getCostSnapshotPath
 } = require('../../scripts/lib/session-cost-snapshot');
 
 // Test helper
@@ -242,7 +242,8 @@ function runTests() {
       const tmpHome = makeTempHome();
       const originalHome = process.env.HOME;
       const originalUserProfile = process.env.USERPROFILE;
-      const originalReadFileSync = fs.readFileSync;
+      const originalReadSync = fs.readSync;
+      let bytesReadFromCostLog = 0;
       try {
         process.env.HOME = tmpHome;
         process.env.USERPROFILE = tmpHome;
@@ -255,27 +256,18 @@ function runTests() {
           input_tokens: 750,
           output_tokens: 375
         };
-        fs.writeFileSync(
-          path.join(metricsDir, 'costs.jsonl'),
-          `${JSON.stringify(snapshotRow)}\n`,
-          'utf8'
-        );
-        assert.strictEqual(
-          publishAppendedSessionCostSnapshot(metricsDir, 'S1', snapshotRow),
-          true
-        );
+        appendSessionCostRow(metricsDir, 'S1', snapshotRow);
 
-        fs.readFileSync = function guardedRead(filePath, ...args) {
-          if (path.basename(String(filePath)) === 'costs.jsonl') {
-            throw new Error('historical JSONL scan should be bypassed on a snapshot hit');
-          }
-          return originalReadFileSync.call(this, filePath, ...args);
+        fs.readSync = function measuredRead(descriptor, buffer, offset, length, position) {
+          bytesReadFromCostLog += length;
+          return originalReadSync.call(this, descriptor, buffer, offset, length, position);
         };
 
         const result = readSessionCost('S1');
         assert.deepStrictEqual(result, { totalCost: 0.75, totalIn: 750, totalOut: 375 });
+        assert.ok(bytesReadFromCostLog <= 3 * 256);
       } finally {
-        fs.readFileSync = originalReadFileSync;
+        fs.readSync = originalReadSync;
         if (originalHome === undefined) delete process.env.HOME;
         else process.env.HOME = originalHome;
         if (originalUserProfile === undefined) delete process.env.USERPROFILE;
@@ -288,7 +280,7 @@ function runTests() {
   else failed++;
 
   if (
-    test('readSessionCost ignores a stale snapshot after costs.jsonl advances', () => {
+    test('readSessionCost keeps session A on the fast path after session B appends', () => {
       const tmpHome = makeTempHome();
       const originalHome = process.env.HOME;
       const originalUserProfile = process.env.USERPROFILE;
@@ -303,38 +295,24 @@ function runTests() {
           input_tokens: 100,
           output_tokens: 50
         };
-        const latest = {
-          session_id: 'S1',
+        appendSessionCostRow(metricsDir, 'S1', first);
+        appendSessionCostRow(metricsDir, 'S2', {
+          session_id: 'S2',
           estimated_cost_usd: 2,
           input_tokens: 200,
           output_tokens: 100
-        };
-        const costsPath = path.join(metricsDir, 'costs.jsonl');
-        fs.writeFileSync(costsPath, `${JSON.stringify(first)}\n`, 'utf8');
-        publishAppendedSessionCostSnapshot(metricsDir, 'S1', first);
-        fs.appendFileSync(costsPath, `${JSON.stringify(latest)}\n`, 'utf8');
-
-        assert.deepStrictEqual(readSessionCost('S1'), {
-          totalCost: 2,
-          totalIn: 200,
-          totalOut: 100
         });
-
-        const originalReadFileSync = fs.readFileSync;
-        fs.readFileSync = function guardedRead(filePath, ...args) {
-          if (path.basename(String(filePath)) === 'costs.jsonl') {
-            throw new Error('fallback should repair the session snapshot');
-          }
-          return originalReadFileSync.call(this, filePath, ...args);
+        const originalReadSync = fs.readSync;
+        let bytesReadFromCostLog = 0;
+        fs.readSync = function measuredRead(descriptor, buffer, offset, length, position) {
+          bytesReadFromCostLog += length;
+          return originalReadSync.call(this, descriptor, buffer, offset, length, position);
         };
         try {
-          assert.deepStrictEqual(readSessionCost('S1'), {
-            totalCost: 2,
-            totalIn: 200,
-            totalOut: 100
-          });
+          assert.deepStrictEqual(readSessionCost('S1'), { totalCost: 1, totalIn: 100, totalOut: 50 });
+          assert.ok(bytesReadFromCostLog <= 2 * 1024);
         } finally {
-          fs.readFileSync = originalReadFileSync;
+          fs.readSync = originalReadSync;
         }
       } finally {
         if (originalHome === undefined) delete process.env.HOME;
@@ -407,12 +385,12 @@ function runTests() {
         };
         const costsPath = path.join(metricsDir, 'costs.jsonl');
         fs.writeFileSync(costsPath, `${JSON.stringify(valid)}\n`, 'utf8');
-        const stat = fs.statSync(costsPath);
+        appendSessionCostRow(metricsDir, 'S1', valid);
+        const snapshot = JSON.parse(fs.readFileSync(getCostSnapshotPath(metricsDir, 'S1'), 'utf8'));
         fs.writeFileSync(
           getCostSnapshotPath(metricsDir, 'S1'),
           JSON.stringify({
-            schema_version: 'ecc.cost-snapshot.v1',
-            source: { size_bytes: stat.size, mtime_ms: stat.mtimeMs },
+            ...snapshot,
             row: { session_id: 'S1' }
           }),
           'utf8'

--- a/tests/lib/session-cost-snapshot.test.js
+++ b/tests/lib/session-cost-snapshot.test.js
@@ -63,9 +63,11 @@ try {
   })) passed++; else failed++;
 
   if (test('a delayed older writer cannot lower the latest cumulative total', () => {
-    const older = row('session-order', 1);
     const newer = row('session-order', 2);
-    older.timestamp = new Date(Date.parse(newer.timestamp) + 1000).toISOString();
+    const older = {
+      ...row('session-order', 1),
+      timestamp: new Date(Date.parse(newer.timestamp) + 1000).toISOString()
+    };
     assert.strictEqual(appendSessionCostRow(root, 'session-order', newer), true);
     assert.strictEqual(appendSessionCostRow(root, 'session-order', older), false);
     assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-order').row, newer);
@@ -73,9 +75,11 @@ try {
 
   if (test('publication failure followed by an older writer still converges to the newer row', () => {
     const sessionId = 'session-publication-race';
-    const older = row(sessionId, 1);
     const newer = row(sessionId, 2);
-    older.timestamp = new Date(Date.parse(newer.timestamp) + 1000).toISOString();
+    const older = {
+      ...row(sessionId, 1),
+      timestamp: new Date(Date.parse(newer.timestamp) + 1000).toISOString()
+    };
     const snapshotPath = getCostSnapshotPath(root, sessionId);
     const originalRenameSync = fs.renameSync;
     let injectedFailure = false;
@@ -99,22 +103,25 @@ try {
 
   if (test('accepts increasing cumulative totals that share a timestamp', () => {
     const first = row('session-same-time', 1);
-    const next = row('session-same-time', 2);
-    next.timestamp = first.timestamp;
+    const next = { ...row('session-same-time', 2), timestamp: first.timestamp };
     appendSessionCostRow(root, 'session-same-time', first);
     assert.strictEqual(appendSessionCostRow(root, 'session-same-time', next), true);
     assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-same-time').row, next);
   })) passed++; else failed++;
 
   if (test('uses timestamps when cumulative dimensions move in opposite directions', () => {
-    const newer = row('session-mixed', 1);
-    newer.input_tokens = 200;
-    newer.output_tokens = 100;
-    newer.timestamp = '2026-01-02T00:00:00.000Z';
-    const delayedOlder = row('session-mixed', 2);
-    delayedOlder.input_tokens = 100;
-    delayedOlder.output_tokens = 50;
-    delayedOlder.timestamp = '2026-01-01T00:00:00.000Z';
+    const newer = {
+      ...row('session-mixed', 1),
+      input_tokens: 200,
+      output_tokens: 100,
+      timestamp: '2026-01-02T00:00:00.000Z'
+    };
+    const delayedOlder = {
+      ...row('session-mixed', 2),
+      input_tokens: 100,
+      output_tokens: 50,
+      timestamp: '2026-01-01T00:00:00.000Z'
+    };
     appendSessionCostRow(root, 'session-mixed', newer);
     assert.strictEqual(appendSessionCostRow(root, 'session-mixed', delayedOlder), false);
     assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-mixed').row, newer);
@@ -187,6 +194,45 @@ try {
       'utf8'
     );
     assert.deepStrictEqual(refreshSessionCostSnapshot(caseRoot, 'utf8').row, current);
+  })) passed++; else failed++;
+
+  if (test('bounds oversized unterminated rows and caches the discarded prefix', () => {
+    const caseRoot = path.join(root, 'oversized-line');
+    fs.mkdirSync(caseRoot, { recursive: true });
+    const oversizedBytes = 32 * 1024 * 1024;
+    fs.writeFileSync(
+      path.join(caseRoot, 'costs.jsonl'),
+      Buffer.alloc(oversizedBytes, 0x78)
+    );
+    const originalConcat = Buffer.concat;
+    let copiedBytes = 0;
+    Buffer.concat = function measuredConcat(list, totalLength) {
+      copiedBytes += totalLength ?? list.reduce((sum, item) => sum + item.length, 0);
+      return originalConcat.call(this, list, totalLength);
+    };
+    try {
+      const first = refreshSessionCostSnapshot(caseRoot, 'oversized');
+      assert.strictEqual(first.row, null);
+      assert.strictEqual(first.malformed, 1);
+      assert.ok(first.scannedBytes > 0 && first.scannedBytes < oversizedBytes);
+      assert.ok(copiedBytes <= 2 * 1024 * 1024, `copied ${copiedBytes} bytes`);
+      const second = refreshSessionCostSnapshot(caseRoot, 'oversized');
+      assert.strictEqual(second.scannedBytes, oversizedBytes - first.scannedBytes);
+      assert.strictEqual(second.malformed, 0);
+      const stable = refreshSessionCostSnapshot(caseRoot, 'oversized');
+      assert.strictEqual(stable.scannedBytes, 0);
+      const recovered = row('oversized', 3);
+      fs.appendFileSync(
+        path.join(caseRoot, 'costs.jsonl'),
+        `\n${JSON.stringify(recovered)}\n`,
+        'utf8'
+      );
+      const resumed = refreshSessionCostSnapshot(caseRoot, 'oversized');
+      assert.deepStrictEqual(resumed.row, recovered);
+      assert.ok(resumed.scannedBytes < 1024);
+    } finally {
+      Buffer.concat = originalConcat;
+    }
   })) passed++; else failed++;
 
   if (test('rebuilds after an in-place rewrite or inode rotation', () => {
@@ -294,6 +340,85 @@ try {
       .filter(name => name.startsWith('session-'));
     assert.strictEqual(removed, 3);
     assert.strictEqual(remaining.length, 2);
+  })) passed++; else failed++;
+
+  if (test('surfaces retention removal failures for the caller to report', () => {
+    const caseRoot = path.join(root, 'retention-failure');
+    fs.mkdirSync(caseRoot, { recursive: true });
+    const sessionId = 'retention-target';
+    appendSessionCostRow(caseRoot, sessionId, row(sessionId, 1));
+    const snapshotPath = getCostSnapshotPath(caseRoot, sessionId);
+    const markerPath = path.join(caseRoot, 'cost-snapshots', '.last-prune');
+    fs.rmSync(markerPath, { force: true });
+    const old = new Date(Date.now() - 10_000);
+    fs.utimesSync(snapshotPath, old, old);
+    const originalRmSync = fs.rmSync;
+    fs.rmSync = function failSnapshotRemoval(filePath, options) {
+      if (path.resolve(filePath) === path.resolve(snapshotPath)) {
+        const error = new Error('injected retention failure');
+        error.code = 'EACCES';
+        throw error;
+      }
+      return originalRmSync.call(this, filePath, options);
+    };
+    try {
+      assert.throws(
+        () => maybePruneSessionCostSnapshots(caseRoot, {
+          force: true,
+          now: Date.now(),
+          maxAgeMs: 1
+        }),
+        /injected retention failure/
+      );
+      assert.strictEqual(
+        fs.existsSync(markerPath),
+        false,
+        'failed pruning must not defer the next retry'
+      );
+    } finally {
+      fs.rmSync = originalRmSync;
+    }
+  })) passed++; else failed++;
+
+  if (test('reports retention failures without rolling back the appended row', () => {
+    const caseRoot = path.join(root, 'retention-warning');
+    fs.mkdirSync(caseRoot, { recursive: true });
+    const snapshotDir = path.join(caseRoot, 'cost-snapshots');
+    const originalReaddirSync = fs.readdirSync;
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    let captured = '';
+    fs.readdirSync = function failRetentionRead(directory, options) {
+      if (path.resolve(directory) === path.resolve(snapshotDir)) {
+        const error = new Error('injected retention read failure');
+        error.code = 'EACCES';
+        throw error;
+      }
+      return originalReaddirSync.call(this, directory, options);
+    };
+    process.stderr.write = chunk => {
+      captured += String(chunk);
+      return true;
+    };
+    try {
+      const current = row('retention-warning-session', 1);
+      assert.strictEqual(appendSessionCostRow(
+        caseRoot,
+        'retention-warning-session',
+        current
+      ), true);
+      assert.strictEqual(appendSessionCostRow(
+        caseRoot,
+        'retention-warning-session',
+        row('retention-warning-session', 2)
+      ), true);
+      const warnings = captured.match(/retention failed/g) || [];
+      assert.strictEqual(warnings.length, 1);
+      const persisted = fs.readFileSync(path.join(caseRoot, 'costs.jsonl'), 'utf8');
+      assert.match(persisted, /retention-warning-session/);
+    } finally {
+      fs.readdirSync = originalReaddirSync;
+      process.stderr.write = originalWrite;
+    }
   })) passed++; else failed++;
 
   if (test('deduplicates snapshot warnings independently by failure kind', () => {

--- a/tests/lib/session-cost-snapshot.test.js
+++ b/tests/lib/session-cost-snapshot.test.js
@@ -8,6 +8,7 @@ const path = require('path');
 const {
   appendSessionCostRow,
   getCostSnapshotPath,
+  MAX_SCAN_BYTES,
   maybePruneSessionCostSnapshots,
   readSessionCostSnapshot,
   refreshSessionCostSnapshot,
@@ -199,7 +200,7 @@ try {
   if (test('bounds oversized unterminated rows and caches the discarded prefix', () => {
     const caseRoot = path.join(root, 'oversized-line');
     fs.mkdirSync(caseRoot, { recursive: true });
-    const oversizedBytes = 32 * 1024 * 1024;
+    const oversizedBytes = 2 * MAX_SCAN_BYTES;
     fs.writeFileSync(
       path.join(caseRoot, 'costs.jsonl'),
       Buffer.alloc(oversizedBytes, 0x78)

--- a/tests/lib/session-cost-snapshot.test.js
+++ b/tests/lib/session-cost-snapshot.test.js
@@ -46,7 +46,9 @@ try {
     assert.strictEqual(appendSessionCostRow(root, 'session-1', current), true);
     const filePath = getCostSnapshotPath(root, 'session-1');
     assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-1').row, current);
-    assert.strictEqual(fs.statSync(filePath).mode & 0o777, 0o600);
+    if (process.platform !== 'win32') {
+      assert.strictEqual(fs.statSync(filePath).mode & 0o777, 0o600);
+    }
     assert.deepStrictEqual(
       fs.readdirSync(path.dirname(filePath)).filter(name => name.endsWith('.tmp')),
       []

--- a/tests/lib/session-cost-snapshot.test.js
+++ b/tests/lib/session-cost-snapshot.test.js
@@ -1,15 +1,28 @@
 'use strict';
 
 const assert = require('assert');
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const {
-  COST_SNAPSHOT_SCHEMA_VERSION,
+  appendSessionCostRow,
   getCostSnapshotPath,
-  publishAppendedSessionCostSnapshot,
+  maybePruneSessionCostSnapshots,
   readSessionCostSnapshot,
+  refreshSessionCostSnapshot,
+  warnSessionCostSnapshotFailure
 } = require('../../scripts/lib/session-cost-snapshot');
+
+function row(sessionId, cost = 1) {
+  return {
+    timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, cost)).toISOString(),
+    session_id: sessionId,
+    estimated_cost_usd: cost,
+    input_tokens: cost * 100,
+    output_tokens: cost * 50
+  };
+}
 
 function test(name, fn) {
   try {
@@ -24,23 +37,16 @@ function test(name, fn) {
 }
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-cost-snapshot-'));
-const costLogPath = path.join(root, 'costs.jsonl');
 let passed = 0;
 let failed = 0;
 
 try {
-  if (test('round-trips a versioned cumulative row atomically', () => {
-    const row = {
-      session_id: 'session-1',
-      estimated_cost_usd: 1.25,
-      input_tokens: 10,
-      output_tokens: 20
-    };
-    fs.writeFileSync(costLogPath, `${JSON.stringify(row)}\n`, 'utf8');
-    assert.strictEqual(publishAppendedSessionCostSnapshot(root, 'session-1', row), true);
+  if (test('appends and atomically publishes a private cumulative snapshot', () => {
+    const current = row('session-1', 1.25);
+    assert.strictEqual(appendSessionCostRow(root, 'session-1', current), true);
     const filePath = getCostSnapshotPath(root, 'session-1');
-    assert.strictEqual(filePath, getCostSnapshotPath(root, 'session-1'));
-    assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-1'), row);
+    assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-1').row, current);
+    assert.strictEqual(fs.statSync(filePath).mode & 0o777, 0o600);
     assert.deepStrictEqual(
       fs.readdirSync(path.dirname(filePath)).filter(name => name.endsWith('.tmp')),
       []
@@ -48,87 +54,177 @@ try {
   })) passed++; else failed++;
 
   if (test('replaces the previous cumulative row for the same session', () => {
-    const first = {
-      session_id: 'session-update',
-      estimated_cost_usd: 1,
-      input_tokens: 100,
-      output_tokens: 50
-    };
-    fs.writeFileSync(costLogPath, `${JSON.stringify(first)}\n`, 'utf8');
-    assert.strictEqual(publishAppendedSessionCostSnapshot(root, 'session-update', first), true);
-    const latest = {
-      session_id: 'session-update',
-      estimated_cost_usd: 2,
-      input_tokens: 200,
-      output_tokens: 100
-    };
-    fs.appendFileSync(costLogPath, `${JSON.stringify(latest)}\n`, 'utf8');
-    assert.strictEqual(publishAppendedSessionCostSnapshot(root, 'session-update', latest), true);
-    assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-update'), latest);
+    appendSessionCostRow(root, 'session-update', row('session-update', 1));
+    const latest = row('session-update', 2);
+    appendSessionCostRow(root, 'session-update', latest);
+    assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-update').row, latest);
   })) passed++; else failed++;
 
-  if (test('invalidates a snapshot when the append-only cost log advances', () => {
-    const first = {
-      session_id: 'session-stale',
-      estimated_cost_usd: 1,
-      input_tokens: 100,
-      output_tokens: 50
+  if (test('a delayed older writer cannot lower the latest cumulative total', () => {
+    const older = row('session-order', 1);
+    const newer = row('session-order', 2);
+    older.timestamp = new Date(Date.parse(newer.timestamp) + 1000).toISOString();
+    assert.strictEqual(appendSessionCostRow(root, 'session-order', newer), true);
+    assert.strictEqual(appendSessionCostRow(root, 'session-order', older), false);
+    assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-order').row, newer);
+  })) passed++; else failed++;
+
+  if (test('publication failure followed by an older writer still converges to the newer row', () => {
+    const sessionId = 'session-publication-race';
+    const older = row(sessionId, 1);
+    const newer = row(sessionId, 2);
+    older.timestamp = new Date(Date.parse(newer.timestamp) + 1000).toISOString();
+    const snapshotPath = getCostSnapshotPath(root, sessionId);
+    const originalRenameSync = fs.renameSync;
+    let injectedFailure = false;
+    fs.renameSync = function failNewerSnapshot(sourcePath, destinationPath) {
+      if (!injectedFailure && path.resolve(destinationPath) === path.resolve(snapshotPath)) {
+        injectedFailure = true;
+        const error = new Error('injected snapshot publication failure');
+        error.code = 'EIO';
+        throw error;
+      }
+      return originalRenameSync.call(this, sourcePath, destinationPath);
     };
-    fs.writeFileSync(costLogPath, `${JSON.stringify(first)}\n`, 'utf8');
-    assert.strictEqual(publishAppendedSessionCostSnapshot(root, 'session-stale', first), true);
-    fs.appendFileSync(
-      costLogPath,
-      `${JSON.stringify({ session_id: 'session-stale', estimated_cost_usd: 2, input_tokens: 200, output_tokens: 100 })}\n`,
+    try {
+      assert.throws(() => appendSessionCostRow(root, sessionId, newer), /injected/);
+    } finally {
+      fs.renameSync = originalRenameSync;
+    }
+    assert.strictEqual(appendSessionCostRow(root, sessionId, older), false);
+    assert.deepStrictEqual(readSessionCostSnapshot(root, sessionId).row, newer);
+  })) passed++; else failed++;
+
+  if (test('accepts increasing cumulative totals that share a timestamp', () => {
+    const first = row('session-same-time', 1);
+    const next = row('session-same-time', 2);
+    next.timestamp = first.timestamp;
+    appendSessionCostRow(root, 'session-same-time', first);
+    assert.strictEqual(appendSessionCostRow(root, 'session-same-time', next), true);
+    assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-same-time').row, next);
+  })) passed++; else failed++;
+
+  if (test('uses timestamps when cumulative dimensions move in opposite directions', () => {
+    const newer = row('session-mixed', 1);
+    newer.input_tokens = 200;
+    newer.output_tokens = 100;
+    newer.timestamp = '2026-01-02T00:00:00.000Z';
+    const delayedOlder = row('session-mixed', 2);
+    delayedOlder.input_tokens = 100;
+    delayedOlder.output_tokens = 50;
+    delayedOlder.timestamp = '2026-01-01T00:00:00.000Z';
+    appendSessionCostRow(root, 'session-mixed', newer);
+    assert.strictEqual(appendSessionCostRow(root, 'session-mixed', delayedOlder), false);
+    assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-mixed').row, newer);
+  })) passed++; else failed++;
+
+  if (test('session B only creates a bounded delta scan for session A', () => {
+    const sessionA = row('session-a', 3);
+    appendSessionCostRow(root, 'session-a', sessionA);
+    const sessionB = row('session-b', 4);
+    appendSessionCostRow(root, 'session-b', sessionB);
+    const refreshed = refreshSessionCostSnapshot(root, 'session-a');
+    assert.deepStrictEqual(refreshed.row, sessionA);
+    assert.ok(refreshed.scannedBytes > 0);
+    assert.ok(refreshed.scannedBytes <= Buffer.byteLength(`${JSON.stringify(sessionB)}\n`));
+    assert.strictEqual(refreshSessionCostSnapshot(root, 'session-a').scannedBytes, 0);
+  })) passed++; else failed++;
+
+  if (test('sessions with no row cache their progress cursor', () => {
+    const caseRoot = path.join(root, 'missing-session');
+    fs.mkdirSync(caseRoot, { recursive: true });
+    const costsPath = path.join(caseRoot, 'costs.jsonl');
+    const other = row('other-only', 1);
+    fs.writeFileSync(costsPath, `${JSON.stringify(other)}\n`.repeat(4000), 'utf8');
+    const first = refreshSessionCostSnapshot(caseRoot, 'missing');
+    const second = refreshSessionCostSnapshot(caseRoot, 'missing');
+    assert.ok(first.scannedBytes > 100000);
+    assert.strictEqual(first.row, null);
+    assert.strictEqual(second.scannedBytes, 0);
+    assert.strictEqual(second.row, null);
+  })) passed++; else failed++;
+
+  if (test('does not advance the cursor past an incomplete trailing row', () => {
+    const caseRoot = path.join(root, 'partial-row');
+    fs.mkdirSync(caseRoot, { recursive: true });
+    const current = row('partial', 6);
+    const serialized = JSON.stringify(current);
+    fs.writeFileSync(path.join(caseRoot, 'costs.jsonl'), serialized, 'utf8');
+    const partial = refreshSessionCostSnapshot(caseRoot, 'partial');
+    assert.deepStrictEqual(partial.row, current);
+    assert.strictEqual(partial.scannedBytes, 0);
+    assert.strictEqual(partial.malformed, 0);
+    fs.appendFileSync(path.join(caseRoot, 'costs.jsonl'), '\n', 'utf8');
+    const complete = refreshSessionCostSnapshot(caseRoot, 'partial');
+    assert.deepStrictEqual(complete.row, current);
+    assert.strictEqual(complete.scannedBytes, Buffer.byteLength(`${serialized}\n`));
+  })) passed++; else failed++;
+
+  if (test('never persists a provisional unterminated row when later bytes corrupt it', () => {
+    const caseRoot = path.join(root, 'partial-corruption');
+    fs.mkdirSync(caseRoot, { recursive: true });
+    const costsPath = path.join(caseRoot, 'costs.jsonl');
+    const provisional = row('partial-corruption', 7);
+    fs.writeFileSync(costsPath, JSON.stringify(provisional), 'utf8');
+    const first = refreshSessionCostSnapshot(caseRoot, 'partial-corruption');
+    assert.deepStrictEqual(first.row, provisional);
+    assert.strictEqual(first.scannedBytes, 0);
+
+    const recovered = row('partial-corruption', 8);
+    appendSessionCostRow(caseRoot, 'partial-corruption', recovered);
+    assert.deepStrictEqual(refreshSessionCostSnapshot(caseRoot, 'partial-corruption').row, recovered);
+  })) passed++; else failed++;
+
+  if (test('keeps UTF-8 rows intact across the 64 KiB read boundary', () => {
+    const caseRoot = path.join(root, 'utf8-boundary');
+    fs.mkdirSync(caseRoot, { recursive: true });
+    const current = { ...row('utf8', 7), note: `${'x'.repeat(65520)}数据` };
+    fs.writeFileSync(
+      path.join(caseRoot, 'costs.jsonl'),
+      `${JSON.stringify(current)}\n`,
       'utf8'
     );
-    assert.strictEqual(readSessionCostSnapshot(root, 'session-stale'), null);
+    assert.deepStrictEqual(refreshSessionCostSnapshot(caseRoot, 'utf8').row, current);
   })) passed++; else failed++;
 
-  if (test('a delayed older writer cannot overwrite the newest session row', () => {
-    const older = { session_id: 'session-race', estimated_cost_usd: 1, input_tokens: 100, output_tokens: 50 };
-    const newer = { session_id: 'session-race', estimated_cost_usd: 2, input_tokens: 200, output_tokens: 100 };
-    fs.writeFileSync(costLogPath, `${JSON.stringify(older)}\n`, 'utf8');
-    fs.appendFileSync(costLogPath, `${JSON.stringify(newer)}\n`, 'utf8');
-    assert.strictEqual(publishAppendedSessionCostSnapshot(root, 'session-race', newer), true);
-    assert.strictEqual(publishAppendedSessionCostSnapshot(root, 'session-race', older), false);
-    assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-race'), newer);
+  if (test('rebuilds after an in-place rewrite or inode rotation', () => {
+    const caseRoot = path.join(root, 'rotation');
+    fs.mkdirSync(caseRoot, { recursive: true });
+    const costsPath = path.join(caseRoot, 'costs.jsonl');
+    const first = row('rotated', 1);
+    const rewritten = row('rotated', 9);
+    appendSessionCostRow(caseRoot, 'rotated', first);
+    fs.writeFileSync(costsPath, `${JSON.stringify(rewritten)}\n`, 'utf8');
+    assert.deepStrictEqual(refreshSessionCostSnapshot(caseRoot, 'rotated').row, rewritten);
+
+    const rotated = row('rotated', 10);
+    fs.renameSync(costsPath, `${costsPath}.old`);
+    fs.writeFileSync(costsPath, `${JSON.stringify(rotated)}\n`, 'utf8');
+    assert.deepStrictEqual(refreshSessionCostSnapshot(caseRoot, 'rotated').row, rotated);
   })) passed++; else failed++;
 
-  if (test('rejects unsafe session IDs instead of escaping the snapshot directory', () => {
-    const unsafeId = '../outside';
-    const row = { session_id: unsafeId, estimated_cost_usd: 9, input_tokens: 9, output_tokens: 9 };
-    fs.writeFileSync(costLogPath, `${JSON.stringify(row)}\n`, 'utf8');
+  if (test('detects same-size in-place changes outside the tail window', () => {
+    const caseRoot = path.join(root, 'same-size-rewrite');
+    fs.mkdirSync(caseRoot, { recursive: true });
+    const costsPath = path.join(caseRoot, 'costs.jsonl');
+    const first = row('same-size', 1);
+    const rewritten = { ...first, estimated_cost_usd: 9 };
+    const filler = `${JSON.stringify(row('filler', 2))}\n`.repeat(20);
+    fs.writeFileSync(costsPath, `${JSON.stringify(first)}\n${filler}`, 'utf8');
+    refreshSessionCostSnapshot(caseRoot, 'same-size');
+    fs.writeFileSync(costsPath, `${JSON.stringify(rewritten)}\n${filler}`, 'utf8');
+    const rebuilt = refreshSessionCostSnapshot(caseRoot, 'same-size');
+    assert.ok(rebuilt.scannedBytes > 0);
+    assert.deepStrictEqual(rebuilt.row, rewritten);
+  })) passed++; else failed++;
+
+  if (test('rejects unsafe session IDs and prefixes Windows device names', () => {
     assert.throws(
-      () => publishAppendedSessionCostSnapshot(root, unsafeId, row),
+      () => appendSessionCostRow(root, '../outside', row('../outside', 9)),
       /safe session ID/
     );
-
-    const escapedPath = path.join(root, 'outside.json');
-    fs.writeFileSync(
-      escapedPath,
-      JSON.stringify({ schema_version: COST_SNAPSHOT_SCHEMA_VERSION, row }),
-      'utf8'
-    );
-    assert.strictEqual(readSessionCostSnapshot(root, unsafeId), null);
-  })) passed++; else failed++;
-
-  if (test('prefixes Windows reserved device names with a safe basename', () => {
     assert.strictEqual(path.basename(getCostSnapshotPath(root, 'CON')), 'session-CON.json');
     assert.strictEqual(path.basename(getCostSnapshotPath(root, 'nul')), 'session-nul.json');
-  })) passed++; else failed++;
-
-  if (test('rejects a snapshot whose row is bound to another session', () => {
-    const filePath = getCostSnapshotPath(root, 'session-2');
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(
-      filePath,
-      JSON.stringify({
-        schema_version: COST_SNAPSHOT_SCHEMA_VERSION,
-        row: { session_id: 'session-3', estimated_cost_usd: 3 }
-      }),
-      'utf8'
-    );
-    assert.strictEqual(readSessionCostSnapshot(root, 'session-2'), null);
   })) passed++; else failed++;
 
   if (test('rejects rows with missing, non-numeric, or negative totals', () => {
@@ -138,33 +234,142 @@ try {
       { session_id: 'invalid-row', estimated_cost_usd: 1, input_tokens: -1, output_tokens: 1 },
       { session_id: 'invalid-row', estimated_cost_usd: 1, input_tokens: 1, output_tokens: Infinity }
     ];
-    for (const row of invalidRows) {
-      fs.writeFileSync(costLogPath, `${JSON.stringify(row)}\n`, 'utf8');
+    for (const invalidRow of invalidRows) {
       assert.throws(
-        () => publishAppendedSessionCostSnapshot(root, 'invalid-row', row),
+        () => appendSessionCostRow(root, 'invalid-row', invalidRow),
         /valid non-negative numeric totals/
       );
     }
   })) passed++; else failed++;
 
-  if (test('rejects unknown schemas and malformed JSON', () => {
-    const filePath = getCostSnapshotPath(root, 'session-4');
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(
-      filePath,
-      JSON.stringify({
-        schema_version: 'ecc.cost-snapshot.v999',
-        row: { session_id: 'session-4' }
-      }),
-      'utf8'
-    );
-    assert.strictEqual(readSessionCostSnapshot(root, 'session-4'), null);
-    fs.writeFileSync(filePath, '{broken', 'utf8');
-    assert.strictEqual(readSessionCostSnapshot(root, 'session-4'), null);
+  if (test('malformed snapshots rebuild from the authoritative JSONL', () => {
+    const sessionId = 'session-invalid';
+    const current = row(sessionId, 5);
+    appendSessionCostRow(root, sessionId, current);
+    fs.writeFileSync(getCostSnapshotPath(root, sessionId), '{broken', 'utf8');
+    const rebuilt = refreshSessionCostSnapshot(root, sessionId);
+    assert.deepStrictEqual(rebuilt.row, current);
+    assert.deepStrictEqual(readSessionCostSnapshot(root, sessionId).row, current);
+  })) passed++; else failed++;
+
+  if (test('prunes expired snapshots and enforces the count bound', () => {
+    const now = Date.now();
+    for (let index = 0; index < 4; index += 1) {
+      const sessionId = `prune-${index}`;
+      appendSessionCostRow(root, sessionId, row(sessionId, index + 1));
+      const old = new Date(now - ((index + 1) * 1000));
+      fs.utimesSync(getCostSnapshotPath(root, sessionId), old, old);
+    }
+    const removed = maybePruneSessionCostSnapshots(root, {
+      force: true,
+      now,
+      maxAgeMs: 2500,
+      maxSnapshots: 2
+    });
+    const remaining = fs.readdirSync(path.join(root, 'cost-snapshots'))
+      .filter(name => name.startsWith('session-'));
+    assert.ok(removed >= 2);
+    assert.ok(remaining.length <= 2);
+  })) passed++; else failed++;
+
+  if (test('enforces the count bound while the age-prune marker is fresh', () => {
+    const caseRoot = path.join(root, 'count-bound');
+    fs.mkdirSync(caseRoot, { recursive: true });
+    const now = Date.now();
+    assert.strictEqual(maybePruneSessionCostSnapshots(caseRoot, {
+      force: true,
+      now,
+      maxSnapshots: 2
+    }), 0);
+    for (let index = 0; index < 5; index += 1) {
+      appendSessionCostRow(caseRoot, `count-${index}`, row(`count-${index}`, index + 1));
+    }
+    const removed = maybePruneSessionCostSnapshots(caseRoot, {
+      now: now + 1000,
+      maxSnapshots: 2
+    });
+    const remaining = fs.readdirSync(path.join(caseRoot, 'cost-snapshots'))
+      .filter(name => name.startsWith('session-'));
+    assert.strictEqual(removed, 3);
+    assert.strictEqual(remaining.length, 2);
+  })) passed++; else failed++;
+
+  if (test('deduplicates snapshot warnings independently by failure kind', () => {
+    const caseRoot = path.join(root, 'warning-dedupe');
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    let captured = '';
+    process.stderr.write = chunk => {
+      captured += String(chunk);
+      return true;
+    };
+    try {
+      const error = Object.assign(new Error('persistent failure'), { code: 'EIO' });
+      warnSessionCostSnapshotFailure('publication', caseRoot, 'warn-session', error);
+      warnSessionCostSnapshotFailure('repair', caseRoot, 'warn-session', error);
+      warnSessionCostSnapshotFailure('publication', caseRoot, 'warn-session', error);
+      warnSessionCostSnapshotFailure('repair', caseRoot, 'warn-session', error);
+      const warnings = captured.trim().split('\n');
+      assert.strictEqual(warnings.length, 2);
+      assert.match(warnings[0], /publication failed/);
+      assert.match(warnings[1], /repair failed/);
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+  })) passed++; else failed++;
+
+  if (test('deduplicates the same snapshot warning across concurrent processes', () => {
+    const caseRoot = path.join(root, 'warning-concurrency');
+    fs.mkdirSync(caseRoot, { recursive: true });
+    const modulePath = path.resolve(__dirname, '../../scripts/lib/session-cost-snapshot.js');
+    const workerScript = [
+      "const fs = require('fs');",
+      "const path = require('path');",
+      "const [modulePath, metricsDir, gatePath, index] = process.argv.slice(1);",
+      "fs.writeFileSync(path.join(metricsDir, `ready-${index}`), '');",
+      "const timer = setInterval(() => {",
+      "  if (!fs.existsSync(gatePath)) return;",
+      "  clearInterval(timer);",
+      "  const { warnSessionCostSnapshotFailure } = require(modulePath);",
+      "  const error = Object.assign(new Error('persistent failure'), { code: 'EIO' });",
+      "  warnSessionCostSnapshotFailure('publication', metricsDir, 'shared-session', error);",
+      "}, 1);"
+    ].join('\n');
+    const orchestratorScript = [
+      "const { spawn } = require('child_process');",
+      "const fs = require('fs');",
+      "const path = require('path');",
+      "const [modulePath, metricsDir] = process.argv.slice(1);",
+      "const gatePath = path.join(metricsDir, 'go');",
+      `const workerScript = ${JSON.stringify(workerScript)};`,
+      "const runs = Array.from({ length: 16 }, (_, index) => new Promise((resolve, reject) => {",
+      "  const child = spawn(process.execPath, ['-e', workerScript, modulePath, metricsDir, gatePath, String(index)], { stdio: ['ignore', 'ignore', 'pipe'] });",
+      "  let stderr = '';",
+      "  child.stderr.on('data', chunk => { stderr += chunk; });",
+      "  child.on('error', reject);",
+      "  child.on('close', code => resolve({ code, stderr }));",
+      "}));",
+      "const readyTimer = setInterval(() => {",
+      "  const ready = fs.readdirSync(metricsDir).filter(name => name.startsWith('ready-'));",
+      "  if (ready.length !== runs.length) return;",
+      "  clearInterval(readyTimer);",
+      "  fs.writeFileSync(gatePath, 'go');",
+      "}, 1);",
+      "Promise.all(runs).then(results => {",
+      "  const warnings = results.flatMap(result => result.stderr.split('\\n')).filter(line => line.includes('publication failed'));",
+      "  process.stdout.write(JSON.stringify({ codes: results.map(result => result.code), warnings: warnings.length }));",
+      "});"
+    ].join('\n');
+    const result = JSON.parse(execFileSync(
+      process.execPath,
+      ['-e', orchestratorScript, modulePath, caseRoot],
+      { encoding: 'utf8', timeout: 10000 }
+    ));
+    assert.deepStrictEqual(result.codes, Array(16).fill(0));
+    assert.strictEqual(result.warnings, 1);
   })) passed++; else failed++;
 } finally {
   fs.rmSync(root, { recursive: true, force: true });
 }
 
-console.log(`\nResults: ${passed} passed, ${failed} failed`);
+console.log(`\nResults: Passed: ${passed}, Failed: ${failed}`);
 process.exit(failed > 0 ? 1 : 0);

--- a/tests/lib/session-cost-snapshot.test.js
+++ b/tests/lib/session-cost-snapshot.test.js
@@ -1,0 +1,170 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  COST_SNAPSHOT_SCHEMA_VERSION,
+  getCostSnapshotPath,
+  publishAppendedSessionCostSnapshot,
+  readSessionCostSnapshot,
+} = require('../../scripts/lib/session-cost-snapshot');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    return true;
+  } catch (error) {
+    console.log(`  FAIL  ${name}`);
+    console.log(`        ${error.message}`);
+    return false;
+  }
+}
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ecc-cost-snapshot-'));
+const costLogPath = path.join(root, 'costs.jsonl');
+let passed = 0;
+let failed = 0;
+
+try {
+  if (test('round-trips a versioned cumulative row atomically', () => {
+    const row = {
+      session_id: 'session-1',
+      estimated_cost_usd: 1.25,
+      input_tokens: 10,
+      output_tokens: 20
+    };
+    fs.writeFileSync(costLogPath, `${JSON.stringify(row)}\n`, 'utf8');
+    assert.strictEqual(publishAppendedSessionCostSnapshot(root, 'session-1', row), true);
+    const filePath = getCostSnapshotPath(root, 'session-1');
+    assert.strictEqual(filePath, getCostSnapshotPath(root, 'session-1'));
+    assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-1'), row);
+    assert.deepStrictEqual(
+      fs.readdirSync(path.dirname(filePath)).filter(name => name.endsWith('.tmp')),
+      []
+    );
+  })) passed++; else failed++;
+
+  if (test('replaces the previous cumulative row for the same session', () => {
+    const first = {
+      session_id: 'session-update',
+      estimated_cost_usd: 1,
+      input_tokens: 100,
+      output_tokens: 50
+    };
+    fs.writeFileSync(costLogPath, `${JSON.stringify(first)}\n`, 'utf8');
+    assert.strictEqual(publishAppendedSessionCostSnapshot(root, 'session-update', first), true);
+    const latest = {
+      session_id: 'session-update',
+      estimated_cost_usd: 2,
+      input_tokens: 200,
+      output_tokens: 100
+    };
+    fs.appendFileSync(costLogPath, `${JSON.stringify(latest)}\n`, 'utf8');
+    assert.strictEqual(publishAppendedSessionCostSnapshot(root, 'session-update', latest), true);
+    assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-update'), latest);
+  })) passed++; else failed++;
+
+  if (test('invalidates a snapshot when the append-only cost log advances', () => {
+    const first = {
+      session_id: 'session-stale',
+      estimated_cost_usd: 1,
+      input_tokens: 100,
+      output_tokens: 50
+    };
+    fs.writeFileSync(costLogPath, `${JSON.stringify(first)}\n`, 'utf8');
+    assert.strictEqual(publishAppendedSessionCostSnapshot(root, 'session-stale', first), true);
+    fs.appendFileSync(
+      costLogPath,
+      `${JSON.stringify({ session_id: 'session-stale', estimated_cost_usd: 2, input_tokens: 200, output_tokens: 100 })}\n`,
+      'utf8'
+    );
+    assert.strictEqual(readSessionCostSnapshot(root, 'session-stale'), null);
+  })) passed++; else failed++;
+
+  if (test('a delayed older writer cannot overwrite the newest session row', () => {
+    const older = { session_id: 'session-race', estimated_cost_usd: 1, input_tokens: 100, output_tokens: 50 };
+    const newer = { session_id: 'session-race', estimated_cost_usd: 2, input_tokens: 200, output_tokens: 100 };
+    fs.writeFileSync(costLogPath, `${JSON.stringify(older)}\n`, 'utf8');
+    fs.appendFileSync(costLogPath, `${JSON.stringify(newer)}\n`, 'utf8');
+    assert.strictEqual(publishAppendedSessionCostSnapshot(root, 'session-race', newer), true);
+    assert.strictEqual(publishAppendedSessionCostSnapshot(root, 'session-race', older), false);
+    assert.deepStrictEqual(readSessionCostSnapshot(root, 'session-race'), newer);
+  })) passed++; else failed++;
+
+  if (test('rejects unsafe session IDs instead of escaping the snapshot directory', () => {
+    const unsafeId = '../outside';
+    const row = { session_id: unsafeId, estimated_cost_usd: 9, input_tokens: 9, output_tokens: 9 };
+    fs.writeFileSync(costLogPath, `${JSON.stringify(row)}\n`, 'utf8');
+    assert.throws(
+      () => publishAppendedSessionCostSnapshot(root, unsafeId, row),
+      /safe session ID/
+    );
+
+    const escapedPath = path.join(root, 'outside.json');
+    fs.writeFileSync(
+      escapedPath,
+      JSON.stringify({ schema_version: COST_SNAPSHOT_SCHEMA_VERSION, row }),
+      'utf8'
+    );
+    assert.strictEqual(readSessionCostSnapshot(root, unsafeId), null);
+  })) passed++; else failed++;
+
+  if (test('prefixes Windows reserved device names with a safe basename', () => {
+    assert.strictEqual(path.basename(getCostSnapshotPath(root, 'CON')), 'session-CON.json');
+    assert.strictEqual(path.basename(getCostSnapshotPath(root, 'nul')), 'session-nul.json');
+  })) passed++; else failed++;
+
+  if (test('rejects a snapshot whose row is bound to another session', () => {
+    const filePath = getCostSnapshotPath(root, 'session-2');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        schema_version: COST_SNAPSHOT_SCHEMA_VERSION,
+        row: { session_id: 'session-3', estimated_cost_usd: 3 }
+      }),
+      'utf8'
+    );
+    assert.strictEqual(readSessionCostSnapshot(root, 'session-2'), null);
+  })) passed++; else failed++;
+
+  if (test('rejects rows with missing, non-numeric, or negative totals', () => {
+    const invalidRows = [
+      { session_id: 'invalid-row', input_tokens: 1, output_tokens: 1 },
+      { session_id: 'invalid-row', estimated_cost_usd: '1', input_tokens: 1, output_tokens: 1 },
+      { session_id: 'invalid-row', estimated_cost_usd: 1, input_tokens: -1, output_tokens: 1 },
+      { session_id: 'invalid-row', estimated_cost_usd: 1, input_tokens: 1, output_tokens: Infinity }
+    ];
+    for (const row of invalidRows) {
+      fs.writeFileSync(costLogPath, `${JSON.stringify(row)}\n`, 'utf8');
+      assert.throws(
+        () => publishAppendedSessionCostSnapshot(root, 'invalid-row', row),
+        /valid non-negative numeric totals/
+      );
+    }
+  })) passed++; else failed++;
+
+  if (test('rejects unknown schemas and malformed JSON', () => {
+    const filePath = getCostSnapshotPath(root, 'session-4');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        schema_version: 'ecc.cost-snapshot.v999',
+        row: { session_id: 'session-4' }
+      }),
+      'utf8'
+    );
+    assert.strictEqual(readSessionCostSnapshot(root, 'session-4'), null);
+    fs.writeFileSync(filePath, '{broken', 'utf8');
+    assert.strictEqual(readSessionCostSnapshot(root, 'session-4'), null);
+  })) passed++; else failed++;
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## What changed

- store a versioned, private per-session cursor snapshot after each Stop hook cost update
- let the PostToolUse metrics bridge read a stable snapshot in O(1), or scan only bytes appended since that session's cursor in O(delta)
- stream JSONL in 64 KiB chunks without splitting UTF-8 rows, and never persist an unterminated provisional row
- cap a single JSONL row at 1 MiB and each hook invocation at 16 MiB, persisting discard/catch-up cursors so malformed input cannot cause repeated unbounded work
- bind cursors to the source file identity, committed byte offset, mtime, and three SHA-256 prefix windows so truncation, rotation, and in-place rewrites rebuild safely
- validate session binding and finite, non-negative cumulative totals before accepting JSONL or snapshot rows
- prevent delayed writers from lowering cumulative totals, including mixed-dimension updates resolved by timestamp
- report snapshot publication and repair failures once per signature across concurrent hook processes while keeping the hook fail-open
- prune rebuildable snapshots after 30 days and cap the cache at 512 entries
- prefix snapshot filenames for Windows reserved-name safety

## Why

The metrics bridge currently reads and parses all of `costs.jsonl` after every tool call. Since the log is append-only, long-running installations pay O(total history) on every PostToolUse event and trend toward quadratic cumulative work.

Per-session byte-offset cursors make unchanged reads O(1) and interleaved-session updates O(new bytes), without weakening the append-only audit log or the prior correctness fix for sessions outside a fixed tail window.

Addresses the Node hook metrics-ingestion optimization in #3018. The broader issue remains open for its independent ECC2, SQLite, Git polling, and transcript optimizations.

## Performance

On a 40.5 MB `costs.jsonl` fixture with 300,001 rows:

- bounded initial catch-up: 308.484 ms across 3 invocations
- 1,000 stable snapshot reads: 99.548 ms total
- stable snapshot average: 0.0995 ms/read
- observed catch-up-to-steady-state speedup: about 3,099x
- after another session appended, the original session scanned only the 128-byte delta

The full scan, stable snapshot, and bounded-delta paths returned the same cumulative row.

## Verification

- session cost snapshot: 23/23
- cost tracker: 20/20
- metrics bridge: 28/28
- snapshot helper coverage: 94.58% lines/statements, 85.8% branches, 100% functions
- PostToolUse dispatcher: 14/14
- Stop stdout contract: 29/29
- hooks integration: 253/253
- install lifecycle: 66/66
- Pi adapter: 28/28
- npm publish surface: 2/2
- skill validator: 810 directories
- full ESLint + markdownlint: pass
- supply-chain IOC scan: 213 files, 0 findings
- real temporary Claude install: helper, settings, and install-state present
- npm tarball: helper, writer, reader, and cost-tracking skill present
- independent code review and security review: no remaining P0/P1/P2 findings

The concurrent warning regression launches 16 Node processes against the same failure signature and verifies exactly one diagnostic is emitted.
The oversized-line regression exercises a 32 MiB unterminated row, bounded two-step catch-up, a zero-byte stable read, and recovery after a newline plus a valid row.

Note: the broad `install-apply` suite completed 32 cases and hit its existing per-child 10-second timeout in 10 cross-target cases. The focused install lifecycle suite, real Claude install, and package surface checks above all passed.

## Type of change

- [x] `perf`: performance improvement
- [x] `test`: regression and concurrency coverage
- [x] `docs`: runtime cache contract

## Security and compatibility

- `costs.jsonl` remains authoritative and append-only
- snapshot files are atomically replaced with mode `0600`
- warning claims use atomic `wx` creation with mode `0600`
- unsafe session IDs are rejected rather than rewritten
- stale, malformed, semantically invalid, truncated, rotated, or concurrently outdated snapshots rebuild safely
- no dependencies, public API contracts, or hook registrations changed
