### PR TITLE
fix(skills): avoid a literal $1 placeholder in the security-review sql example

### DIFF
--- a/skills/security-review/SKILL.md
+++ b/skills/security-review/SKILL.md
@@ -124,12 +124,19 @@ const { data } = await supabase
   .select('*')
   .eq('email', userEmail)
 
-// Or with raw SQL
+// Or with raw SQL -- the value goes in the params array, never in the
+// string. Use your driver's placeholder syntax (Postgres numbers its
+// placeholders, MySQL uses "?").
 await db.query(
-  'SELECT * FROM users WHERE email = $1',
+  'SELECT * FROM users WHERE email = ?',
   [userEmail]
 )
 ```
+
+<!-- Do not write a literal dollar-sign-N placeholder anywhere in this file.
+     Invoking this skill with arguments substitutes it away, and the example
+     above then renders as concatenated SQL -- the exact anti-pattern this
+     section warns against. Use "?" and name the Postgres form in prose. -->
 
 #### Verification Steps
 - [ ] All database queries use parameterized queries


### PR DESCRIPTION
## Summary

`skills/security-review/SKILL.md` uses a literal `$1` in its **"PASS: ALWAYS Use Parameterized Queries"** example. Argument substitution replaces it when the skill is invoked with arguments, so running `/security-review also attacks` renders the canonical *correct* example as:

```typescript
await db.query(
  'SELECT * FROM users WHERE email = attacks',
  [userEmail]
)
```

That is concatenated SQL — precisely the anti-pattern the **"FAIL: NEVER Concatenate SQL"** block directly above it warns against. Of all the lines in this repo that should not be rewritten by the loader, this is arguably the worst one, because a reader following the skill's own guidance is shown an injection-shaped query labelled as safe.

Found while running the skill against a Next.js + Supabase codebase; the substitution was visible in the loaded skill content.

## Fix

Switches the raw-SQL example from `$1` to `?` and names the Postgres numbered form in prose, so the lesson is unchanged and no substitutable token remains. Adds an HTML comment so the placeholder is not reintroduced later.

Removing the token rather than backslash-escaping it is deliberate: with `also attacks` as the argument, `$1` rendered as `attacks`, which does not match a straightforward "first positional" reading, so I did not want the fix to depend on the exact index mapping.

## Scope note (no change proposed)

I scanned all 292 skills inside fenced code blocks. 24 `$N`/`$@` occurrences exist across 11 skills, but for 10 of them the token is **unavoidable language syntax** and must not be touched:

- Perl capture variables and `$@` — `perl-security`, `perl-patterns`, `perl-testing`
- bash positionals — `repo-scan`, `flox-environments`, `jira-integration`
- awk field references — `golang-testing`, `perl-testing`
- a bcrypt hash (`$2a$14$...`) — `uncloud`

Two others carry genuine Postgres placeholders that substitution would also mangle — `error-handling` (Go, L272) and `hexagonal-architecture` (TS, L182/L188) — but neither inverts a security lesson, and `$1` is correct for their drivers. Those read as a harness-level escaping concern rather than something skill text can fix, so this PR touches only `security-review`, where `?` is equally correct and the stakes are highest. Happy to follow up on the others if you'd prefer a different approach.

## Type
- [x] Skill
- [ ] Agent
- [ ] Hook
- [ ] Command

## Testing

`npm test` run on this branch and on `main` for comparison — both exit 0 with identical results, so this adds no failures. Change is one line of a markdown code fence plus comments; no scripts, manifests, or lockfiles touched.

## Checklist
- [x] Follows format guidelines
- [x] Tested with Claude Code
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions