### PR TITLE
fix(gateguard): sanitize dangerous invisible unicode in denial paths

### DIFF
--- a/scripts/hooks/gateguard-fact-force.js
+++ b/scripts/hooks/gateguard-fact-force.js
@@ -1008,13 +1008,30 @@ function isChecked(key) {
 // --- Sanitize file path against injection ---
 
 function sanitizePath(filePath) {
-  // Strip control chars (including null), bidi overrides, and newlines
+  // Strip control chars (including null), bidi overrides, newlines,
+  // and the dangerous invisible characters defined by the repo-wide
+  // unicode safety policy (scripts/ci/check-unicode-safety.js):
+  // zero-width/format/variation-selector/tag blocks are all rendered
+  // or reviewed invisibly, so a denial message must not carry them.
   let sanitized = '';
   for (const char of String(filePath || '')) {
     const code = char.codePointAt(0);
     const isAsciiControl = code <= 0x1f || code === 0x7f;
     const isBidiOverride = (code >= 0x200e && code <= 0x200f) || (code >= 0x202a && code <= 0x202e) || (code >= 0x2066 && code <= 0x2069);
-    sanitized += isAsciiControl || isBidiOverride ? ' ' : char;
+    const isUnicodeSeparator = code === 0x2028 || code === 0x2029;
+    const isDangerousInvisible =
+      (code >= 0x200b && code <= 0x200d) ||
+      code === 0x2060 ||
+      code === 0xfeff ||
+      (code >= 0xfe00 && code <= 0xfe0f) ||
+      (code >= 0xe0100 && code <= 0xe01ef) ||
+      (code >= 0xe0000 && code <= 0xe007f) ||
+      code === 0x180e ||
+      code === 0x115f ||
+      code === 0x1160 ||
+      (code >= 0x2061 && code <= 0x2064) ||
+      code === 0x3164;
+    sanitized += isAsciiControl || isBidiOverride || isUnicodeSeparator || isDangerousInvisible ? ' ' : char;
   }
   return sanitized.trim().slice(0, 500);
 }

--- a/tests/hooks/gateguard-fact-force.test.js
+++ b/tests/hooks/gateguard-fact-force.test.js
@@ -3113,6 +3113,34 @@ function runTests() {
     console.error(`  [cleanup] failed to remove ${stateDir}: ${err.message}`);
   }
 
+  // --- sanitizePath dangerous invisible unicode regression ---
+  clearState();
+  if (
+    test('sanitizePath strips CI-defined dangerous invisible unicode from denial paths', () => {
+      const file_path =
+        '/src/eu2028\u2028app.js\u200bhidden\u2060name\ufefftail\u3164x.js';
+      const input = {
+        tool_name: 'Edit',
+        tool_input: { file_path, old_string: 'foo', new_string: 'bar' }
+      };
+      const result = runHook(input);
+      const output = parseOutput(result.stdout);
+      const reason = String(
+        output && output.hookSpecificOutput
+          ? output.hookSpecificOutput.permissionDecisionReason
+          : ''
+      );
+      for (const bad of ['\u2028', '\u2029', '\u200b', '\u2060', '\ufeff', '\u3164']) {
+        assert.ok(!reason.includes(bad), `denial reason must not carry U+${bad.codePointAt(0).toString(16)} (${bad})`);
+      }
+      assert.ok(reason.includes('app.js'), 'visible path text must remain');
+    })
+  ) {
+    passed++;
+  } else {
+    failed++;
+  }
+
   console.log(`\n  ${passed} passed, ${failed} failed\n`);
   process.exit(failed > 0 ? 1 : 0);
 }


### PR DESCRIPTION
## What changed
- `sanitizePath` now strips the dangerous-invisible codepoints defined by the repo-wide unicode safety policy (`scripts/ci/check-unicode-safety.js`): zero-width `U+200B-200D`, `U+2060`, invisible math operators `U+2061-2064`, variation selectors `U+FE00-FE0F`, tag block `U+E0000-E007F` (ASCII-smuggling vector), Hangul fillers `U+115F/1160/3164`, `U+180E`, `U+FEFF`, plus the `U+2028`/`U+2029` line and paragraph separators
- Previously only control chars and bidi overrides were replaced, so these 394 codepoints passed verbatim into Edit/Write denial messages — a path containing invisible characters could look clean to a human reviewer while carrying different content
- Visible path text is preserved (each dangerous char is replaced by a space, exactly like the existing control-char handling)

## Tests
- new hook-output regression test: a file_path seeded with `U+2028 / U+200B / U+2060 / U+FEFF / U+3164` produces a denial reason that contains none of them while the visible `app.js` text remains
- full hook suite: `node tests/hooks/gateguard-fact-force.test.js` → 197 passed, 0 failed
- `node scripts/ci/check-unicode-safety.js` passes on the hook file